### PR TITLE
Parse the file extension prior to download

### DIFF
--- a/application/ui/src/features/models/model-listing/model-variants/model-variant-table.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/model-variant-table.component.test.tsx
@@ -188,7 +188,7 @@ describe('ModelVariantTable', () => {
 
         expect(downloadFile).toHaveBeenCalledWith(
             expect.stringContaining(`/api/projects/project-123/models/${model.id}/variants/ov-1/binary`),
-            undefined,
+            `model-${String(model.id).split('-')[0]}-openvino-fp16.zip`,
             'Model download started'
         );
     });

--- a/application/ui/src/features/models/model-listing/model-variants/model-variant-table.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-variants/model-variant-table.component.tsx
@@ -1,7 +1,6 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { API_BASE_URL } from '@/api';
 import type { Model, ModelFormat, ModelVariant } from '@/api/types';
 import {
     ActionButton,
@@ -23,6 +22,7 @@ import { get } from 'lodash-es';
 import { useNumberFormatter } from 'react-aria';
 
 import { downloadFile, formatBytes } from '../../../../shared/util';
+import { getModelVariantBinaryFilename, getModelVariantBinaryUrl } from '../utils/utils';
 import {
     getBaselineVariant,
     getFp32PytorchVariant,
@@ -98,9 +98,12 @@ export const ModelVariantTable = ({ model, format }: ModelVariantTableProps) => 
         ? getVariantPerformanceValue(baselineVariant, fp32PytorchMetric)
         : undefined;
 
-    const handleDownloadModel = (modelVariantId: string) => {
-        const url = `${API_BASE_URL}/api/projects/${projectId}/models/${model.id}/variants/${modelVariantId}/binary`;
-        downloadFile(url, undefined, 'Model download started');
+    const handleDownloadModel = (variant: ModelVariant) => {
+        downloadFile(
+            getModelVariantBinaryUrl(projectId, model.id, variant.id),
+            getModelVariantBinaryFilename(model.id, variant),
+            'Model download started'
+        );
     };
 
     return (
@@ -147,7 +150,7 @@ export const ModelVariantTable = ({ model, format }: ModelVariantTableProps) => 
                                     <ActionButton
                                         isQuiet
                                         aria-label={`Download model ${variant.id}`}
-                                        onPress={() => handleDownloadModel(variant.id)}
+                                        onPress={() => handleDownloadModel(variant)}
                                     >
                                         <DownloadIcon />
                                     </ActionButton>

--- a/application/ui/src/features/models/model-listing/utils/utils.ts
+++ b/application/ui/src/features/models/model-listing/utils/utils.ts
@@ -1,7 +1,8 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import type { Model } from '@/api/types';
+import { API_BASE_URL } from '@/api';
+import type { Model, ModelVariant } from '@/api/types';
 
 const TRAINING_STATUS = {
     Failed: 'failed',
@@ -19,3 +20,13 @@ export const isSuccessfulModel = (model: Pick<Model, 'training_info'>): boolean 
     model.training_info?.status === TRAINING_STATUS.Successful;
 
 export const hasDeletedWeights = (model: Pick<Model, 'files_deleted'>): boolean => model.files_deleted;
+
+export const getModelVariantBinaryUrl = (projectId: string, modelId: string, variantId: string): string =>
+    `${API_BASE_URL}/api/projects/${projectId}/models/${modelId}/variants/${variantId}/binary`;
+
+// Mirrors the Content-Disposition filename set by the backend for the endpoint above. The desktop app
+// needs it up front to open the save dialog before the (potentially large) download starts.
+export const getModelVariantBinaryFilename = (
+    modelId: string,
+    variant: Pick<ModelVariant, 'format' | 'precision'>
+): string => `model-${modelId.split('-')[0]}-${variant.format}-${variant.precision}.zip`;

--- a/application/ui/src/platform/download-file.tauri.ts
+++ b/application/ui/src/platform/download-file.tauri.ts
@@ -15,7 +15,7 @@ const saveDownload = async (url: string, name?: string, startedMessage?: string)
         const filename = name ?? getFallbackFilename(url);
         const selectedPath = await save({
             defaultPath: filename,
-            filters: [{ name: 'All Files', extensions: ['*'] }],
+            filters: [getFilterForFilename(filename)],
         });
 
         if (selectedPath === null) {
@@ -37,6 +37,16 @@ const saveDownload = async (url: string, name?: string, startedMessage?: string)
         console.error('[tauri downloadFile] failed', error);
         toast({ type: 'error', message: 'Failed to download file' });
     }
+};
+
+const getFilterForFilename = (filename: string): { name: string; extensions: string[] } => {
+    const extension = filename.split('.').pop();
+
+    if (extension === undefined || extension === '' || extension === filename) {
+        return { name: 'All Files', extensions: ['*'] };
+    }
+
+    return { name: `${extension.toUpperCase()} File`, extensions: [extension.toLowerCase()] };
 };
 
 const getFallbackFilename = (url: string): string => {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Mirror content disposition header to generate the correct filename on tauri
* We could fetch the url, parse and sanitise the headers but it would be 5 or 6x times more code (and uglier, with all the regexes) so I decided to just mirror the name, faster and simpler. Besides I dont think the header will change much, if at all.
* This is needed because downloading a file in tauri is done solely with js, whereas on web is native behavior, which leverages the CSP and sets the extension correctly.
* Manually tested on tauri-windows
* Also tested the web app on chrome for regressions

Closes https://github.com/open-edge-platform/geti/issues/7203

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
