### PR TITLE
Add instructions and Just recipe to support legacy Nvidia GPU via patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ uv pip install "getitune[cuda]" --extra-index-url https://download.pytorch.org/w
 uv pip install getitune # CPU-only by default
 ```
 
-> [!IMPORTANT] > **Ultralytics YOLO Models**: The PyPI package does **not** include Ultralytics YOLO models, which are distributed under the [AGPL-3.0 license](https://www.ultralytics.com/license).
+> [!IMPORTANT]  
+> The PyPI package does NOT include **Ultralytics YOLO models**, which are distributed under the [AGPL-3.0 license](https://www.ultralytics.com/license).
 >
 > Install `getitune` from source to use them:
 >

--- a/application/Justfile
+++ b/application/Justfile
@@ -393,3 +393,10 @@ stop-coturn:
     @echo "Stopping coturn server..."
     @docker stop coturn-server || true
 
+# Patch Geti source code to use CUDA 12.6 instead of 13.0 for the 'cuda' target, needed for legacy Nvidia GPUs
+# (Volta, Maxwell, Pascal). See https://github.com/open-edge-platform/geti/issues/7163
+patch-for-legacy-gpu-support:
+    cd {{ justfile_directory() }}/../library && just patch-for-legacy-gpu-support
+    cd {{ justfile_directory() }}/backend && just venv-lock
+    @echo "Patched the code to use CUDA 12.6 for the 'cuda' target (legacy Nvidia GPU support)."
+    @echo "For Docker users: run 'just build-image --accelerator cuda' to rebuild the image with the patched code."

--- a/application/docs/install.md
+++ b/application/docs/install.md
@@ -6,12 +6,16 @@ can choose the method that best fits your workflow.
 
 ## System requirements
 
-| Component | Requirement                                            |
-| --------- | ------------------------------------------------------ |
-| CPU       | 8 threads                                              |
-| RAM       | 16 GB                                                  |
-| Disk      | 40 GB free                                             |
-| GPU       | Optional - Intel® XPU or NVIDIA® GPU for larger models |
+| Component | Requirement                                              |
+| --------- | -------------------------------------------------------- |
+| CPU       | 8 threads                                                |
+| RAM       | 16 GB                                                    |
+| Disk      | 40 GB free                                               |
+| GPU       | Optional - Intel® XPU or NVIDIA® GPU for larger models   |
+
+> [!NOTE]
+> NVIDIA® GPUs with compute capability below 7.5 (e.g. Volta, Maxwell, Pascal) require a manual patch to work.
+> See [Troubleshooting > I have an old Nvidia GPU, does Geti support it?](#i-have-an-old-nvidia-gpu-does-geti-support-it).
 
 ## Installation methods
 
@@ -41,7 +45,7 @@ If Windows shows a security prompt, verify that the package is from the official
 
 > [!IMPORTANT]
 > Windows apps do not include Ultralytics models due to AGPL licensing constraints. If you need them,
-> please use the [install script](#install-script) or [build a Docker image from source](#option-2-build-the-image) 
+> please use the [install script](#install-script) or [build a Docker image from source](#option-2-build-the-image)
 > as described below.
 
 ## Run with Docker
@@ -175,12 +179,12 @@ Geti™ uses WebRTC for real-time inference streaming visualization in the UI. W
 direct connection to the backend's media server. Use these options when the in-app WebRTC preview does not connect under
 NAT, load balancers, or restrictive firewall policies.
 
-| Scenario | Recommended setup |
-|---|---|
-| Local machine / same LAN | Usually no extra setup. If needed, set a STUN server so the host advertises a reachable address. |
-| Public or cloud host with dynamic public IP | Use STUN so the host can discover and advertise its public address. |
-| Public host behind load balancer with fixed public IP/DNS | Configure the advertised public endpoint in your runtime setup. |
-| Restrictive firewall (UDP blocked, only TCP 443 allowed) | Run a TURN relay and start Geti™ with TURN enabled. |
+| Scenario                                                  | Recommended setup                                                                                |
+| --------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Local machine / same LAN                                  | Usually no extra setup. If needed, set a STUN server so the host advertises a reachable address. |
+| Public or cloud host with dynamic public IP               | Use STUN so the host can discover and advertise its public address.                              |
+| Public host behind load balancer with fixed public IP/DNS | Configure the advertised public endpoint in your runtime setup.                                  |
+| Restrictive firewall (UDP blocked, only TCP 443 allowed)  | Run a TURN relay and start Geti™ with TURN enabled.                                             |
 
 <details>
 <summary><strong>Local machine or local network</strong></summary>
@@ -479,6 +483,49 @@ docker run --rm -v geti-data:/data alpine ls -l /data/pretrained_weights/<TASK_T
   **Settings > Apps > Installed apps > Geti™ > Uninstall**.
 
 ## Troubleshooting
+
+<details>
+<summary><strong>I have an old Nvidia GPU, does Geti support it?</strong></summary>
+
+<a id="i-have-an-old-nvidia-gpu-does-geti-support-it"></a>
+
+Geti's `cuda` builds use PyTorch wheels compiled against CUDA 13.0, which dropped support for NVIDIA GPU
+architectures older than Ampere (compute capability < 8.0), covering Volta, Turing, Maxwell, and Pascal cards. If
+your GPU falls in this range, you must patch the source to build against CUDA 12.6 instead, which still supports
+compute capability >= 5.0.
+
+- **Install script:** patch `pyproject.toml` before running the installer:
+
+  ```bash
+  git clone https://github.com/open-edge-platform/geti.git
+  cd geti/library
+  just patch-for-legacy-gpu-support
+  cd ../application
+  just patch-for-legacy-gpu-support
+  # Then run install.sh / install.ps1 as usual, from the repo root
+  ```
+
+- **Docker (build from source):** run the patch recipe from the `application` directory, then build the image as usual:
+
+  ```bash
+  cd application
+  just patch-for-legacy-gpu-support
+  just build-image --accelerator cuda
+  ```
+
+- **Run from source (development):** run the patch recipe from the `application` directory before initializing the backend environment:
+
+  ```bash
+  cd application
+  just patch-for-legacy-gpu-support
+  cd backend
+  just venv --accelerator cuda
+  ```
+
+> [!NOTE]
+> The Windows app (MSIX) is prebuilt and cannot be patched this way; it requires the newer PyTorch/CUDA wheels.
+
+</details>
 
 <details>
 <summary><strong>WSL2: WebRTC preview connects but video freezes after a few frames</strong></summary>

--- a/application/docs/install.md
+++ b/application/docs/install.md
@@ -11,7 +11,7 @@ can choose the method that best fits your workflow.
 | CPU       | 8 threads                                                |
 | RAM       | 16 GB                                                    |
 | Disk      | 40 GB free                                               |
-| GPU       | Optional - Intel® XPU or NVIDIA® GPU for larger models   |
+| GPU       | Optional - Intel® XPU or NVIDIA® GPU for larger models |
 
 > [!NOTE]
 > NVIDIA® GPUs with compute capability below 7.5 (e.g. Volta, Maxwell, Pascal) require a manual patch to work.
@@ -498,9 +498,7 @@ compute capability >= 5.0.
 
   ```bash
   git clone https://github.com/open-edge-platform/geti.git
