### PR TITLE
Bugfix: model size LRU cache would never hit

### DIFF
--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -88,6 +88,11 @@ KEY_MAPPING = {
 }
 
 
+@lru_cache
+def _cached_model_size_in_bytes(model_path: Path) -> int:
+    return sum(f.stat().st_size for f in model_path.glob("**/*") if f.is_file())
+
+
 @dataclass(frozen=True)
 class ModelRevisionMetadata:
     model_id: UUID
@@ -198,17 +203,12 @@ class ModelService(BaseSessionManagedService):
         Returns:
             int: Total size of the model and all its files in bytes.
         """
-
-        @lru_cache
-        def _cached_model_size_in_bytes(_model_path: Path) -> int:
-            return sum(f.stat().st_size for f in _model_path.glob("**/*") if f.is_file())
-
         model_revision = self.get_model(project_id=project_id, model_id=model_id)
         if model_revision.files_deleted:
             return 0
 
         model_path = self._projects_dir / str(project_id) / "models" / str(model_id)
-        return _cached_model_size_in_bytes(_model_path=model_path)
+        return _cached_model_size_in_bytes(model_path)
 
     def rename_model(self, project_id: UUID, model_id: UUID, model_metadata: dict[str, str]) -> ModelRevision:
         """


### PR DESCRIPTION
### Summary

Since the cache was defined inside a function, it would be recreated on every call defeating its purpose.

Credits to @jpggvilaca and Opus for spotting the bug :)

### How to test

I measured the response time of `GET /models` in a project with ~40 trained models, after this PR the average response time is reduced from ~400ms to ~300ms. It's not 0 of course because the endpoint does a lot more work than just retrieving the model size.

I also verified that the size returned by the server is correctly updated after deleting the model weights, i.e. the server doesn't return stale cached info.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
