### PR TITLE
ci: Better suffix for MSIX package on RC app creation

### DIFF
--- a/.github/workflows/publish-rc-app.yml
+++ b/.github/workflows/publish-rc-app.yml
@@ -16,6 +16,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       rc_version: "${{ steps.validate.outputs.rc_version }}"
+      rc_number: "${{ steps.validate.outputs.rc_number }}"
     steps:
       - name: Harden the runner (audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -122,6 +123,7 @@ jobs:
           fi
 
           echo "rc_version=$RC_VERSION" >> "$GITHUB_OUTPUT"
+          echo "rc_number=$RC_NUMBER" >> "$GITHUB_OUTPUT"
 
   publish-rc:
     name: Build and push container RC (${{ matrix.device }})
@@ -214,7 +216,7 @@ jobs:
     uses: ./.github/workflows/windows-installer.yml
     with:
       device: ${{ matrix.device }}
-      tag: ${{ needs.validate.outputs.rc_version }}
+      tag: rc${{ needs.validate.outputs.rc_number }} # Suffix only; VERSION file already supplies the base version
       exclude-agpl-models: true # RC installers must not bundle Ultralytics/AGPL-licensed models
     secrets:
       MSIX_SIGN_CERTIFICATE: ${{ secrets.MSIX_SIGN_CERTIFICATE }}


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

## Summary

The name of MSIX package created for RC app promotion event was like geti-cpu-3.1.0-3.1.0rc4.msix. 
This PR address doubling version in name and makes it appear like geti-cpu-3.1.0-rc4.msix

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

Trigger workflow run

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