-  cd geti/library
-  just patch-for-legacy-gpu-support
-  cd ../application
+  cd geti/application
   just patch-for-legacy-gpu-support
   # Then run install.sh / install.ps1 as usual, from the repo root
   ```

--- a/library/Justfile
+++ b/library/Justfile
@@ -33,8 +33,8 @@ venv-lock: _ensure_uv
 
 # Patch pyproject.toml to build torch/torchvision against CUDA 12.6 instead of 13.0 for the 'cuda' target,
 # needed for legacy Nvidia GPUs (Volta, Maxwell, Pascal). See https://github.com/open-edge-platform/geti/issues/7163
-patch-for-legacy-gpu-support:
-    sed -i 's/cu130/cu126/g' pyproject.toml
+patch-for-legacy-gpu-support: _ensure_uv
+    uv run python -c "from pathlib import Path; p = Path('pyproject.toml'); p.write_text(p.read_text().replace('cu130', 'cu126'))"
     just venv-lock
 
 # -------------------------------------------------------------------------------------------------

--- a/library/Justfile
+++ b/library/Justfile
@@ -4,7 +4,7 @@ default:
     @just --list --unsorted
 
 # -------------------------------------------------------------------------------------------------
-# Virtual environment management
+# Virtual environment and dependency management
 # -------------------------------------------------------------------------------------------------
 
 uv_version := `grep -A 3 '\[tool\.uv\]' pyproject.toml | grep 'required-version' | sed 's/.*= "[~=<>]*\(.*\)"/\1/'`
@@ -30,6 +30,12 @@ venv-benchmark device="cpu": _ensure_uv
 # Generate or update the uv lock file
 venv-lock: _ensure_uv
     uv lock
+
+# Patch pyproject.toml to build torch/torchvision against CUDA 12.6 instead of 13.0 for the 'cuda' target,
+# needed for legacy Nvidia GPUs (Volta, Maxwell, Pascal). See https://github.com/open-edge-platform/geti/issues/7163
+patch-for-legacy-gpu-support:
+    sed -i 's/cu130/cu126/g' pyproject.toml
+    just venv-lock
 
 # -------------------------------------------------------------------------------------------------
 # Linting and formatting

--- a/library/README.md
+++ b/library/README.md
@@ -116,9 +116,8 @@ uv pip install "getitune[cuda]" --extra-index-url https://download.pytorch.org/w
 uv pip install "getitune[cpu]"
 ```
 
