### PR TITLE
Add a path to training_toolbox to PYTHONPATH in a virtual environment

### DIFF
--- a/tools/init_venv.sh
+++ b/tools/init_venv.sh
@@ -9,6 +9,7 @@ if [ -e venv ]; then
 fi
 
 virtualenv venv -p python3 --prompt="(tf-toolbox) "
+echo "export PYTHONPATH=\$PYTHONPATH:${cur_dir}/training_toolbox" >> venv/bin/activate
 . venv/bin/activate
 pip install -qr requirements.txt
 cd external/cocoapi


### PR DESCRIPTION
Lets add a path to `training_toolbox` at PYTHONPATH by default to easy run py-scripts 