### PR TITLE
Remove mirror URLs pointing to internal storage

### DIFF
--- a/application/backend/app/models/model_manifest.py
+++ b/application/backend/app/models/model_manifest.py
@@ -97,7 +97,9 @@ class PretrainedWeights(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
     url: str = Field(title="Weights URL", description="URL to download the pretrained weights")
-    mirror_url: str = Field(title="Weights mirror URL", description="Alternative URL to download the weights")
+    mirror_url: str | None = Field(
+        default=None, title="Weights mirror URL", description="Alternative URL to download the weights"
+    )
     sha_sum: str = Field(title="Weights SHA256", description="SHA256 checksum of the pretrained weights file")
     cache_filename: str | None = Field(
         default=None,

--- a/application/backend/app/services/base_weights_service.py
+++ b/application/backend/app/services/base_weights_service.py
@@ -76,8 +76,11 @@ class BaseWeightsService:
             raise FileNotFoundError(f"Weights not found locally for model {model_manifest_id} and download is disabled")
 
         logger.info("Downloading pretrained weights for {}", model_manifest_id)
+        urls = [manifest.pretrained_weights.url]
+        if manifest.pretrained_weights.mirror_url is not None:
+            urls.append(manifest.pretrained_weights.mirror_url)
         self._download_weights(
-            urls=[manifest.pretrained_weights.url, manifest.pretrained_weights.mirror_url],
+            urls=urls,
             local_path=local_path,
             sha_sum=manifest.pretrained_weights.sha_sum,
         )

--- a/application/backend/app/supported_models/manifests/classification/dinov2.yaml
+++ b/application/backend/app/supported_models/manifests/classification/dinov2.yaml
@@ -3,7 +3,6 @@ name: DINOv2-Small
 
 pretrained_weights:
   url: https://dl.fbaipublicfiles.com/dinov2/dinov2_vits14/dinov2_vits14_reg4_pretrain.pth
-  mirror_url: https://storage.geti.intel.com/weights/dinov2_vits14_reg4_pretrain.pth
   sha_sum: f433177089a681826f849f194ece3bb48f4d63fb38d32fc837e3dc7a4e5641fb
 
 description: "DINOv2 is a self-supervised vision transformer model trained with a combination of discriminative and generative pretraining objectives. It produces robust, general-purpose visual features that transfer well to classification tasks. Fine-tuning uses DoRA (Weight-Decomposed Low-Rank Adaptation) for parameter-efficient training, making it especially effective for small-dataset regimes."

--- a/application/backend/app/supported_models/manifests/classification/efficientnet_b0.yaml
+++ b/application/backend/app/supported_models/manifests/classification/efficientnet_b0.yaml
@@ -3,7 +3,6 @@ name: EfficientNet-B0
 
 pretrained_weights:
   url: https://github.com/osmr/imgclsmob/releases/download/v0.0.364/efficientnet_b0-0752-0e386130.pth.zip
-  mirror_url: https://storage.geti.intel.com/weights/efficientnet_b0-0752-0e386130.pth.zip
   sha_sum: 79f2b405a15399a0772337bd7f58052cb88299a65ed838a43c1ea8d3e0253f70
 
 description: "EfficientNet-B0 is the baseline model of the EfficientNet family, designed using neural architecture search to optimize accuracy and efficiency. It uses a compound scaling method to balance network depth, width, and resolution, achieving strong performance with relatively low computational cost and around 5.3M parameters."

--- a/application/backend/app/supported_models/manifests/classification/efficientnet_b3.yaml
+++ b/application/backend/app/supported_models/manifests/classification/efficientnet_b3.yaml
@@ -3,7 +3,6 @@ name: EfficientNet-B3
 
 pretrained_weights:
   url: https://download.pytorch.org/models/efficientnet_b3_rwightman-b3899882.pth
-  mirror_url: https://storage.geti.intel.com/weights/efficientnet_b3_rwightman-b3899882.pth
   sha_sum: b3899882250c22946d0229d266049fcd133c169233530b36b9ffa7983988362f
 
 description: "EfficientNet-B3 is a scaled-up version of EfficientNet-B0, offering improved accuracy by increasing the network's depth, width, and resolution using compound scaling. It provides a good balance between performance and computational cost, making it suitable for applications that require higher accuracy without significantly sacrificing efficiency."

--- a/application/backend/app/supported_models/manifests/classification/efficientnet_v2_s.yaml
+++ b/application/backend/app/supported_models/manifests/classification/efficientnet_v2_s.yaml
@@ -3,7 +3,6 @@ name: EfficientNet-V2-S
 
 pretrained_weights:
   url: https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-effv2-weights/tf_efficientnetv2_s_21k-6337ad01.pth
-  mirror_url: https://storage.geti.intel.com/weights/tf_efficientnetv2_s_21k-6337ad01.pth
   sha_sum: 6337ad01eda2fde154ffd358cf1583fb3040f1bf467739f28f17fb1dce1c3eb3
 
 description: "EfficientNetV2-Small is a compact and fast classification model that combines neural architecture search with training-aware optimizations. It introduces fused MBConv layers for early-stage acceleration and improves training speed while maintaining accuracy, making it ideal for edge and mobile devices."

--- a/application/backend/app/supported_models/manifests/classification/mobilenet_v3_large.yaml
+++ b/application/backend/app/supported_models/manifests/classification/mobilenet_v3_large.yaml
@@ -3,7 +3,6 @@ name: MobileNet-V3-Large
 
 pretrained_weights:
   url: https://raw.githubusercontent.com/d-li14/mobilenetv3.pytorch/master/pretrained/mobilenetv3-large-1cd25616.pth
-  mirror_url: https://storage.geti.intel.com/weights/mobilenetv3-large-1cd25616.pth
   sha_sum: 1cd25616db4b6481677fcbe5f6932520894cb34860ed86f7080f03eedf937b11
 
 description: "MobileNetV3-Large is a lightweight and efficient image classification model tailored for high-performance applications on mobile and embedded devices. It combines MobileNetV2’s inverted residuals with enhancements like squeeze-and-excitation (SE) blocks, hard-swish activation, and neural architecture search for optimal speed-accuracy trade-offs."

--- a/application/backend/app/supported_models/manifests/classification/vit_tiny.yaml
+++ b/application/backend/app/supported_models/manifests/classification/vit_tiny.yaml
@@ -3,7 +3,6 @@ name: ViT-Tiny
 
 pretrained_weights:
   url: https://storage.googleapis.com/vit_models/augreg/Ti_16-i21k-300ep-lr_0.001-aug_none-wd_0.03-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.03-res_224.npz
-  mirror_url: https://storage.geti.intel.com/weights/Ti_16-i21k-300ep-lr_0.001-aug_none-wd_0.03-do_0.0-sd_0.0--imagenet2012-steps_20k-lr_0.03-res_224.npz
   sha_sum: 0c5c4818ecf1049ae34194223c908172a2967334bab6d86670351b59d608b5dd
 
 description: "ViT-Tiny (Vision Transformer) is a lightweight transformer-based model for image classification. It uses a standard ViT architecture with Google Brain pretrained weights (ImageNet-21k pre-training, ImageNet-1k fine-tuning). ViT-Tiny is the smallest variant, optimized for speed and efficiency while maintaining competitive performance on image classification tasks."

--- a/application/backend/app/supported_models/manifests/detection/atss_mobilenet_v2.yaml
+++ b/application/backend/app/supported_models/manifests/detection/atss_mobilenet_v2.yaml
@@ -3,7 +3,6 @@ name: ATSS-MobileNet-V2
 
 pretrained_weights:
   url: https://storage.openvinotoolkit.org/repositories/openvino_training_extensions/models/object_detection/v2/mobilenet_v2-atss.pth
-  mirror_url: https://storage.geti.intel.com/weights/mobilenet_v2-atss.pth
   sha_sum: f0caa5966a77f4f74b1f051f626d942e60b30d53cbf2f7af93fe2951a2295602
 
 description: "ATSS (Adaptive Training Sample Selection) is an anchor-based object detection algorithm that introduces an adaptive strategy for selecting positive and negative samples during training. Instead of using fixed IoU thresholds, ATSS dynamically determines positive samples based on the statistical characteristics of object candidates for each ground truth. This improves training stability and enhances detection performance, especially for objects of varying sizes and aspect ratios."

--- a/application/backend/app/supported_models/manifests/detection/dfine_l.yaml
+++ b/application/backend/app/supported_models/manifests/detection/dfine_l.yaml
@@ -3,7 +3,6 @@ name: D-FINE-L
 
 pretrained_weights:
   url: https://github.com/eugene123tw/DEIM/releases/download/poc/deim_dfine_hgnetv2_l_coco_50e.pth
-  mirror_url: https://storage.geti.intel.com/weights/deim_dfine_hgnetv2_l_coco_50e.pth
   sha_sum: a9ac1f9bf51a41a7ec02c373c85e0109f84908dde11d80759b43248dcb638baa
 
 description: "D-FINE is a powerful real-time object detector that redefines the bounding box regression task in DETRs as Fine-grained Distribution Refinement (FDR). Combined with the DEIM adaptive augmentation scheduling framework (enabled by default), it achieves outstanding performance with faster convergence."

--- a/application/backend/app/supported_models/manifests/detection/dfine_m.yaml
+++ b/application/backend/app/supported_models/manifests/detection/dfine_m.yaml
@@ -3,7 +3,6 @@ name: D-FINE-M
 
 pretrained_weights:
   url: https://github.com/eugene123tw/DEIM/releases/download/poc/deim_dfine_hgnetv2_m_coco_90e.pth
-  mirror_url: https://storage.geti.intel.com/weights/deim_dfine_hgnetv2_m_coco_90e.pth
   sha_sum: 2b6cd0582a4aa711f583982057b7fb0f3daebdd98e4dc168824714014c3219bc
 
 description: "D-FINE is a powerful real-time object detector that redefines the bounding box regression task in DETRs as Fine-grained Distribution Refinement (FDR). Combined with the DEIM adaptive augmentation scheduling framework (enabled by default), it achieves outstanding performance with faster convergence."

--- a/application/backend/app/supported_models/manifests/detection/dfine_x.yaml
+++ b/application/backend/app/supported_models/manifests/detection/dfine_x.yaml
@@ -3,7 +3,6 @@ name: D-FINE-X
 
 pretrained_weights:
   url: https://github.com/eugene123tw/DEIM/releases/download/poc/deim_dfine_hgnetv2_x_coco_50e.pth
-  mirror_url: https://storage.geti.intel.com/weights/deim_dfine_hgnetv2_x_coco_50e.pth
   sha_sum: e729436f96d95e78dbf67452bf3fb654cd5bed37de43067f5cf0aafb24d0fc7a
 
 description: "D-FINE is a powerful real-time object detector that redefines the bounding box regression task in DETRs as Fine-grained Distribution Refinement (FDR). Combined with the DEIM adaptive augmentation scheduling framework (enabled by default), it achieves outstanding performance with faster convergence."

--- a/application/backend/app/supported_models/manifests/detection/dinov3_detr_l.yaml
+++ b/application/backend/app/supported_models/manifests/detection/dinov3_detr_l.yaml
@@ -3,7 +3,6 @@ name: DINOv3-DETR-L
 
 pretrained_weights:
   url: https://github.com/kprokofi/DEIMv2/releases/download/1.0.0/deimv2_dinov3_l_coco.pth
-  mirror_url: https://storage.geti.intel.com/weights/deimv2_dinov3_l_coco.pth
   sha_sum: 54ec9c9a0f1c16e958fde04ffebb4766061fbf5312e86f80090058c82dcfa183
 
 description: "DINOv3-DETR is an efficient end-to-end object detection transformer that leverages the DEIMv2 training framework with a DINOv3 backbone, achieving strong accuracy with fewer parameters."

--- a/application/backend/app/supported_models/manifests/detection/dinov3_detr_m.yaml
+++ b/application/backend/app/supported_models/manifests/detection/dinov3_detr_m.yaml
@@ -3,7 +3,6 @@ name: DINOv3-DETR-M
 
 pretrained_weights:
   url: https://github.com/kprokofi/DEIMv2/releases/download/1.0.0/deimv2_dinov3_m_coco.pth
-  mirror_url: https://storage.geti.intel.com/weights/deimv2_dinov3_m_coco.pth
   sha_sum: 3ef951bfc71b177df65009d97506b3ed50a3b3b306729cc4584e37dc222c6706
 
 description: "DINOv3-DETR is an efficient end-to-end object detection transformer that leverages the DEIMv2 training framework with a DINOv3 backbone, achieving strong accuracy with fewer parameters."

--- a/application/backend/app/supported_models/manifests/detection/dinov3_detr_s.yaml
+++ b/application/backend/app/supported_models/manifests/detection/dinov3_detr_s.yaml
@@ -3,7 +3,6 @@ name: DINOv3-DETR-S
 
 pretrained_weights:
   url: https://github.com/kprokofi/DEIMv2/releases/download/1.0.0/deimv2_dinov3_s_coco.pth
-  mirror_url: https://storage.geti.intel.com/weights/deimv2_dinov3_s_coco.pth
   sha_sum: 9491ab33b68ecfc0e34043abb3009599ab1e892fb953a1faad12ef4fca5a35c4
 
 description: "DINOv3-DETR is an efficient end-to-end object detection transformer that leverages the DEIMv2 training framework with a DINOv3 backbone, achieving strong accuracy with fewer parameters."

--- a/application/backend/app/supported_models/manifests/detection/edgecrafter_l.yaml
+++ b/application/backend/app/supported_models/manifests/detection/edgecrafter_l.yaml
@@ -3,7 +3,6 @@ name: ECDet-L
 
 pretrained_weights:
   url: https://github.com/capsule2077/edgecrafter/releases/download/edgecrafterv1/ecdet_l.pth
-  mirror_url: https://storage.geti.intel.com/weights/ecdet_l.pth
   sha_sum: 60e48c51b33d70acf8e3a3faddbdb70b0876c64509b74cb623106cc7c31e85a1
 
 description: "EdgeCrafter detection model (ECDet-L) combines an efficient ECViT backbone with a hybrid encoder and transformer decoder for real-time, high-accuracy object detection with low latency."

--- a/application/backend/app/supported_models/manifests/detection/edgecrafter_m.yaml
+++ b/application/backend/app/supported_models/manifests/detection/edgecrafter_m.yaml
@@ -3,7 +3,6 @@ name: ECDet-M
 
 pretrained_weights:
   url: https://github.com/capsule2077/edgecrafter/releases/download/edgecrafterv1/ecdet_m.pth
-  mirror_url: https://storage.geti.intel.com/weights/ecdet_m.pth
   sha_sum: c4cdf8bcd3b27c7903e422acd03caf733b5e1bfd664550bce43e50e2a3bbdc6e
 
 description: "EdgeCrafter detection model (ECDet-M) combines an efficient ECViT backbone with a hybrid encoder and transformer decoder for real-time, high-accuracy object detection with low latency."

--- a/application/backend/app/supported_models/manifests/detection/edgecrafter_s.yaml
+++ b/application/backend/app/supported_models/manifests/detection/edgecrafter_s.yaml
@@ -3,7 +3,6 @@ name: ECDet-S
 
 pretrained_weights:
   url: https://github.com/capsule2077/edgecrafter/releases/download/edgecrafterv1/ecdet_s.pth
-  mirror_url: https://storage.geti.intel.com/weights/ecdet_s.pth
   sha_sum: 35340a45101d24a094becf8776aeaa327c9e6b37453e5e81dfd2923c134c4619
 
 description: "EdgeCrafter detection model (ECDet-S) combines an efficient ECViT backbone with a hybrid encoder and transformer decoder for real-time, high-accuracy object detection with low latency."

--- a/application/backend/app/supported_models/manifests/detection/edgecrafter_x.yaml
+++ b/application/backend/app/supported_models/manifests/detection/edgecrafter_x.yaml
@@ -3,7 +3,6 @@ name: ECDet-X
 
 pretrained_weights:
   url: https://github.com/capsule2077/edgecrafter/releases/download/edgecrafterv1/ecdet_x.pth
-  mirror_url: https://storage.geti.intel.com/weights/ecdet_x.pth
   sha_sum: c87394be021b573fd8e25969b85a8670127120c9d0209ac7807fbadae1a5cec6
 
 description: "EdgeCrafter detection model (ECDet-X) combines an efficient ECViT backbone with a hybrid encoder and transformer decoder for real-time, high-accuracy object detection with low latency."

--- a/application/backend/app/supported_models/manifests/detection/rfdetr_l.yaml
+++ b/application/backend/app/supported_models/manifests/detection/rfdetr_l.yaml
@@ -3,7 +3,6 @@ name: RF-DETR-L
 
 pretrained_weights:
   url: https://storage.googleapis.com/rfdetr/rf-detr-large-2026.pth
-  mirror_url: https://storage.geti.intel.com/weights/rf-detr-large-2026.pth
   cache_filename: rf-detr-large-2026.pth
   sha_sum: 0f4e20e19a99c0f8a62b5685f57f6c8b5c371c59081feda6752a0561a79ccf38
 

--- a/application/backend/app/supported_models/manifests/detection/rfdetr_m.yaml
+++ b/application/backend/app/supported_models/manifests/detection/rfdetr_m.yaml
@@ -3,7 +3,6 @@ name: RF-DETR-M
 
 pretrained_weights:
   url: https://storage.googleapis.com/rfdetr/medium_coco/checkpoint_best_regular.pth
-  mirror_url: https://storage.geti.intel.com/weights/rf-detr-medium-2026.pth
   cache_filename: rf-detr-medium-2026.pth
   sha_sum: 749ff6071828aaffac63e204c4f4135ed3d6cdae4d702e086c360edc3b5768c8
 

--- a/application/backend/app/supported_models/manifests/detection/rfdetr_n.yaml
+++ b/application/backend/app/supported_models/manifests/detection/rfdetr_n.yaml
@@ -3,7 +3,6 @@ name: RF-DETR-N
 
 pretrained_weights:
   url: https://storage.googleapis.com/rfdetr/nano_coco/checkpoint_best_regular.pth
-  mirror_url: https://storage.geti.intel.com/weights/rf-detr-nano-2026.pth
   cache_filename: rf-detr-nano-2026.pth
   sha_sum: d8d6b9ee57d4d0ed2b1f305163624712a0532cb7bce0c747317984fc5457440d
 

--- a/application/backend/app/supported_models/manifests/detection/rfdetr_s.yaml
+++ b/application/backend/app/supported_models/manifests/detection/rfdetr_s.yaml
@@ -3,7 +3,6 @@ name: RF-DETR-S
 
 pretrained_weights:
   url: https://storage.googleapis.com/rfdetr/small_coco/checkpoint_best_regular.pth
-  mirror_url: https://storage.geti.intel.com/weights/rf-detr-small-2026.pth
   cache_filename: rf-detr-small-2026.pth
   sha_sum: d81979a9213a2109345158ce9232668df4c1ae52e9b8db3f2ec0a8cbad959b33
 

--- a/application/backend/app/supported_models/manifests/detection/rtdetr_50.yaml
+++ b/application/backend/app/supported_models/manifests/detection/rtdetr_50.yaml
@@ -3,7 +3,6 @@ name: RT-DETR-R50
 
 pretrained_weights:
   url: https://github.com/lyuwenyu/storage/releases/download/v0.1/rtdetr_r50vd_2x_coco_objects365_from_paddle.pth
-  mirror_url: https://storage.geti.intel.com/weights/rtdetr_r50vd_2x_coco_objects365_from_paddle.pth
   sha_sum: 7788173453f771d45d0b49ffa23dbeb60796ccb8425afa52befb0b8fe033608c
 
 description: "RT-DETR is a real-time object detection algorithm based on the transformer architecture. It combines a convolutional backbone with an efficient encoder-decoder transformer to directly predict object classes and bounding boxes without the need for anchor boxes or NMS."

--- a/application/backend/app/supported_models/manifests/detection/ssd_mobilenet_v2.yaml
+++ b/application/backend/app/supported_models/manifests/detection/ssd_mobilenet_v2.yaml
@@ -3,7 +3,6 @@ name: SSD-MobileNet-V2
 
 pretrained_weights:
   url: https://storage.openvinotoolkit.org/repositories/openvino_training_extensions/models/object_detection/v2/mobilenet_v2-2s_ssd-992x736.pth
-  mirror_url: https://storage.geti.intel.com/weights/mobilenet_v2-2s_ssd-992x736.pth
   sha_sum: c94e3d76fb60db7de2c6fc824a692564cf7ebb2156a58ed2e0f37ff4c0089d28
 
 description: "SSD (Single Shot MultiBox Detector) is a real-time, anchor-based object detection algorithm that performs object localization and classification in a single forward pass. It uses a convolutional backbone and multiple feature maps at different scales to detect objects of various sizes. SSD balances speed and accuracy, making it efficient for deployment on resource-constrained devices."

--- a/application/backend/app/supported_models/manifests/detection/yolox_l.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_l.yaml
@@ -3,7 +3,6 @@ name: YOLOX-L
 
 pretrained_weights:
   url: https://download.openmmlab.com/mmdetection/v2.0/yolox/yolox_l_8x8_300e_coco/yolox_l_8x8_300e_coco_20211126_140236-d3bd2b23.pth
-  mirror_url: https://storage.geti.intel.com/weights/yolox_l_8x8_300e_coco_20211126_140236-d3bd2b23.pth
   sha_sum: d3bd2b23e4cd178bfcc756df67e0d0949f3d77e0a73482f6da694c580ed54da1
 
 description: "YOLOX is a high-performance, anchor-free object detection algorithm that builds on the YOLO series with modern improvements. It features a decoupled head for separate classification and regression tasks, strong data augmentation techniques, and advanced label assignment strategies. YOLOX achieves a great balance between speed and accuracy, making it suitable for real-time applications across various domains."

--- a/application/backend/app/supported_models/manifests/detection/yolox_s.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_s.yaml
@@ -3,7 +3,6 @@ name: YOLOX-S
 
 pretrained_weights:
   url: https://download.openmmlab.com/mmdetection/v2.0/yolox/yolox_s_8x8_300e_coco/yolox_s_8x8_300e_coco_20211121_095711-4592a793.pth
-  mirror_url: https://storage.geti.intel.com/weights/yolox_s_8x8_300e_coco_20211121_095711-4592a793.pth
   sha_sum: 4592a793b95f18f62fd73fbb6cfe61dd445f71a8e072366e114e7134d4492760
 
 description: "YOLOX is a high-performance, anchor-free object detection algorithm that builds on the YOLO series with modern improvements. It features a decoupled head for separate classification and regression tasks, strong data augmentation techniques, and advanced label assignment strategies. YOLOX achieves a great balance between speed and accuracy, making it suitable for real-time applications across various domains."

--- a/application/backend/app/supported_models/manifests/detection/yolox_t.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_t.yaml
@@ -3,7 +3,6 @@ name: YOLOX-Tiny
 
 pretrained_weights:
   url: https://storage.openvinotoolkit.org/repositories/openvino_training_extensions/models/object_detection/v2/yolox_tiny_8x8.pth
-  mirror_url: https://storage.geti.intel.com/weights/yolox_tiny_8x8.pth
   sha_sum: 4ff3b67e005a6356a5794f5fbc42b133e077aa30ddcb0449b2153cfd953a0030
 
 description: "YOLOX is a high-performance, anchor-free object detection algorithm that builds on the YOLO series with modern improvements. It features a decoupled head for separate classification and regression tasks, strong data augmentation techniques, and advanced label assignment strategies. YOLOX achieves a great balance between speed and accuracy, making it suitable for real-time applications across various domains."

--- a/application/backend/app/supported_models/manifests/detection/yolox_x.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_x.yaml
@@ -3,7 +3,6 @@ name: YOLOX-X
 
 pretrained_weights:
   url: https://download.openmmlab.com/mmdetection/v2.0/yolox/yolox_x_8x8_300e_coco/yolox_x_8x8_300e_coco_20211126_140254-1ef88d67.pth
-  mirror_url: https://storage.geti.intel.com/weights/yolox_x_8x8_300e_coco_20211126_140254-1ef88d67.pth
   sha_sum: 1ef88d67f9c912a7c3a6df4f4d9bdf391cf70df867e6c9d7f249c7a3990e3dec
 
 description: "YOLOX is a high-performance, anchor-free object detection algorithm that builds on the YOLO series with modern improvements. It features a decoupled head for separate classification and regression tasks, strong data augmentation techniques, and advanced label assignment strategies. YOLOX achieves a great balance between speed and accuracy, making it suitable for real-time applications across various domains."

--- a/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_efficientnet_b2.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_efficientnet_b2.yaml
@@ -3,7 +3,6 @@ name: Mask-RCNN-EfficientNet-B2
 
 pretrained_weights:
   url: https://storage.openvinotoolkit.org/repositories/openvino_training_extensions/models/instance_segmentation/v2/efficientnet_b2b-mask_rcnn-576x576.pth
-  mirror_url: https://storage.geti.intel.com/weights/efficientnet_b2b-mask_rcnn-576x576.pth
   sha_sum: b00407a212bdba77866b6c337a24e997b4b2621afb50e62b261df1a4f8efd3c6
 
 description: "This model integrates Mask R-CNN with an EfficientNet-B2B backbone, combining the accuracy of a region-based detection approach with the efficiency of the EfficientNet architecture. It offers strong instance segmentation performance with reduced computational cost, making it suitable for scenarios where both precision and efficiency are important."

--- a/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_r50.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_r50.yaml
@@ -3,7 +3,6 @@ name: Mask-RCNN-ResNet50
 
 pretrained_weights:
   url: https://download.pytorch.org/models/maskrcnn_resnet50_fpn_v2_coco-73cbd019.pth
-  mirror_url: https://storage.geti.intel.com/weights/maskrcnn_resnet50_fpn_v2_coco-73cbd019.pth
   sha_sum: 73cbd0190fcbe3ba339921fbce2c3a0b6bb9126c9a133c85e43a2a8e060a109e
 
 description: "Mask R-CNN with a ResNet-50 backbone is a widely used instance segmentation model that balances accuracy and speed. The ResNet-50 backbone provides strong feature extraction, while the Mask R-CNN head enables precise object detection and mask prediction for each instance."

--- a/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_swin_t.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/maskrcnn_swin_t.yaml
@@ -3,7 +3,6 @@ name: Mask-RCNN-Swin-T
 
 pretrained_weights:
   url: https://download.openmmlab.com/mmdetection/v2.0/swin/mask_rcnn_swin-t-p4-w7_fpn_fp16_ms-crop-3x_coco/mask_rcnn_swin-t-p4-w7_fpn_fp16_ms-crop-3x_coco_20210908_165006-90a4008c.pth
-  mirror_url: https://storage.geti.intel.com/weights/mask_rcnn_swin-t-p4-w7_fpn_fp16_ms-crop-3x_coco_20210908_165006-90a4008c.pth
   sha_sum: 90a4008ce84011fc0d75a08db1b65b01ee1f145e9a1dffe8acc15ea8894b348d
 
 description: "This model combines the Mask R-CNN framework with a Swin-Tiny transformer backbone, leveraging hierarchical attention and shifted windows for better spatial understanding. It delivers enhanced instance segmentation performance, especially on complex scenes, while maintaining a lightweight transformer design."

--- a/application/backend/app/supported_models/manifests/instance_segmentation/rfdetr_2xl.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/rfdetr_2xl.yaml
@@ -3,7 +3,6 @@ name: RF-DETR-Seg-2XL
 
 pretrained_weights:
   url: https://storage.googleapis.com/rfdetr/rf-detr-seg-2xl-ft.pth
-  mirror_url: https://storage.geti.intel.com/weights/rf-detr-seg-2xl-ft.pth
   sha_sum: f6e06ac5ebafd3f9f6f01c55a7f53b8785a1697037063a6adeb737c4c6ce4838
 
 description: "RF-DETR for instance segmentation extends the RF-DETR object detector with mask prediction capabilities, providing high-accuracy instance segmentation with real-time performance."

--- a/application/backend/app/supported_models/manifests/instance_segmentation/rfdetr_l.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/rfdetr_l.yaml
@@ -3,7 +3,6 @@ name: RF-DETR-Seg-L
 
 pretrained_weights:
   url: https://storage.googleapis.com/rfdetr/rf-detr-seg-l-ft.pth
-  mirror_url: https://storage.geti.intel.com/weights/rf-detr-seg-l-ft.pth
   sha_sum: ca7b7c630ba22496067cc4f034c4e70c8e47fd7adcea04c3a49aa8c1755cbe6b
 
 description: "RF-DETR for instance segmentation extends the RF-DETR object detector with mask prediction capabilities, providing high-accuracy instance segmentation with real-time performance."

--- a/application/backend/app/supported_models/manifests/instance_segmentation/rfdetr_m.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/rfdetr_m.yaml
@@ -3,7 +3,6 @@ name: RF-DETR-Seg-M
 
 pretrained_weights:
   url: https://storage.googleapis.com/rfdetr/rf-detr-seg-m-ft.pth
-  mirror_url: https://storage.geti.intel.com/weights/rf-detr-seg-m-ft.pth
   sha_sum: 3ad325094735f431aee9962a8d204d68eb5bfc393d53e7e836e70998fef5ea58
 
 description: "RF-DETR for instance segmentation extends the RF-DETR object detector with mask prediction capabilities, providing high-accuracy instance segmentation with real-time performance."

--- a/application/backend/app/supported_models/manifests/instance_segmentation/rfdetr_n.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/rfdetr_n.yaml
@@ -3,7 +3,6 @@ name: RF-DETR-Seg-N
 
 pretrained_weights:
   url: https://storage.googleapis.com/rfdetr/rf-detr-seg-n-ft.pth
-  mirror_url: https://storage.geti.intel.com/weights/rf-detr-seg-n-ft.pth
   sha_sum: a44613a4ecd6b5ba61a62002c600b0b6cb7a9da2936a45317ec4b62c635fb99b
 
 description: "RF-DETR for instance segmentation extends the RF-DETR object detector with mask prediction capabilities, providing high-accuracy instance segmentation with real-time performance."

--- a/application/backend/app/supported_models/manifests/instance_segmentation/rfdetr_s.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/rfdetr_s.yaml
@@ -3,7 +3,6 @@ name: RF-DETR-Seg-S
 
 pretrained_weights:
   url: https://storage.googleapis.com/rfdetr/rf-detr-seg-s-ft.pth
-  mirror_url: https://storage.geti.intel.com/weights/rf-detr-seg-s-ft.pth
   sha_sum: 6de3da31b2572cac214a1c76cce4a92a13966d56390ac2b3a3de9a8dc2b2bca3
 
 description: "RF-DETR for instance segmentation extends the RF-DETR object detector with mask prediction capabilities, providing high-accuracy instance segmentation with real-time performance."

--- a/application/backend/app/supported_models/manifests/instance_segmentation/rfdetr_xl.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/rfdetr_xl.yaml
@@ -3,7 +3,6 @@ name: RF-DETR-Seg-XL
 
 pretrained_weights:
   url: https://storage.googleapis.com/rfdetr/rf-detr-seg-xl-ft.pth
-  mirror_url: https://storage.geti.intel.com/weights/rf-detr-seg-xl-ft.pth
   sha_sum: 77d67f2b8033fbb25e23f29c22c02a8f677b3939687e9a1a5fdde3765f33f423
 
 description: "RF-DETR for instance segmentation extends the RF-DETR object detector with mask prediction capabilities, providing high-accuracy instance segmentation with real-time performance."

--- a/application/backend/app/supported_models/manifests/instance_segmentation/rtmdet_tiny.yaml
+++ b/application/backend/app/supported_models/manifests/instance_segmentation/rtmdet_tiny.yaml
@@ -3,7 +3,6 @@ name: RTMDet-Tiny
 
 pretrained_weights:
   url: https://download.openmmlab.com/mmdetection/v3.0/rtmdet/rtmdet-ins_tiny_8xb32-300e_coco/rtmdet-ins_tiny_8xb32-300e_coco_20221130_151727-ec670f7e.pth
-  mirror_url: https://storage.geti.intel.com/weights/rtmdet-ins_tiny_8xb32-300e_coco_20221130_151727-ec670f7e.pth
   sha_sum: ec670f7ee9e20bd7931e15f15b7016f7fe531baaab81f2e6153382d046111885
 
 description: "RTMDet for instance segmentation extends the real-time object detection framework with mask prediction capabilities. It features a unified, anchor-free architecture with a decoupled head and task-specific neck, enabling high-performance instance segmentation with real-time inference speed."


### PR DESCRIPTION
### Summary

Changes:
- Make `mirror_url` optional in model manifests.
- Remove mirror URLs pointing to storage.intel.com due to internal compliance reasons.

### How to test

- [x] Clean weights cache, train one model that used to have a mirror URL and verify that training still works.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