-> [!NOTE] > **macOS**: PyTorch's `+cpu` wheel is only published for Linux and Windows. The `[cpu]` extra resolves this automatically and installs the default `torch==2.10.0` wheel on macOS.
-> **Ultralytics YOLO models**: The PyPI version doesn't include Ultralytics YOLO support.
-> To use YOLO26 models, you must [install from source](#advanced-install-from-source).
+> [!NOTE]
+> For **macOS** users: PyTorch's `+cpu` wheel is only published for Linux and Windows. The `[cpu]` extra resolves this automatically and installs the default `torch==2.10.0` wheel on macOS.
 
 </details>
 
@@ -149,7 +148,8 @@ pip install -e ".[cuda]" \
   --extra-index-url https://download.pytorch.org/whl/cu130
 ```
 
-> [!NOTE] > **Ultralytics YOLO models**: Add `--extra ultralytics` for `uv sync` or `[ultralytics]` for `pip install`:
+> [!NOTE]
+> For **Ultralytics YOLO models**, add `--extra ultralytics` for `uv sync` or `[ultralytics]` for `pip install`:
 >
 > ```bash
 > uv sync --extra xpu --extra ultralytics  # Intel GPU + YOLO
@@ -157,6 +157,34 @@ pip install -e ".[cuda]" \
 > # or with pip
 > pip install -e ".[xpu,ultralytics]" --extra-index-url https://download.pytorch.org/whl/xpu  #Intel GPU + YOLO
 > ```
+
+</details>
+
+<details>
+<summary><a id="legacy-cuda-support"></a><strong> Advanced Installation: Install from Source with Legacy CUDA Support (12.6)</strong></summary>
+
+By default, the `[cuda]` extra builds `torch`/`torchvision` against CUDA 13.0, which doesn't support older NVIDIA GPU
+architectures (Volta, Maxwell, Pascal). If you have one of these GPUs, patch the project to use CUDA 12.6 instead:
+
+```bash
+git clone https://github.com/open-edge-platform/geti.git
+cd geti/library
+
+# Replace CUDA 13.0 with CUDA 12.6 in pyproject.toml and refresh the lockfile
+just patch-for-legacy-gpu-support
+
+# Then install as usual, e.g. with uv
+uv sync --extra cuda         # NVIDIA GPU (CUDA 12.6) — setup: https://developer.nvidia.com/cuda-12-6-0-download-archive
+
+# Or with pip in a virtual environment
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[cuda]" \
+  --extra-index-url https://download.pytorch.org/whl/cu126
+```
+
+> [!NOTE]
+> See [this PyTorch thread](https://github.com/pytorch/pytorch/issues/178665) for more details about what GPUs are
+> supported for each CUDA version.
 
 </details>
 
@@ -375,7 +403,8 @@ engine.train(epochs=50)
 engine.test()
 engine.export()
 
-> ⚠️ **Note**: Ultralytics YOLO models and the `UltralyticsEngine` backend require [installing from source](#advanced-installation-install-from-source) with the `[ultralytics]` extra.
+> [!NOTE]
+> Ultralytics YOLO models and the `UltralyticsEngine` backend require [installing from source](#advanced-installation-install-from-source) with the `[ultralytics]` extra.
 > The PyPI package does **not** include Ultralytics support.
 
 


### PR DESCRIPTION
### Summary

This PR aims to help users with old Nvidia GPUs (CC<7.5, e.g. Volta, Maxwell, Pascal) by providing and documenting a technical path to patch Geti to use CUDA 12.6 instead of CUDA 13.0. The PR introduces new `just` recipes to automate this patching process and updates the documentation to clearly explain installation steps, requirements, and limitations for these older GPUs.

**For library users**:
```sh
cd library
just patch-for-legacy-gpu-support
```

**For application users**:
```sh
cd application
just patch-for-legacy-gpu-support
just build-image --accelerator cuda
```

Resolves #7163
Resolves #7106

### How to test

- [x] Run `just patch-for-legacy-gpu-support` followed by `just build-image -a cuda` on a machine with legacy GPU (e.g. Tesla T4), then run Geti and verify that training works.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [x] Documentation has been updated (if applicable)
