### PR TITLE
ci: use ubuntu-latest for getitrack workflow (overflow runner retired)

### DIFF
--- a/.github/workflows/getitrack-lint-and-test.yaml
+++ b/.github/workflows/getitrack-lint-and-test.yaml
@@ -25,7 +25,7 @@ jobs:
   # changes (including getitune at library/) do not trigger it.
   check-paths:
     name: Check if workflow should run
-    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     outputs:
       run_workflow: ${{ steps.check_paths.outputs.run }}
     steps:
@@ -46,7 +46,7 @@ jobs:
               - .github/actions/**
 
   code-quality-checks:
-    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     needs: check-paths
     if: needs.check-paths.outputs.run_workflow == 'true'
     permissions:
@@ -69,7 +69,7 @@ jobs:
         run: just lint
 
   unit-tests:
-    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     needs:
@@ -108,7 +108,7 @@ jobs:
       - check-paths
       - code-quality-checks
       - unit-tests
-    runs-on: ${{ github.repository_owner == 'open-edge-platform' && 'overflow' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     env:
       CHECKS: ${{ join(needs.*.result, ' ') }}
     if: always() && !cancelled()


### PR DESCRIPTION
The self-hosted `overflow` runner was retired on `develop`, which moved all workflows to `ubuntu-latest`. `feature/getitrack` predates that, so its workflows still resolve `runs-on` to `overflow`, and every getitrack PR fails CI on a runner that no longer exists.

`getitrack-lint-and-test.yaml` is getitrack-specific and does not exist on `develop`, so it is the one workflow that a develop sync cannot fix. This switches its four `runs-on` lines to `ubuntu-latest` (matching develop's runner change); no other changes.

The remaining shared workflows (lib-lint, backend, ui, build, etc.) are fixed separately by syncing `develop` into `feature/getitrack`, so they are intentionally not touched here.

Unblocks the getitrack CI check on the open PRs targeting this branch (#7066, #7067, #7068, and the rest) once merged.
