### PR TITLE
Leverage SSE for import/export dataset jobs

### DIFF
--- a/application/ui/src/api/fetch-sse.ts
+++ b/application/ui/src/api/fetch-sse.ts
@@ -43,6 +43,9 @@ export const connectSSE = <T = unknown>(path: string, options: SSEOptions<T>): S
         eventSource.onmessage = (event: MessageEvent) => {
             try {
                 const data = JSON.parse(event.data) as T;
+
+                // A delivered message proves the stream works, so later drops get a fresh retry budget
+                retryCount = 0;
                 options.onMessage(data);
             } catch {
                 // Skip unparseable messages

--- a/application/ui/src/features/dataset/import-export/export-jobs-list/hooks/use-export-status.hook.tsx
+++ b/application/ui/src/features/dataset/import-export/export-jobs-list/hooks/use-export-status.hook.tsx
@@ -5,21 +5,21 @@ import { useEffect } from 'react';
 
 import { $api } from '@/api';
 import type { ExportDatasetJob } from '@/api/types';
-import { isInvalidJob, isJobDone, isJobFailed } from 'hooks/api/util';
+import { useStreamJobDetail } from 'hooks/api/jobs/jobs.hook';
+import { isInvalidJob } from 'hooks/api/util';
 
 import { useExportDataset } from '../../../../../hooks/storage/use-export-dataset.hook';
 
 export const useExportStatus = (jobId: string) => {
     const { removeLsExportId } = useExportDataset();
 
+    useStreamJobDetail(jobId);
+
     const response = $api.useQuery(
         'get',
         '/api/jobs/{job_id}',
         { params: { path: { job_id: jobId } } },
         {
-            refetchInterval: ({ state }) => {
-                return isJobDone(state.data) || isJobFailed(state.data) || state.status === 'error' ? false : 1_000;
-            },
             select: (currentData) => currentData as ExportDatasetJob,
         }
     );

--- a/application/ui/src/hooks/api/jobs/jobs.hook.ts
+++ b/application/ui/src/hooks/api/jobs/jobs.hook.ts
@@ -23,6 +23,7 @@ export const useStreamJobStatus = (jobId: string | undefined) => {
     const modelIdRef = useRef<string | null>(null);
 
     const { close } = useSSE<Job>(jobId ? `/api/jobs/${jobId}/status` : undefined, {
+        retry: true,
         onMessage: (updatedJob) => {
             if (isQuantizeJob(updatedJob)) {
                 modelIdRef.current = updatedJob.metadata.model.id;
@@ -83,6 +84,7 @@ export const useStreamJobDetail = (jobId: string | undefined | null) => {
     const queryClient = useQueryClient();
 
     const { close } = useSSE<Job>(jobId ? `/api/jobs/${jobId}/status` : undefined, {
+        retry: true,
         onMessage: (updatedJob) => {
             queryClient.setQueryData<Job>(
                 getQueryKey(['get', '/api/jobs/{job_id}', { params: { path: { job_id: updatedJob.job_id } } }]),
@@ -91,6 +93,19 @@ export const useStreamJobDetail = (jobId: string | undefined | null) => {
 
             if (TERMINAL_STATUSES.includes(updatedJob.status)) {
                 close();
+            }
+        },
+        onClose: () => {
+            if (!jobId) {
+                return;
+            }
+
+            const jobKey = getQueryKey(['get', '/api/jobs/{job_id}', { params: { path: { job_id: jobId } } }]);
+            const cachedJob = queryClient.getQueryData<Job>(jobKey);
+
+            // The stream gave up before the job settled, so whatever is cached is stale
+            if (!cachedJob || !TERMINAL_STATUSES.includes(cachedJob.status)) {
+                queryClient.invalidateQueries({ queryKey: jobKey });
             }
         },
     });

--- a/application/ui/src/hooks/api/jobs/jobs.hook.ts
+++ b/application/ui/src/hooks/api/jobs/jobs.hook.ts
@@ -77,6 +77,25 @@ export const useStreamJobStatus = (jobId: string | undefined) => {
     });
 };
 
+// Same stream as useStreamJobStatus, but writes to the single-job cache instead of the job-list
+// cache, so consumers that query a job by id (import/export) don't have to poll.
+export const useStreamJobDetail = (jobId: string | undefined | null) => {
+    const queryClient = useQueryClient();
+
+    const { close } = useSSE<Job>(jobId ? `/api/jobs/${jobId}/status` : undefined, {
+        onMessage: (updatedJob) => {
+            queryClient.setQueryData<Job>(
+                getQueryKey(['get', '/api/jobs/{job_id}', { params: { path: { job_id: updatedJob.job_id } } }]),
+                updatedJob
+            );
+
+            if (TERMINAL_STATUSES.includes(updatedJob.status)) {
+                close();
+            }
+        },
+    });
+};
+
 export const useSubmitJob = () => {
     return $api.useMutation('post', '/api/jobs', {
         meta: {

--- a/application/ui/src/hooks/api/jobs/use-import-job-status.hook.tsx
+++ b/application/ui/src/hooks/api/jobs/use-import-job-status.hook.tsx
@@ -9,6 +9,7 @@ import { isFunction } from 'lodash-es';
 import { toast } from '../../../components/toast/toast.component';
 import { isNonEmptyString } from '../../../shared/util';
 import { isInvalidJob, isJobDone, isJobFailed } from '../util';
+import { useStreamJobDetail } from './jobs.hook';
 
 type UseImportJobStatusProps = {
     jobId: string | null | undefined;
@@ -17,15 +18,14 @@ type UseImportJobStatusProps = {
 };
 
 export const useImportJobStatus = ({ jobId, onError, onSuccess }: UseImportJobStatusProps) => {
+    useStreamJobDetail(jobId);
+
     const response = $api.useQuery(
         'get',
         '/api/jobs/{job_id}',
         { params: { path: { job_id: jobId } } },
         {
             enabled: isNonEmptyString(jobId),
-            refetchInterval: ({ state }) => {
-                return isJobDone(state.data) || isJobFailed(state.data) || state.status === 'error' ? false : 1_000;
-            },
         }
     );
 

--- a/application/ui/src/hooks/api/jobs/use-import-job-status.test.tsx
+++ b/application/ui/src/hooks/api/jobs/use-import-job-status.test.tsx
@@ -1,18 +1,25 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import { HttpResponse } from 'msw';
 import { renderHook } from 'test-utils/render';
 
 import { getMockedPrepareImportDatasetJob } from '../../../../mocks/mock-job';
 import { http } from '../../../api/utils';
 import { server } from '../../../msw-node-setup';
+import {
+    getLastEventSource,
+    MockEventSourceConstructor,
+    resetMockEventSource,
+    simulateSSEMessage,
+} from '../../../test-utils/mock-event-source';
 import { useImportJobStatus } from './use-import-job-status.hook';
 
 describe('useImportJobStatus', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        resetMockEventSource();
     });
 
     it('polls job status and calls onSuccess when job finishes successfully', async () => {
@@ -96,5 +103,55 @@ describe('useImportJobStatus', () => {
         expect(result.current.data).toBeUndefined();
         expect(onSuccess).not.toHaveBeenCalled();
         expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('does not open an SSE connection when jobId is not provided', () => {
+        renderHook(() => useImportJobStatus({ jobId: undefined }));
+
+        expect(MockEventSourceConstructor).not.toHaveBeenCalled();
+    });
+
+    it('updates the job from the SSE status stream instead of polling', async () => {
+        server.use(
+            http.get('/api/jobs/{job_id}', ({ params }) => {
+                return HttpResponse.json(
+                    getMockedPrepareImportDatasetJob({ job_id: params.job_id, status: 'RUNNING', progress: 10 }),
+                    { status: 200 }
+                );
+            })
+        );
+
+        const onSuccess = vi.fn();
+        const { result } = renderHook(() => useImportJobStatus({ jobId: 'job-sse', onSuccess }));
+
+        await waitFor(() => {
+            expect(result.current.data?.progress).toBe(10);
+        });
+
+        expect(MockEventSourceConstructor).toHaveBeenCalledWith(expect.stringContaining('/api/jobs/job-sse/status'));
+
+        const eventSource = getLastEventSource();
+
+        act(() => {
+            simulateSSEMessage(
+                eventSource,
+                getMockedPrepareImportDatasetJob({ job_id: 'job-sse', status: 'RUNNING', progress: 75 })
+            );
+        });
+
+        await waitFor(() => {
+            expect(result.current.data?.progress).toBe(75);
+        });
+
+        act(() => {
+            simulateSSEMessage(eventSource, getMockedPrepareImportDatasetJob({ job_id: 'job-sse', status: 'DONE' }));
+        });
+
+        await waitFor(() => {
+            expect(onSuccess).toHaveBeenCalled();
+        });
+
+        // The stream is closed once the job reaches a terminal state
+        expect(eventSource.close).toHaveBeenCalled();
     });
 });

--- a/application/ui/src/hooks/api/jobs/use-import-job-status.test.tsx
+++ b/application/ui/src/hooks/api/jobs/use-import-job-status.test.tsx
@@ -22,7 +22,7 @@ describe('useImportJobStatus', () => {
         resetMockEventSource();
     });
 
-    it('polls job status and calls onSuccess when job finishes successfully', async () => {
+    it('calls onSuccess when job finishes successfully', async () => {
         const onError = vi.fn();
         const onSuccess = vi.fn();
 

--- a/application/ui/tests/datasets/export-dataset.spec.ts
+++ b/application/ui/tests/datasets/export-dataset.spec.ts
@@ -8,6 +8,7 @@ import { getMockedStagedDataset } from 'mocks/mock-staged-dataset';
 import { HttpResponse } from 'msw';
 
 import { expect, http, test } from '../fixtures';
+import { jobStatusStreamHandler } from './utils';
 
 const STAGED_DATASET_ID = 'staged-dataset-456';
 
@@ -78,16 +79,13 @@ test.describe('Export dataset', () => {
     });
 
     test('export dataset with default settings', async ({ network, page }) => {
-        let pollCount = 0;
         let deletedStagedDatasetId: string | undefined;
 
         network.use(
             http.get('/api/jobs/{job_id}', () => {
-                pollCount += 1;
-
-                const job = pollCount <= 2 ? exportingJob : doneJob;
-                return HttpResponse.json(job, { status: 200 });
+                return HttpResponse.json(exportingJob, { status: 200 });
             }),
+            jobStatusStreamHandler({ [exportJob.job_id]: [exportingJob, doneJob] }),
             http.delete('/api/staged_datasets/{staged_dataset_id}', ({ params }) => {
                 deletedStagedDatasetId = params.staged_dataset_id as string;
                 return new HttpResponse(null, { status: 204 });

--- a/application/ui/tests/datasets/import-dataset-as-new-project.spec.ts
+++ b/application/ui/tests/datasets/import-dataset-as-new-project.spec.ts
@@ -14,7 +14,7 @@ import {
     getMockedImportJob,
     getMockedPrepareJob,
     IMPORT_JOB_ID,
-    jobPollHandler,
+    jobStatusStreamHandler,
     PREPARE_JOB_ID,
     STAGED_DATASET_ID,
     stagedDatasetWithMetadata,
@@ -66,27 +66,23 @@ test.describe('Import dataset as new project', () => {
             message: 'Importing progress...',
         });
 
-        const preparePoll = jobPollHandler({
-            jobId: PREPARE_JOB_ID,
-            whileRunning: getMockedPrepareJob(),
-            whenDone: getMockedPrepareJob({ status: 'DONE', progress: 100, message: 'Preparation completed' }),
-        });
-        const importPoll = jobPollHandler({
-            jobId: IMPORT_JOB_ID,
-            whileRunning: importingJob,
-            whenDone: getMockedImportJob('import_dataset_as_new_project', {
-                status: 'DONE',
-                progress: 100,
-                message: 'Import completed',
-            }),
+        const preparingJob = getMockedPrepareJob();
+        const preparedJob = getMockedPrepareJob({ status: 'DONE', progress: 100, message: 'Preparation completed' });
+        const importedJob = getMockedImportJob('import_dataset_as_new_project', {
+            status: 'DONE',
+            progress: 100,
+            message: 'Import completed',
         });
         const { handler: deleteHandler, getDeletedId } = deleteStagedDatasetHandler();
 
         network.use(
             http.get('/api/jobs/{job_id}', ({ params }) => {
-                const jobId = params.job_id as string;
-                const job = importPoll(jobId) ?? preparePoll(jobId);
+                const job = params.job_id === IMPORT_JOB_ID ? importingJob : preparingJob;
                 return HttpResponse.json(job, { status: 200 });
+            }),
+            jobStatusStreamHandler({
+                [PREPARE_JOB_ID]: [preparingJob, preparedJob],
+                [IMPORT_JOB_ID]: [importingJob, importedJob],
             }),
             deleteHandler
         );
@@ -179,18 +175,18 @@ test.describe('Import dataset as new project', () => {
             message: 'Importing progress...',
         });
 
-        const preparePoll = jobPollHandler({
-            jobId: PREPARE_JOB_ID,
-            whileRunning: getMockedPrepareJob(),
-            whenDone: getMockedPrepareJob({ status: 'DONE', progress: 100, message: 'Preparation completed' }),
-        });
+        const preparingJob = getMockedPrepareJob();
+        const preparedJob = getMockedPrepareJob({ status: 'DONE', progress: 100, message: 'Preparation completed' });
         const { handler: deleteHandler, getDeletedId } = deleteStagedDatasetHandler();
 
         network.use(
             http.get('/api/jobs/{job_id}', ({ params }) => {
-                const jobId = params.job_id as string;
-                const job = jobId === IMPORT_JOB_ID ? importingJob : preparePoll(jobId);
+                const job = params.job_id === IMPORT_JOB_ID ? importingJob : preparingJob;
                 return HttpResponse.json(job, { status: 200 });
+            }),
+            jobStatusStreamHandler({
+                [PREPARE_JOB_ID]: [preparingJob, preparedJob],
+                [IMPORT_JOB_ID]: [importingJob],
             }),
             http.post('/api/jobs/{job_id}:cancel', () => {
                 return HttpResponse.json(getMockedJob({ ...importingJob, status: 'CANCELLED' }), { status: 200 });
@@ -273,21 +269,18 @@ test.describe('Import dataset as new project', () => {
         const errorData = { message: 'An error occurred during preparation.', error: 'error test' };
         const failedImportJob = getMockedImportJob('import_dataset_as_new_project', { status: 'FAILED', ...errorData });
 
-        const preparePoll = jobPollHandler({
-            jobId: PREPARE_JOB_ID,
-            whileRunning: getMockedPrepareJob(),
-            whenDone: getMockedPrepareJob({ status: 'DONE', progress: 100, message: 'Preparation completed' }),
-        });
+        const preparingJob = getMockedPrepareJob();
+        const preparedJob = getMockedPrepareJob({ status: 'DONE', progress: 100, message: 'Preparation completed' });
         const { handler: deleteHandler, getDeletedId } = deleteStagedDatasetHandler();
 
         network.use(
             http.get('/api/jobs/{job_id}', ({ params }) => {
-                const jobId = params.job_id as string;
-                if (jobId === IMPORT_JOB_ID) {
-                    return HttpResponse.json(failedImportJob, { status: 200 });
-                }
-                const job = preparePoll(jobId);
+                const job = params.job_id === IMPORT_JOB_ID ? failedImportJob : preparingJob;
                 return HttpResponse.json(job, { status: 200 });
+            }),
+            jobStatusStreamHandler({
+                [PREPARE_JOB_ID]: [preparingJob, preparedJob],
+                [IMPORT_JOB_ID]: [failedImportJob],
             }),
             deleteHandler
         );

--- a/application/ui/tests/datasets/import-dataset-to-project.spec.ts
+++ b/application/ui/tests/datasets/import-dataset-to-project.spec.ts
@@ -14,7 +14,7 @@ import {
     getMockedImportJob,
     getMockedPrepareJob,
     IMPORT_JOB_ID,
-    jobPollHandler,
+    jobStatusStreamHandler,
     PREPARE_JOB_ID,
     STAGED_DATASET_ID,
     stagedDatasetWithMetadata,
@@ -65,27 +65,23 @@ test.describe('Import dataset to project', () => {
             message: 'Importing progress...',
         });
 
-        const preparePoll = jobPollHandler({
-            jobId: PREPARE_JOB_ID,
-            whileRunning: getMockedPrepareJob(),
-            whenDone: getMockedPrepareJob({ status: 'DONE', progress: 100, message: 'Preparation completed' }),
-        });
-        const importPoll = jobPollHandler({
-            jobId: IMPORT_JOB_ID,
-            whileRunning: importingJob,
-            whenDone: getMockedImportJob('import_dataset_to_project', {
-                status: 'DONE',
-                progress: 100,
-                message: 'Import completed',
-            }),
+        const preparingJob = getMockedPrepareJob();
+        const preparedJob = getMockedPrepareJob({ status: 'DONE', progress: 100, message: 'Preparation completed' });
+        const importedJob = getMockedImportJob('import_dataset_to_project', {
+            status: 'DONE',
+            progress: 100,
+            message: 'Import completed',
         });
         const { handler: deleteHandler, getDeletedId } = deleteStagedDatasetHandler();
 
         network.use(
             http.get('/api/jobs/{job_id}', ({ params }) => {
-                const jobId = params.job_id as string;
-                const job = importPoll(jobId) ?? preparePoll(jobId);
+                const job = params.job_id === IMPORT_JOB_ID ? importingJob : preparingJob;
                 return HttpResponse.json(job, { status: 200 });
+            }),
+            jobStatusStreamHandler({
+                [PREPARE_JOB_ID]: [preparingJob, preparedJob],
+                [IMPORT_JOB_ID]: [importingJob, importedJob],
             }),
             deleteHandler
         );
@@ -132,17 +128,17 @@ test.describe('Import dataset to project', () => {
             message: 'Importing progress...',
         });
 
-        const preparePoll = jobPollHandler({
-            jobId: PREPARE_JOB_ID,
-            whileRunning: getMockedPrepareJob(),
-            whenDone: getMockedPrepareJob({ status: 'DONE', progress: 100, message: 'Preparation completed' }),
-        });
+        const preparingJob = getMockedPrepareJob();
+        const preparedJob = getMockedPrepareJob({ status: 'DONE', progress: 100, message: 'Preparation completed' });
 
         network.use(
             http.get('/api/jobs/{job_id}', ({ params }) => {
-                const jobId = params.job_id as string;
-                const job = jobId === IMPORT_JOB_ID ? importingJob : preparePoll(jobId);
+                const job = params.job_id === IMPORT_JOB_ID ? importingJob : preparingJob;
                 return HttpResponse.json(job, { status: 200 });
+            }),
+            jobStatusStreamHandler({
+                [PREPARE_JOB_ID]: [preparingJob, preparedJob],
+                [IMPORT_JOB_ID]: [importingJob],
             }),
             http.post('/api/jobs/{job_id}:cancel', () => {
                 return HttpResponse.json(getMockedJob({ ...importingJob, status: 'CANCELLED' }), { status: 200 });
@@ -219,17 +215,17 @@ test.describe('Import dataset to project', () => {
             message: 'Import failed due to server error',
         });
 
-        const preparePoll = jobPollHandler({
-            jobId: PREPARE_JOB_ID,
-            whileRunning: getMockedPrepareJob(),
-            whenDone: getMockedPrepareJob({ status: 'DONE', progress: 100, message: 'Preparation completed' }),
-        });
+        const preparingJob = getMockedPrepareJob();
+        const preparedJob = getMockedPrepareJob({ status: 'DONE', progress: 100, message: 'Preparation completed' });
 
         network.use(
             http.get('/api/jobs/{job_id}', ({ params }) => {
-                const jobId = params.job_id as string;
-                const job = jobId === IMPORT_JOB_ID ? failedImportJob : preparePoll(jobId);
+                const job = params.job_id === IMPORT_JOB_ID ? failedImportJob : preparingJob;
                 return HttpResponse.json(job, { status: 200 });
+            }),
+            jobStatusStreamHandler({
+                [PREPARE_JOB_ID]: [preparingJob, preparedJob],
+                [IMPORT_JOB_ID]: [failedImportJob],
             }),
             http.delete('/api/staged_datasets/{staged_dataset_id}', ({}) => {
                 return HttpResponse.json(

--- a/application/ui/tests/datasets/utils.ts
+++ b/application/ui/tests/datasets/utils.ts
@@ -51,24 +51,34 @@ export const stagedDatasetWithMetadata = getMockedStagedDataset({
     },
 });
 
-export const jobPollHandler = ({
-    jobId,
-    whileRunning,
-    whenDone,
-    afterPolls = 2,
-}: {
-    jobId: string;
-    whileRunning: ReturnType<typeof getMockedJob>;
-    whenDone: ReturnType<typeof getMockedJob>;
-    afterPolls?: number;
-}) => {
-    let pollCount = 0;
+const SSE_HEADERS = { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' };
+const SNAPSHOT_STEP_MS = 1_000;
 
-    return (requestJobId: string) => {
-        if (requestJobId !== jobId) return undefined;
-        pollCount += 1;
-        return pollCount <= afterPolls ? whileRunning : whenDone;
-    };
+// Responses are buffered by @msw/playwright, so a connection can only carry one snapshot. Which
+// snapshot is picked by elapsed time rather than connection count, so a client that reconnects or
+// opens the stream twice still observes every step.
+export const jobStatusStreamHandler = (snapshotsByJobId: Record<string, Job[]>) => {
+    const firstRequestedAt = new Map<string, number>();
+
+    return http.get('/api/jobs/{job_id}/status', ({ params }) => {
+        const jobId = params.job_id as string;
+        const snapshots = snapshotsByJobId[jobId] ?? [];
+
+        if (snapshots.length === 0) {
+            return new HttpResponse(':ok\n\n', { status: 200, headers: SSE_HEADERS });
+        }
+
+        const startedAt = firstRequestedAt.get(jobId) ?? Date.now();
+        firstRequestedAt.set(jobId, startedAt);
+
+        const step = Math.floor((Date.now() - startedAt) / SNAPSHOT_STEP_MS);
+        const snapshot = snapshots[Math.min(step, snapshots.length - 1)];
+
+        return new HttpResponse(`data: ${JSON.stringify(snapshot)}\n\n`, {
+            status: 200,
+            headers: SSE_HEADERS,
+        });
+    });
 };
 
 export const deleteStagedDatasetHandler = () => {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Replace refetchInterval on import/export dataset job hooks by SSE (same as for status). We dont reuse the hook because there's a few difference between the two so i'd rather have a small duplication than extending an already long hook. (e.g. of a difference: projectIdentifier might not be present on import/export for instance if you run it on the project list page)
Why: `jobs.py` exposes GET /api/jobs/{job_id}/status as EventSourceResponse, and running-job-row uses it. But use-`export-status.hook.tsx` and `use-import-job-status.hook.tsx` still refetchInterval: 1_000 against GET /api/jobs/{job_id}.


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
