### PR TITLE
Query thumbnails only if the scroll has stopped

### DIFF
--- a/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
@@ -1,9 +1,12 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { useState } from 'react';
+
 import type { Media, MediaVideo } from '@/api/types';
 import { Flex } from '@geti-ui/ui';
 
+import { useIsScrolling } from '../../hooks/use-is-scrolling.hook';
 import { isVideo } from '../../shared/media-item-utils';
 import { formatCompactDuration } from './util';
 
@@ -15,6 +18,19 @@ type MediaThumbnailProps = {
     url: string;
     alt: string;
     item: Pick<Media, 'type'> | Pick<MediaVideo, 'type' | 'frame_count' | 'annotated_frame_count' | 'duration'>;
+};
+
+// Only request a thumbnail once scrolling stops: fast scrolling unmounts thumbnails mid-request,
+// and enough cancelled requests wedge the HTTP/2 connection. Once set, src is never cleared.
+const useSettledSrc = (url: string): string | undefined => {
+    const isScrolling = useIsScrolling();
+    const [src, setSrc] = useState<string>();
+
+    if (src === undefined && !isScrolling) {
+        setSrc(url);
+    }
+
+    return src;
 };
 
 type VideoIndicatorProps = {
@@ -37,9 +53,11 @@ const VideoIndicator = ({ duration }: VideoIndicatorProps) => {
 };
 
 export const MediaThumbnail = ({ onDoubleClick, onClick, url, alt, item }: MediaThumbnailProps) => {
+    const src = useSettledSrc(url);
+
     return (
         <div onDoubleClick={onDoubleClick} onClick={onClick} className={classes.imgContainer}>
-            <img src={url} alt={alt} className={classes.img} draggable={false} />
+            <img src={src} alt={alt} className={classes.img} draggable={false} decoding='async' />
             {isVideo(item) && <VideoIndicator duration={item.duration} />}
         </div>
     );

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.module.scss
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.module.scss
@@ -3,6 +3,7 @@
     overflow: hidden;
     position: relative;
     text-align: center;
+    background-color: var(--spectrum-global-color-gray-100);
 }
 
 .img {

--- a/application/ui/src/components/virtualizer-grid-layout/virtualizer-grid-layout.component.tsx
+++ b/application/ui/src/components/virtualizer-grid-layout/virtualizer-grid-layout.component.tsx
@@ -7,6 +7,7 @@ import { AriaComponentsListBox, AriaListBoxItem, GridLayout, Loading, View, Virt
 import { useLoadMore } from '@react-aria/utils';
 import { GridLayoutOptions } from 'react-aria-components';
 
+import { IsScrollingProvider } from '../../hooks/use-is-scrolling.hook';
 import { useGetTargetPosition } from './use-get-target-position.hook';
 
 import classes from './virtualizer-grid-layout.module.scss';
@@ -70,37 +71,39 @@ export const VirtualizerGridLayout = <T extends GridItem>({
 
     return (
         <View UNSAFE_className={classes.mainContainer}>
-            <Virtualizer layout={GridLayout} layoutOptions={layoutOptions}>
-                <AriaComponentsListBox
-                    ref={ref}
-                    layout='grid'
-                    aria-label={ariaLabel}
-                    className={classes.container}
-                    selectedKeys={selectedKeys}
-                    selectionMode={selectionMode}
-                    onSelectionChange={onSelectionChange}
-                >
-                    {items.map((item, index) => {
-                        const itemId = getItemId(item);
+            <IsScrollingProvider scrollRef={ref}>
+                <Virtualizer layout={GridLayout} layoutOptions={layoutOptions}>
+                    <AriaComponentsListBox
+                        ref={ref}
+                        layout='grid'
+                        aria-label={ariaLabel}
+                        className={classes.container}
+                        selectedKeys={selectedKeys}
+                        selectionMode={selectionMode}
+                        onSelectionChange={onSelectionChange}
+                    >
+                        {items.map((item) => {
+                            const itemId = getItemId(item);
 
-                        return (
-                            <AriaListBoxItem
-                                id={itemId}
-                                key={`${ariaLabel}-${itemId}-${index}`}
-                                textValue={String(itemId)}
-                                className={classes.mediaItem}
-                            >
-                                {contentItem(item)}
+                            return (
+                                <AriaListBoxItem
+                                    id={itemId}
+                                    key={`${ariaLabel}-${itemId}`}
+                                    textValue={String(itemId)}
+                                    className={classes.mediaItem}
+                                >
+                                    {contentItem(item)}
+                                </AriaListBoxItem>
+                            );
+                        })}
+                        {isLoadingMore && !isPending && (
+                            <AriaListBoxItem id={'loader'} textValue={'loading'}>
+                                <Loading mode='overlay' />
                             </AriaListBoxItem>
-                        );
-                    })}
-                    {isLoadingMore && !isPending && (
-                        <AriaListBoxItem id={'loader'} textValue={'loading'}>
-                            <Loading mode='overlay' />
-                        </AriaListBoxItem>
-                    )}
-                </AriaComponentsListBox>
-            </Virtualizer>
+                        )}
+                    </AriaComponentsListBox>
+                </Virtualizer>
+            </IsScrollingProvider>
             {isPending && <Loading mode='overlay' />}
         </View>
     );

--- a/application/ui/src/hooks/use-is-scrolling.hook.tsx
+++ b/application/ui/src/hooks/use-is-scrolling.hook.tsx
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { createContext, ReactNode, RefObject, useContext, useEffect, useRef, useState } from 'react';
+
+import { useEventListener } from './event-listener.hook';
+
+const IsScrollingContext = createContext(false);
+
+const SCROLL_END_FALLBACK_MS = 150;
+
+type IsScrollingProviderProps = {
+    scrollRef: RefObject<HTMLElement | null>;
+    children: ReactNode;
+};
+
+export const IsScrollingProvider = ({ scrollRef, children }: IsScrollingProviderProps) => {
+    const [isScrolling, setIsScrolling] = useState(false);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+    useEventListener(
+        'scroll',
+        () => {
+            setIsScrolling(true);
+
+            clearTimeout(timeoutRef.current);
+            timeoutRef.current = setTimeout(() => setIsScrolling(false), SCROLL_END_FALLBACK_MS);
+        },
+        scrollRef
+    );
+
+    useEventListener(
+        'scrollend',
+        () => {
+            clearTimeout(timeoutRef.current);
+            setIsScrolling(false);
+        },
+        scrollRef
+    );
+
+    useEffect(() => () => clearTimeout(timeoutRef.current), []);
+
+    return <IsScrollingContext.Provider value={isScrolling}>{children}</IsScrollingContext.Provider>;
+};
+
+export const useIsScrolling = (): boolean => useContext(IsScrollingContext);


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Tested on a dataset with ~1800 images
* Issue is 2 fold, client side we were querying the endpoint too many times, and on the server side we are querying the DB more times than necessary. For the latter, a ticket has been created (-> https://github.com/open-edge-platform/geti/issues/7221)

Closes https://github.com/open-edge-platform/geti/issues/7205

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
