### PR TITLE
Fix inference device validation

### DIFF
--- a/application/backend/app/api/routers/jobs.py
+++ b/application/backend/app/api/routers/jobs.py
@@ -68,7 +68,7 @@ async def submit_job(
         job_id = uuid4()
         match job_request.job_type:
             case JobType.TRAIN:
-                device = system_service.get_device_info(job_request.parameters.device)
+                device = system_service.training_device(job_request.parameters.device)
                 project = project_service.get_project_by_id(job_request.project_id)
                 arch_id = job_request.parameters.model_architecture_id
                 arch_name = ModelManifestService.get_model_manifest_by_id(arch_id).name

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -617,7 +617,7 @@ def media_predict(
         )
 
     try:
-        device = system_service.get_inference_device_info(request.device)
+        device = system_service.inference_device(request.device)
         return media_prediction_service.predict_media(project=project, request=request, device=device)
     except VideoRangeError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))

--- a/application/backend/app/api/routers/pipelines.py
+++ b/application/backend/app/api/routers/pipelines.py
@@ -188,7 +188,7 @@ def update_pipeline(
 
     if "device" in pipeline_config:
         device_str = pipeline_config["device"]
-        if not system_service.validate_device(device_str):
+        if not system_service.is_valid_inference_device(device_str):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT, detail=f"Device '{device_str}' is not available on this system"
             )

--- a/application/backend/app/api/routers/system.py
+++ b/application/backend/app/api/routers/system.py
@@ -38,7 +38,7 @@ async def get_inference_devices(
     system_service: Annotated[SystemService, Depends(get_system_service)],
 ) -> list[DeviceInfoView]:
     """Returns the list of available compute devices (CPU, Intel XPU)."""
-    inference_devices = system_service.get_inference_devices()
+    inference_devices = system_service.inference_devices()
     return [DeviceInfoView.model_validate(device, from_attributes=True) for device in inference_devices]
 
 
@@ -47,7 +47,7 @@ async def get_training_devices(
     system_service: Annotated[SystemService, Depends(get_system_service)],
 ) -> list[DeviceInfoView]:
     """Returns the list of available training devices (CPU, Intel XPU, NVIDIA CUDA)."""
-    training_devices = system_service.get_training_devices()
+    training_devices = system_service.training_devices()
     return [DeviceInfoView.model_validate(device, from_attributes=True) for device in training_devices]
 
 
@@ -56,7 +56,7 @@ async def get_camera_devices(
     system_service: Annotated[SystemService, Depends(get_system_service)],
 ) -> list[CameraInfoView]:
     """Returns the list of available camera devices."""
-    camera_devices = system_service.get_camera_devices()
+    camera_devices = system_service.list_cameras()
     return [CameraInfoView.model_validate(device, from_attributes=True) for device in camera_devices]
 
 

--- a/application/backend/app/models/__init__.py
+++ b/application/backend/app/models/__init__.py
@@ -12,6 +12,7 @@ from .data_collection_policy import (
 from .dataset import AnnotationType, DatasetFormat, StagedDataset
 from .dataset_item import DatasetItem, DatasetItemAnnotation, DatasetItemAnnotationStatus, DatasetItemSubset
 from .dataset_revision import DatasetRevision
+from .device_spec import DeviceSpec
 from .evaluation import EvaluationResult
 from .inference import (
     BatchInferenceInput,
@@ -80,6 +81,7 @@ __all__ = [
     "DatasetItemAnnotationStatus",
     "DatasetItemSubset",
     "DatasetRevision",
+    "DeviceSpec",
     "DisconnectedSinkConfig",
     "DisconnectedSourceConfig",
     "EvaluationResult",

--- a/application/backend/app/models/device_spec.py
+++ b/application/backend/app/models/device_spec.py
@@ -1,0 +1,82 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+
+from app.models.system import DeviceInfo, DeviceType
+
+
+class DeviceSpec:
+    """A parsed device request, e.g. 'xpu-1', that knows how to match a `DeviceInfo`."""
+
+    _PATTERN = re.compile(r"^(auto|cpu|xpu|cuda)(-(\d+))?$")
+
+    def __init__(self, device_type: DeviceType, index: int) -> None:
+        self._type = device_type
+        self._index = index
+
+    @classmethod
+    def parse(cls, device_str: str) -> "DeviceSpec":
+        """
+        Parse a device string into a `DeviceSpec`.
+
+        Args:
+            device_str: Device string in format '<target>[-<index>]'
+                (e.g., 'auto', 'cpu', 'xpu', 'cuda', 'xpu-2', 'cuda-1').
+
+        Returns:
+            DeviceSpec: The parsed device specification.
+
+        Raises:
+            ValueError: If `device_str` does not match the expected format.
+        """
+        match = cls._PATTERN.match(device_str.lower())
+        if not match:
+            raise ValueError(f"Invalid device string: {device_str}")
+        kind, _, index = match.groups()
+        if kind in {"auto", "cpu"} and index is not None:
+            raise ValueError(f"Invalid device string: {device_str}")
+        return cls(DeviceType(kind), int(index) if index is not None else 0)
+
+    @property
+    def type(self) -> DeviceType:
+        """The requested device type."""
+        return self._type
+
+    def is_cpu(self) -> bool:
+        """Whether this spec refers to the CPU."""
+        return self._type == DeviceType.CPU
+
+    def is_auto(self) -> bool:
+        """Whether this spec refers to automatic device selection."""
+        return self._type == DeviceType.AUTO
+
+    def is_cuda(self) -> bool:
+        """Whether this spec refers to a CUDA device."""
+        return self._type == DeviceType.CUDA
+
+    def matches(self, device: DeviceInfo) -> bool:
+        """
+        Check whether a `DeviceInfo` satisfies this spec.
+
+        Args:
+            device: The candidate device.
+
+        Returns:
+            bool: True if `device` has the same type and index as this spec.
+        """
+        return self._type == device.type and self._index == (device.index or 0)
+
+    def __str__(self) -> str:
+        return f"{self._type.value}-{self._index}"
+
+    def fixed_device(self) -> DeviceInfo | None:
+        """Resolve this spec to a fixed `DeviceInfo` without consulting a device catalog.
+
+        `AUTO` and `CPU` are always available and never need to be looked up among the
+        devices a catalog actually discovers (e.g. via PyTorch or OpenVINO)."""
+        if self.is_cpu():
+            return DeviceInfo.cpu()
+        if self.is_auto():
+            return DeviceInfo.auto()
+        return None

--- a/application/backend/app/models/device_spec.py
+++ b/application/backend/app/models/device_spec.py
@@ -68,6 +68,8 @@ class DeviceSpec:
         return self._type == device.type and self._index == (device.index or 0)
 
     def __str__(self) -> str:
+        if self.is_auto() or self.is_cpu():
+            return self._type.value
         return f"{self._type.value}-{self._index}"
 
     def fixed_device(self) -> DeviceInfo | None:

--- a/application/backend/app/services/active_model_service.py
+++ b/application/backend/app/services/active_model_service.py
@@ -24,13 +24,13 @@ class ActiveModelService:
     Used exclusively by the InferenceWorker process.
     """
 
-    def __init__(self, data_dir: Path) -> None:
+    def __init__(self, data_dir: Path, system_service: SystemService) -> None:
         self.projects_dir = data_dir / "projects"
+        self._system_service = system_service
         self._model_activation_state: ModelActivationState = self._load_state()
         self._loaded_model: LoadedModelHandle | None = None
 
-    @staticmethod
-    def _load_state() -> ModelActivationState:
+    def _load_state(self) -> ModelActivationState:
         """Load the state from the DB if it exists, otherwise initialize an empty state"""
         with get_db_session() as db:
             active_model_repo = ActiveModelRepo(db=db)
@@ -59,7 +59,7 @@ class ActiveModelService:
             pipeline_device = active_model_repo.get_active_pipeline_device()
             if pipeline_device is None:
                 raise RuntimeError("Active pipeline must have a device configured")
-            geti_device = SystemService().get_device_info(pipeline_device)
+            geti_device = self._system_service.inference_device(pipeline_device)
             return ModelActivationState(
                 project_id=UUID(active_model.project_id),
                 active_model_id=UUID(active_model.id),

--- a/application/backend/app/services/active_model_service.py
+++ b/application/backend/app/services/active_model_service.py
@@ -59,7 +59,7 @@ class ActiveModelService:
             pipeline_device = active_model_repo.get_active_pipeline_device()
             if pipeline_device is None:
                 raise RuntimeError("Active pipeline must have a device configured")
-            geti_device = self._system_service.inference_device(pipeline_device)
+            geti_device = self._system_service.inference_device(pipeline_device, fallback_to_cpu=True)
             return ModelActivationState(
                 project_id=UUID(active_model.project_id),
                 active_model_id=UUID(active_model.id),

--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -92,7 +92,7 @@ class PipelineService(BaseSessionManagedService):
         if pipeline_db is None:
             return None
 
-        if not self._system_service.validate_device(pipeline_db.device):
+        if not self._system_service.is_valid_inference_device(pipeline_db.device):
             logger.warning(
                 "The configured device '{}' is not available for pipeline '{}'. Falling back to 'cpu'.",
                 pipeline_db.device,
@@ -302,6 +302,6 @@ class PipelineService(BaseSessionManagedService):
         """
         if self._system_service is None:
             raise ValueError("System service is required to validate INT8 support.")
-        device_info = self._system_service.get_device_info(device)
+        device_info = self._system_service.inference_device(device)
         if not self._system_service.supports_int8(device_info):
             raise DeviceInt8NotSupportedError(device)

--- a/application/backend/app/services/system_service.py
+++ b/application/backend/app/services/system_service.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import platform
 import re
-from typing import Any
+from typing import Any, Protocol
 
 import cv2
 import psutil
@@ -11,7 +11,6 @@ from loguru import logger
 
 from app.models.system import CameraInfo, DeviceInfo, DeviceType
 
-DEVICE_PATTERN = re.compile(r"^(auto|cpu|xpu|cuda)(-(\d+))?$")
 DEFAULT_DEVICE = "cpu"
 CV2_BACKENDS = {
     "Windows": cv2.CAP_MSMF,
@@ -19,93 +18,260 @@ CV2_BACKENDS = {
     "Darwin": cv2.CAP_AVFOUNDATION,
 }
 
-# torch is imported lazily on first use to keep server startup fast (importing torch eagerly
-# added several seconds to boot). Kept as a module-level name so tests can patch
-# ``app.services.system_service.torch``. Typed as Any because the module is loaded lazily.
-torch: Any = None
+
+class DeviceSpec:
+    """A parsed device request, e.g. 'xpu-1', that knows how to match a `DeviceInfo`."""
+
+    _PATTERN = re.compile(r"^(auto|cpu|xpu|cuda)(-(\d+))?$")
+
+    def __init__(self, device_type: DeviceType, index: int) -> None:
+        self._type = device_type
+        self._index = index
+
+    @classmethod
+    def parse(cls, device_str: str) -> "DeviceSpec":
+        """
+        Parse a device string into a `DeviceSpec`.
+
+        Args:
+            device_str: Device string in format '<target>[-<index>]'
+                (e.g., 'auto', 'cpu', 'xpu', 'cuda', 'xpu-2', 'cuda-1').
+
+        Returns:
+            DeviceSpec: The parsed device specification.
+
+        Raises:
+            ValueError: If `device_str` does not match the expected format.
+        """
+        match = cls._PATTERN.match(device_str.lower())
+        if not match:
+            raise ValueError(f"Invalid device string: {device_str}")
+        kind, _, index = match.groups()
+        return cls(DeviceType(kind), int(index) if index is not None else 0)
+
+    @property
+    def type(self) -> DeviceType:
+        """The requested device type."""
+        return self._type
+
+    def is_cpu(self) -> bool:
+        """Whether this spec refers to the CPU."""
+        return self._type == DeviceType.CPU
+
+    def is_auto(self) -> bool:
+        """Whether this spec refers to automatic device selection."""
+        return self._type == DeviceType.AUTO
+
+    def is_cuda(self) -> bool:
+        """Whether this spec refers to a CUDA device."""
+        return self._type == DeviceType.CUDA
+
+    def matches(self, device: DeviceInfo) -> bool:
+        """
+        Check whether a `DeviceInfo` satisfies this spec.
+
+        Args:
+            device: The candidate device.
+
+        Returns:
+            bool: True if `device` has the same type and index as this spec.
+        """
+        return self._type == device.type and self._index == (device.index or 0)
+
+    def __str__(self) -> str:
+        return f"{self._type.value}-{self._index}"
+
+    def fixed_device(self) -> DeviceInfo | None:
+        """Resolve this spec to a fixed `DeviceInfo` without consulting a device catalog.
+
+        `AUTO` and `CPU` are always available and never need to be looked up among the
+        devices a catalog actually discovers (e.g. via PyTorch or OpenVINO)."""
+        if self.is_cpu():
+            return DeviceInfo.cpu()
+        if self.is_auto():
+            return DeviceInfo.auto()
+        return None
 
 
-def _get_torch() -> Any:
-    """Import torch on first use and cache it on the module.
+class DeviceCatalog(Protocol):
+    """Can list and resolve devices."""
 
-    Returns:
-        The imported ``torch`` module.
+    def devices(self) -> list[DeviceInfo]: ...
+    def find(self, spec: DeviceSpec) -> DeviceInfo | None: ...
+
+
+class TrainingDeviceCatalog:
+    """Devices available for training, sourced from PyTorch (CPU, XPU, CUDA)."""
+
+    def __init__(self) -> None:
+        self._torch: Any = None
+
+    def _get_torch(self) -> Any:
+        if self._torch is None:
+            import torch
+
+            self._torch = torch
+        return self._torch
+
+    def devices(self) -> list[DeviceInfo]:
+        """
+        Get available compute devices for training.
+
+        Returns:
+            list[DeviceInfo]: CPU plus any detected XPU/CUDA devices.
+        """
+        torch = self._get_torch()
+        devices: list[DeviceInfo] = [DeviceInfo.cpu()]
+        devices.extend(self._xpu_devices(torch))
+        devices.extend(self._cuda_devices(torch))
+        return devices
+
+    def find(self, spec: DeviceSpec) -> DeviceInfo | None:
+        """
+        Resolve a `DeviceSpec` against training devices.
+
+        Args:
+            spec: The requested device specification.
+
+        Returns:
+            DeviceInfo | None: The matching device, or None if unavailable.
+        """
+        if (device := spec.fixed_device()) is not None:
+            return device
+        return next((device for device in self.devices() if spec.matches(device)), None)
+
+    @staticmethod
+    def _xpu_devices(torch: Any) -> list[DeviceInfo]:
+        if not torch.xpu.is_available():
+            return []
+        devices = []
+        for index in range(torch.xpu.device_count()):
+            props = torch.xpu.get_device_properties(index)
+            devices.append(DeviceInfo(type=DeviceType.XPU, name=props.name, memory=props.total_memory, index=index))
+        return devices
+
+    @staticmethod
+    def _cuda_devices(torch: Any) -> list[DeviceInfo]:
+        if not torch.cuda.is_available():
+            return []
+        devices = []
+        for index in range(torch.cuda.device_count()):
+            props = torch.cuda.get_device_properties(index)
+            devices.append(DeviceInfo(type=DeviceType.CUDA, name=props.name, memory=props.total_memory, index=index))
+        return devices
+
+
+class OpenVinoInferenceDeviceCatalog:
     """
-    if torch is None:
-        import torch as _torch
+    Devices available for OpenVINO inference (CPU, integrated GPUs, and Intel discrete GPUs).
 
-        # Update the module attribute (rather than a `global` statement) so it stays patchable
-        # via ``app.services.system_service.torch`` while satisfying the linter.
-        globals()["torch"] = _torch
-    return torch
+    OpenVINO returns device names such as 'CPU', 'GPU', 'GPU.0', 'GPU.1', ... Per the OpenVINO
+    documentation, when an integrated GPU is present it always takes id 0, and 'GPU' is an alias
+    for 'GPU.0'. A GPU is included when it is either integrated (iGPU) or an Intel-branded
+    discrete GPU (dGPU), since only Intel GPUs can perform OpenVINO inference.
+    """
 
+    def __init__(self) -> None:
+        self._core = self._try_create_core()
 
-def _get_available_devices() -> tuple[Any, list[str]] | None:
-    import openvino as ov
+    @staticmethod
+    def _try_create_core() -> Any | None:
+        try:
+            import openvino as ov
 
-    try:
-        core = ov.Core()
-        return core, list(core.available_devices)
-    except Exception:
-        logger.exception("Failed to query OpenVINO inference devices; falling back to CPU only.")
+            return ov.Core()
+        except Exception:
+            logger.exception("Failed to query OpenVINO inference devices; falling back to CPU only.")
+            return None
+
+    def devices(self) -> list[DeviceInfo]:
+        """
+        Get available compute devices for inference.
+
+        Returns:
+            list[DeviceInfo]: CPU plus any detected integrated/Intel discrete GPUs.
+        """
+        if self._core is None:
+            return [DeviceInfo.cpu()]
+
+        found = [d for name in self._core.available_devices if (d := self._device_info(name)) is not None]
+        if not any(device.type == DeviceType.CPU for device in found):
+            found.insert(0, DeviceInfo.cpu())
+        return found
+
+    def find(self, spec: DeviceSpec) -> DeviceInfo | None:
+        """
+        Resolve a `DeviceSpec` against inference devices.
+
+        Args:
+            spec: The requested device specification.
+
+        Returns:
+            DeviceInfo | None: The matching device, or None if unavailable.
+        """
+        if (device := spec.fixed_device()) is not None:
+            return device
+        return next((device for device in self.devices() if spec.matches(device)), None)
+
+    def _device_info(self, ov_device: str) -> DeviceInfo | None:
+        if ov_device == "CPU":
+            return DeviceInfo.cpu()
+        if ov_device.startswith("GPU"):
+            return self._gpu_device_info(ov_device)
+        logger.debug("Skipping unsupported OpenVINO inference device: {}", ov_device)
         return None
 
+    def _gpu_device_info(self, ov_device: str) -> DeviceInfo | None:
+        try:
+            device_type = self._core.get_property(ov_device, "DEVICE_TYPE")  # pyrefly: ignore[missing-attribute]
+            name = str(self._core.get_property(ov_device, "FULL_DEVICE_NAME"))  # pyrefly: ignore[missing-attribute]
+        except Exception:
+            logger.exception("Failed to query required OpenVINO GPU properties for '{}'; skipping.", ov_device)
+            return None
 
-def _device_info(core: Any, ov_device: str) -> DeviceInfo | None:
-    if ov_device == "CPU":
-        return DeviceInfo.cpu()
+        if not self._is_supported_gpu(device_type=device_type, name=name):
+            logger.debug("Skipping non-Intel discrete OpenVINO GPU device: {} ({})", ov_device, name)
+            return None
 
-    if ov_device.startswith("GPU"):
-        return _gpu_device_info(core, ov_device)
+        return DeviceInfo(
+            type=DeviceType.XPU, name=name, memory=self._gpu_memory(ov_device), index=self._gpu_index(ov_device)
+        )
 
-    logger.debug("Skipping unsupported OpenVINO inference device: {}", ov_device)
-    return None
+    @staticmethod
+    def _is_supported_gpu(device_type: Any, name: str) -> bool:
+        is_integrated = "integrated" in str(device_type).lower()
+        is_intel = "intel" in name.lower()
+        return is_integrated or is_intel
 
+    @staticmethod
+    def _gpu_index(ov_device: str) -> int:
+        if ov_device == "GPU":
+            return 0
+        return int(ov_device.split(".", maxsplit=1)[1])
 
-def _gpu_device_info(core: Any, ov_device: str) -> DeviceInfo | None:
-    try:
-        device_type = core.get_property(ov_device, "DEVICE_TYPE")
-        name = str(core.get_property(ov_device, "FULL_DEVICE_NAME"))
-    except Exception:
-        logger.exception("Failed to query required OpenVINO GPU properties for '{}'; skipping.", ov_device)
-        return None
-
-    if not _is_supported_gpu(device_type=device_type, name=name):
-        logger.debug("Skipping non-Intel discrete OpenVINO GPU device: {} ({})", ov_device, name)
-        return None
-
-    return DeviceInfo(
-        type=DeviceType.XPU,
-        name=name,
-        memory=_gpu_memory(core, ov_device),
-        index=_gpu_index(ov_device),
-    )
-
-
-def _is_supported_gpu(device_type: Any, name: str) -> bool:
-    is_integrated = "integrated" in str(device_type).lower()
-    is_intel = "intel" in name.lower()
-    return is_integrated or is_intel
-
-
-def _gpu_index(ov_device: str) -> int:
-    if ov_device == "GPU":
-        return 0
-    return int(ov_device.split(".", maxsplit=1)[1])
-
-
-def _gpu_memory(core: Any, ov_device: str) -> int | None:
-    try:
-        return int(core.get_property(ov_device, "GPU_DEVICE_TOTAL_MEM_SIZE"))
-    except Exception:
-        return None
+    def _gpu_memory(self, ov_device: str) -> int | None:
+        try:
+            return int(
+                self._core.get_property(ov_device, "GPU_DEVICE_TOTAL_MEM_SIZE")  # pyrefly: ignore[missing-attribute]
+            )
+        except Exception:
+            return None
 
 
 class SystemService:
-    """Service to get system information"""
+    """Reports host system information and resolves compute devices for training and inference.
 
-    def __init__(self) -> None:
+    Exposes process-level CPU/memory usage, available camera devices, and device lookup backed by
+    pluggable `DeviceCatalog` implementations (defaults to PyTorch for training and OpenVINO for
+    inference).
+    """
+
+    def __init__(
+        self, training_catalog: DeviceCatalog | None = None, inference_catalog: DeviceCatalog | None = None
+    ) -> None:
         self.process = psutil.Process()
+        self._training = training_catalog or TrainingDeviceCatalog()
+        self._inference = inference_catalog or OpenVinoInferenceDeviceCatalog()
 
     def get_memory_usage(self) -> tuple[float, float]:
         """
@@ -126,241 +292,148 @@ class SystemService:
         """
         return self.process.cpu_percent(interval=None)
 
-    @staticmethod
-    def get_devices() -> list[DeviceInfo]:
+    def training_devices(self) -> list[DeviceInfo]:
         """
-        Get available compute devices (CPU, GPUs, ...)
+        Get available compute devices for training (CPU, XPU, CUDA).
 
         Returns:
-            list[DeviceInfo]: List of available devices
+            list[DeviceInfo]: List of available training devices.
         """
-        torch = _get_torch()
+        return self._training.devices()
 
-        # CPU is always available
-        devices: list[DeviceInfo] = [DeviceInfo.cpu()]
-
-        # Check for Intel XPU devices
-        if torch.xpu.is_available():
-            for device_idx in range(torch.xpu.device_count()):
-                xpu_dp = torch.xpu.get_device_properties(device_idx)
-                devices.append(
-                    DeviceInfo(
-                        type=DeviceType.XPU,
-                        name=xpu_dp.name,
-                        memory=xpu_dp.total_memory,
-                        index=device_idx,
-                    )
-                )
-
-        # Check for NVIDIA CUDA devices
-        if torch.cuda.is_available():
-            for device_idx in range(torch.cuda.device_count()):
-                cuda_dp = torch.cuda.get_device_properties(device_idx)
-                devices.append(
-                    DeviceInfo(
-                        type=DeviceType.CUDA,
-                        name=cuda_dp.name,
-                        memory=cuda_dp.total_memory,
-                        index=device_idx,
-                    )
-                )
-
-        return devices
-
-    @staticmethod
-    def get_inference_devices() -> list[DeviceInfo]:
+    def inference_devices(self) -> list[DeviceInfo]:
         """
-        Get available compute devices for inference (CPU, integrated GPUs, and Intel discrete GPUs).
-
-        Unlike training (which relies on PyTorch), inference is performed via OpenVINO, so devices are listed using
-        OpenVINO's `core.available_devices` API.
-
-        OpenVINO returns device names such as 'CPU', 'GPU', 'GPU.0', 'GPU.1', ... Per the OpenVINO documentation,
-        when an integrated GPU is present it always takes id 0, and 'GPU' is an alias for 'GPU.0'.
-
-        A GPU is included as an inference device when it is either an integrated GPU (iGPU) or an Intel-branded
-        discrete GPU (dGPU), since only Intel GPUs can perform OpenVINO inference. Non-Intel discrete GPUs are
-        intentionally excluded. The integrated vs. discrete distinction is made using OpenVINO's `DEVICE_TYPE`
-        property, and the brand is determined from the `FULL_DEVICE_NAME` property.
+        Get available compute devices for inference (CPU and Intel GPUs, via OpenVINO).
 
         Returns:
             list[DeviceInfo]: List of available inference devices.
         """
-        openvino_devices = _get_available_devices()
-        if openvino_devices is None:
-            return [DeviceInfo.cpu()]
+        return self._inference.devices()
 
-        core, available_devices = openvino_devices
-        devices = [device for ov_device in available_devices if (device := _device_info(core, ov_device)) is not None]
-
-        if not any(device.type == DeviceType.CPU for device in devices):
-            devices.insert(0, DeviceInfo.cpu())
-
-        return devices
-
-    def get_training_devices(self) -> list[DeviceInfo]:
+    def training_device(self, device_str: str) -> DeviceInfo:
         """
-        Get available compute devices for training (CPUs, XPUs, GPUs, ...)
-
-        Returns:
-            list[DeviceInfo]: List of available training devices
-        """
-        return self.get_devices()  # currently same as get_devices, can be customized later with filters
-
-    def validate_device(self, device_str: str) -> bool:
-        """
-        Validate if a device string is available on the system.
+        Resolve a device string to a `DeviceInfo` for training.
 
         Args:
             device_str: Device string in format '<target>[-<index>]'
-                (e.g., 'auto', 'cpu', 'xpu', 'cuda', 'xpu-2', 'cuda-1')
+                (e.g., 'auto', 'cpu', 'xpu', 'cuda', 'xpu-2', 'cuda-1').
 
         Returns:
-            bool: True if the device is available, False otherwise
+            DeviceInfo: Information about the specified training device.
+
+        Raises:
+            ValueError: If `device_str` is invalid or not available for training.
+        """
+        spec = self._parse(device_str)
+        device = self._training.find(spec)
+        if device is None:
+            raise ValueError(f"Device '{device_str}' is not available for training.")
+        return device
+
+    def inference_device(self, device_str: str) -> DeviceInfo:
+        """
+        Resolve a device string to a `DeviceInfo` for inference.
+
+        Args:
+            device_str: Device string in format '<target>[-<index>]'
+                (e.g., 'auto', 'cpu', 'xpu', 'xpu-2').
+
+        Returns:
+            DeviceInfo: Information about the specified inference device.
+
+        Raises:
+            ValueError: If `device_str` is invalid, is a CUDA device, or is not available
+                for inference.
+        """
+        spec = self._parse(device_str)
+        if spec.is_cuda():
+            raise ValueError(f"Device '{device_str}' is not valid for inference (CUDA devices are not supported).")
+        device = self._inference.find(spec)
+        if device is None:
+            raise ValueError(f"Device '{device_str}' is not available for inference.")
+        return device
+
+    def is_valid_training_device(self, device_str: str) -> bool:
+        """
+        Check whether a device string is available for training.
+
+        Args:
+            device_str: Device string to validate.
+
+        Returns:
+            bool: True if the device is available for training.
+        """
+        return self._is_valid(device_str, self._training)
+
+    def is_valid_inference_device(self, device_str: str) -> bool:
+        """
+        Check whether a device string is available for inference.
+
+        Args:
+            device_str: Device string to validate.
+
+        Returns:
+            bool: True if the device is available for inference.
         """
         try:
-            device_type, device_index = self._parse_device(device_str)
+            spec = self._parse(device_str)
+        except ValueError:
+            return False
+        if spec.is_cuda():
+            return False
+        return self._inference.find(spec) is not None
+
+    @staticmethod
+    def _is_valid(device_str: str, catalog: DeviceCatalog) -> bool:
+        try:
+            spec = DeviceSpec.parse(device_str)
         except ValueError:
             logger.debug("Cannot parse invalid device string: {}", device_str)
             return False
+        return catalog.find(spec) is not None
 
-        # CPU is always available
-        if device_type in [DeviceType.AUTO, DeviceType.CPU]:
-            return True
-
-        # Check if desired device is among available devices
-        available_devices = self.get_devices()
-        for available_device in available_devices:
-            if device_type == available_device.type and device_index == (available_device.index or 0):
-                return True
-
-        return False
-
-    def get_device_info(self, device_str: str) -> DeviceInfo:
-        """
-        Get DeviceInfo for a given device string.
-
-        Args:
-            device_str: Device string in format '<target>[-<index>]'
-                (e.g., 'auto', 'cpu', 'xpu', 'cuda', 'xpu-2', 'cuda-1')
-
-        Returns:
-            DeviceInfo: Information about the specified device
-        """
-        if not self.validate_device(device_str):
-            raise ValueError(f"Device '{device_str}' is not available on the system.")
-
-        device_type, device_index = self._parse_device(device_str)
-        if device_type == DeviceType.CPU:
-            return DeviceInfo.cpu()
-        if device_type == DeviceType.AUTO:
-            return DeviceInfo.auto()
-        return next(
-            device for device in self.get_devices() if device.type == device_type and device.index == device_index
-        )
-
-    def get_inference_device_info(self, device_str: str) -> DeviceInfo:
-        """
-        Get DeviceInfo for a given device string, ensuring it's valid for inference.
-
-        Inference device availability is determined via OpenVINO (see `get_inference_devices`).
-
-        Args:
-            device_str: Device string in format '<target>[-<index>]'
-                (e.g., 'auto', 'cpu', 'xpu', 'xpu-2')
-
-        Returns:
-            DeviceInfo: Information about the specified inference device
-        """
+    @staticmethod
+    def _parse(device_str: str) -> DeviceSpec:
         try:
-            device_type, device_index = self._parse_device(device_str)
+            return DeviceSpec.parse(device_str)
         except ValueError as ex:
-            raise ValueError(f"Device '{device_str}' is not valid for inference.") from ex
+            raise ValueError(f"Invalid device string: {device_str}") from ex
 
-        if device_type == DeviceType.CUDA:
-            raise ValueError(f"Device '{device_str}' is not valid for inference (CUDA devices are not supported).")
-        if device_type == DeviceType.AUTO:
-            return DeviceInfo.auto()
-        if device_type == DeviceType.CPU:
-            return DeviceInfo.cpu()
-
-        for available_device in self.get_inference_devices():
-            if device_type == available_device.type and device_index == (available_device.index or 0):
-                return available_device
-
-        raise ValueError(f"Device '{device_str}' is not available for inference on the system.")
-
-    def get_training_device_info(self, device_str: str) -> DeviceInfo:
-        """
-        Get DeviceInfo for a given device string, ensuring it's valid for training.
-
-        Args:
-            device_str: Device string in format '<target>[-<index>]'
-                (e.g., 'auto', 'cpu', 'xpu', 'cuda', 'xpu-2', 'cuda-1')
-
-        Returns:
-            DeviceInfo: Information about the specified training device
-        """
-        # For training, all devices are currently valid, but we can add custom validation here if needed in the future
-        return self.get_device_info(device_str)
-
-    @staticmethod
-    def _parse_device(device_str: str) -> tuple[DeviceType, int]:
-        """
-        Parse device string into type and index
-
-        Args:
-            device_str: Device string in format '<target>[-<index>]'
-                (e.g., 'auto', 'cpu', 'xpu', 'cuda', 'xpu-2', 'cuda-1')
-
-        Returns:
-            tuple[str, int]: Device type and index
-        """
-        m = DEVICE_PATTERN.match(device_str.lower())
-        if not m:
-            raise ValueError(f"Invalid device string: {device_str}")
-
-        device_type, _, device_index = m.groups()
-        device_index = int(device_index) if device_index is not None else 0
-        return DeviceType(device_type.lower()), device_index
-
-    @staticmethod
-    def supports_int8(device_info: DeviceInfo) -> bool:
+    def supports_int8(self, device: DeviceInfo) -> bool:
         """
         Check if the given device supports INT8 inference using OpenVINO.
 
-        For CPU devices, INT8 is always supported.
-        For GPU devices, the check is done via OpenVINO's OPTIMIZATION_CAPABILITIES property.
+        For CPU devices, INT8 is always supported. For GPU devices, the check is done via
+        OpenVINO's `OPTIMIZATION_CAPABILITIES` property.
 
         Args:
-            device_info: The device to check.
+            device: The device to check.
 
         Returns:
             bool: True if the device supports INT8 inference, False otherwise.
         """
-        if device_info.type == DeviceType.CPU:
+        if device.type == DeviceType.CPU:
             return True
-        if device_info.type == DeviceType.CUDA:
+        if device.type == DeviceType.CUDA:
             return False
         try:
             from model_api.adapters import create_core
 
             core = create_core()
-            ov_device = device_info.as_openvino
-            capabilities = core.get_property(device_name=ov_device, property="OPTIMIZATION_CAPABILITIES")
+            capabilities = core.get_property(device_name=device.as_openvino, property="OPTIMIZATION_CAPABILITIES")
             return "INT8" in capabilities
         except Exception:
             logger.exception(
                 "Failed to query INT8 support for device '{}' (OpenVINO device '{}'). Assuming not supported.",
-                device_info,
-                device_info.as_openvino,
+                device,
+                device.as_openvino,
             )
             return False
 
     @staticmethod
-    def get_camera_devices() -> list[CameraInfo]:
+    def list_cameras() -> list[CameraInfo]:
         """
-        Get available camera devices.
+        List available camera devices.
         Camera names are formatted as "<camera_name> [<index>]".
 
         Returns:

--- a/application/backend/app/services/system_service.py
+++ b/application/backend/app/services/system_service.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 import platform
-import re
 from typing import Any, Protocol
 
 import cv2
@@ -9,6 +8,7 @@ import psutil
 from cv2_enumerate_cameras import enumerate_cameras
 from loguru import logger
 
+from app.models import DeviceSpec
 from app.models.system import CameraInfo, DeviceInfo, DeviceType
 
 DEFAULT_DEVICE = "cpu"
@@ -17,80 +17,6 @@ CV2_BACKENDS = {
     "Linux": cv2.CAP_V4L2,
     "Darwin": cv2.CAP_AVFOUNDATION,
 }
-
-
-class DeviceSpec:
-    """A parsed device request, e.g. 'xpu-1', that knows how to match a `DeviceInfo`."""
-
-    _PATTERN = re.compile(r"^(auto|cpu|xpu|cuda)(-(\d+))?$")
-
-    def __init__(self, device_type: DeviceType, index: int) -> None:
-        self._type = device_type
-        self._index = index
-
-    @classmethod
-    def parse(cls, device_str: str) -> "DeviceSpec":
-        """
-        Parse a device string into a `DeviceSpec`.
-
-        Args:
-            device_str: Device string in format '<target>[-<index>]'
-                (e.g., 'auto', 'cpu', 'xpu', 'cuda', 'xpu-2', 'cuda-1').
-
-        Returns:
-            DeviceSpec: The parsed device specification.
-
-        Raises:
-            ValueError: If `device_str` does not match the expected format.
-        """
-        match = cls._PATTERN.match(device_str.lower())
-        if not match:
-            raise ValueError(f"Invalid device string: {device_str}")
-        kind, _, index = match.groups()
-        return cls(DeviceType(kind), int(index) if index is not None else 0)
-
-    @property
-    def type(self) -> DeviceType:
-        """The requested device type."""
-        return self._type
-
-    def is_cpu(self) -> bool:
-        """Whether this spec refers to the CPU."""
-        return self._type == DeviceType.CPU
-
-    def is_auto(self) -> bool:
-        """Whether this spec refers to automatic device selection."""
-        return self._type == DeviceType.AUTO
-
-    def is_cuda(self) -> bool:
-        """Whether this spec refers to a CUDA device."""
-        return self._type == DeviceType.CUDA
-
-    def matches(self, device: DeviceInfo) -> bool:
-        """
-        Check whether a `DeviceInfo` satisfies this spec.
-
-        Args:
-            device: The candidate device.
-
-        Returns:
-            bool: True if `device` has the same type and index as this spec.
-        """
-        return self._type == device.type and self._index == (device.index or 0)
-
-    def __str__(self) -> str:
-        return f"{self._type.value}-{self._index}"
-
-    def fixed_device(self) -> DeviceInfo | None:
-        """Resolve this spec to a fixed `DeviceInfo` without consulting a device catalog.
-
-        `AUTO` and `CPU` are always available and never need to be looked up among the
-        devices a catalog actually discovers (e.g. via PyTorch or OpenVINO)."""
-        if self.is_cpu():
-            return DeviceInfo.cpu()
-        if self.is_auto():
-            return DeviceInfo.auto()
-        return None
 
 
 class DeviceCatalog(Protocol):

--- a/application/backend/app/services/system_service.py
+++ b/application/backend/app/services/system_service.py
@@ -98,17 +98,25 @@ class OpenVinoInferenceDeviceCatalog:
     """
 
     def __init__(self) -> None:
-        self._core = self._try_create_core()
+        self._core: Any | None = None
+        self._core_init_failed = False
 
-    @staticmethod
-    def _try_create_core() -> Any | None:
+    def _get_core(self) -> Any | None:
+        if self._core is not None:
+            return self._core
+        if self._core_init_failed:
+            return None
         try:
             import openvino as ov
 
-            return ov.Core()
+            self._core = ov.Core()
+        except ImportError:
+            logger.warning("OpenVINO is not installed; falling back to CPU-only inference devices.")
+            self._core_init_failed = True
         except Exception:
             logger.exception("Failed to query OpenVINO inference devices; falling back to CPU only.")
-            return None
+            self._core_init_failed = True
+        return self._core
 
     def devices(self) -> list[DeviceInfo]:
         """
@@ -117,10 +125,15 @@ class OpenVinoInferenceDeviceCatalog:
         Returns:
             list[DeviceInfo]: CPU plus any detected integrated/Intel discrete GPUs.
         """
-        if self._core is None:
+        core = self._get_core()
+        if core is None:
             return [DeviceInfo.cpu()]
 
-        found = [d for name in self._core.available_devices if (d := self._device_info(name)) is not None]
+        found = [
+            d
+            for name in self._core.available_devices  # pyrefly: ignore[missing-attribute]
+            if (d := self._device_info(name)) is not None
+        ]
         if not any(device.type == DeviceType.CPU for device in found):
             found.insert(0, DeviceInfo.cpu())
         return found
@@ -256,26 +269,49 @@ class SystemService:
             raise ValueError(f"Device '{device_str}' is not available for training.")
         return device
 
-    def inference_device(self, device_str: str) -> DeviceInfo:
+    def inference_device(self, device_str: str, fallback_to_cpu: bool = False) -> DeviceInfo:
         """
         Resolve a device string to a `DeviceInfo` for inference.
 
         Args:
             device_str: Device string in format '<target>[-<index>]'
                 (e.g., 'auto', 'cpu', 'xpu', 'xpu-2').
+            fallback_to_cpu: If True, return the CPU device (with a warning logged) instead of
+                raising when `device_str` is malformed, is a CUDA device, or is not currently
+                available for inference.
 
         Returns:
-            DeviceInfo: Information about the specified inference device.
+            DeviceInfo: Information about the specified inference device, or CPU if
+                `fallback_to_cpu` is True and the requested device can't be resolved
 
         Raises:
-            ValueError: If `device_str` is invalid, is a CUDA device, or is not available
-                for inference.
+            ValueError: If `device_str` is invalid, or if it is a CUDA device or not available
+                for inference and `fallback_to_cpu` is False.
         """
-        spec = self._parse(device_str)
+        try:
+            spec = self._parse(device_str)
+        except ValueError:
+            if fallback_to_cpu:
+                logger.warning("Configured inference device '{}' is invalid; falling back to CPU.", device_str)
+                return DeviceInfo.cpu()
+            raise
+
         if spec.is_cuda():
+            if fallback_to_cpu:
+                logger.warning(
+                    "Configured inference device '{}' is a CUDA device, which is not supported for inference; "
+                    "falling back to CPU.",
+                    device_str,
+                )
+                return DeviceInfo.cpu()
             raise ValueError(f"Device '{device_str}' is not valid for inference (CUDA devices are not supported).")
         device = self._inference.find(spec)
         if device is None:
+            if fallback_to_cpu:
+                logger.warning(
+                    "Configured inference device '{}' is not currently available; falling back to CPU.", device_str
+                )
+                return DeviceInfo.cpu()
             raise ValueError(f"Device '{device_str}' is not available for inference.")
         return device
 

--- a/application/backend/app/workers/inference.py
+++ b/application/backend/app/workers/inference.py
@@ -16,7 +16,7 @@ from loguru import logger
 from loguru._logger import Logger as LoguruLogger
 
 from app.models.inference import InferenceWorkerStatus, InferenceWorkerStatusCode
-from app.services import ActiveModelService, MetricsService
+from app.services import ActiveModelService, MetricsService, SystemService
 from app.services.inference.model_loader import LoadedModelHandle
 from app.settings import Settings, get_settings
 from app.stream.stream_data import InferenceData, StreamData
@@ -120,7 +120,8 @@ class InferenceWorker(BaseProcessWorker):
         super().setup()
         self._inference_status_shm = SharedMemory(name=self._inference_status_shm_name, create=False)
         self._metrics_service = MetricsService(self._shm_name, self._shm_lock)
-        self._model_service = ActiveModelService(get_settings().data_dir)
+        system_service = SystemService()
+        self._model_service = ActiveModelService(get_settings().data_dir, system_service)
         self.__prediction_buffer = PredictionReorderBuffer()
 
     @property

--- a/application/backend/tests/integration/services/test_active_model_service.py
+++ b/application/backend/tests/integration/services/test_active_model_service.py
@@ -9,7 +9,7 @@ import pytest
 
 from app.db.schema import ModelRevisionDB, ModelVariantDB, PipelineDB, ProjectDB
 from app.models.model_revision import ModelFormat, ModelPrecision, TrainingStatus
-from app.services.active_model_service import ActiveModelService
+from app.services import ActiveModelService, SystemService
 from tests.integration.project_factory import ProjectTestDataFactory
 
 
@@ -88,7 +88,7 @@ class TestActiveModelServiceLoadState:
     def test_load_state_no_active_pipeline_returns_empty_state(self, db_session, tmp_path):
         """When no pipeline is running, load_state returns an empty ModelActivationState."""
         with _make_db_session_patcher(db_session):
-            service = ActiveModelService(data_dir=tmp_path)
+            service = ActiveModelService(data_dir=tmp_path, system_service=SystemService())
 
         state = service._model_activation_state
 
@@ -133,7 +133,7 @@ class TestActiveModelServiceLoadState:
         db_session.flush()
 
         with _make_db_session_patcher(db_session):
-            service = ActiveModelService(data_dir=tmp_path)
+            service = ActiveModelService(data_dir=tmp_path, system_service=SystemService())
 
         state = service._model_activation_state
 

--- a/application/backend/tests/integration/services/test_active_model_service.py
+++ b/application/backend/tests/integration/services/test_active_model_service.py
@@ -132,11 +132,19 @@ class TestActiveModelServiceLoadState:
         db_session.add(pipeline)
         db_session.flush()
 
-        with _make_db_session_patcher(db_session):
-            service = ActiveModelService(data_dir=tmp_path, system_service=SystemService())
+        system_service = SystemService()
+
+        with (
+            _make_db_session_patcher(db_session),
+            patch.object(
+                system_service, "inference_device", wraps=system_service.inference_device
+            ) as mock_inference_device,
+        ):
+            service = ActiveModelService(data_dir=tmp_path, system_service=system_service)
+
+        mock_inference_device.assert_called_once_with("cpu", fallback_to_cpu=True)
 
         state = service._model_activation_state
-
         assert len(state.available_models) == 2
         assert set(state.available_models) == {UUID(fxt_successful_model.id), UUID(second_successful.id)}
         assert str(state.active_model_id) == fxt_successful_model.id

--- a/application/backend/tests/unit/api/routers/test_system.py
+++ b/application/backend/tests/unit/api/routers/test_system.py
@@ -22,7 +22,7 @@ def fxt_system_service(fxt_app) -> Mock:
 class TestSystemEndpoints:
     def test_get_training_devices_with_all_devices(self, fxt_system_service: Mock, fxt_client: TestClient):
         """Test GET /api/system/devices/training with all device types"""
-        fxt_system_service.get_training_devices.return_value = [
+        fxt_system_service.training_devices.return_value = [
             DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None),
             DeviceInfo(type=DeviceType.XPU, name="Intel(R) Graphics [0x7d41]", memory=36022263808, index=0),
             DeviceInfo(type=DeviceType.CUDA, name="NVIDIA GeForce RTX 4090", memory=25769803776, index=0),
@@ -45,7 +45,7 @@ class TestSystemEndpoints:
 
     def test_get_inference_devices_with_xpu(self, fxt_system_service: Mock, fxt_client: TestClient):
         """Test GET /api/system/devices/inference with Intel XPU"""
-        fxt_system_service.get_inference_devices.return_value = [
+        fxt_system_service.inference_devices.return_value = [
             DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None),
             DeviceInfo(type=DeviceType.XPU, name="Intel(R) Graphics [0x7d41]", memory=36022263808, index=0),
         ]
@@ -63,7 +63,7 @@ class TestSystemEndpoints:
 
     def test_get_camera_devices(self, fxt_system_service: Mock, fxt_client: TestClient):
         """Test GET /api/system/devices/camera"""
-        fxt_system_service.get_camera_devices.return_value = [
+        fxt_system_service.list_cameras.return_value = [
             {"index": 0, "name": "Integrated USB Camera"},
             {"index": 1, "name": "USB Camera"},
         ]

--- a/application/backend/tests/unit/models/test_device_spec.py
+++ b/application/backend/tests/unit/models/test_device_spec.py
@@ -1,0 +1,94 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from app.models import DeviceSpec
+from app.models.system import DeviceInfo, DeviceType
+
+
+class TestDeviceSpec:
+    """Test cases for DeviceSpec"""
+
+    @pytest.mark.parametrize(
+        "device_str, expected_type, expected_index",
+        [
+            ("auto", DeviceType.AUTO, 0),
+            ("cpu", DeviceType.CPU, 0),
+            ("xpu", DeviceType.XPU, 0),
+            ("cuda", DeviceType.CUDA, 0),
+            ("xpu-0", DeviceType.XPU, 0),
+            ("xpu-2", DeviceType.XPU, 2),
+            ("cuda-1", DeviceType.CUDA, 1),
+            ("XPU-1", DeviceType.XPU, 1),  # case-insensitive
+        ],
+    )
+    def test_parse_valid(self, device_str, expected_type, expected_index):
+        """Test parsing valid device strings"""
+        spec = DeviceSpec.parse(device_str)
+
+        assert spec.type == expected_type
+        assert str(spec) == f"{expected_type.value}-{expected_index}"
+
+    @pytest.mark.parametrize(
+        "device_str",
+        [
+            "auto-0",  # auto must not have an index
+            "cpu-0",  # cpu must not have an index
+            "cpu-cpu",
+            "cpu--1",
+            "cpu-",
+            "cpu-0.9",
+            "1",
+            "-1",
+            "gpu",
+            "tpu",
+            "invalid",
+            "",
+        ],
+    )
+    def test_parse_invalid(self, device_str):
+        """Test parsing invalid device strings raises ValueError"""
+        with pytest.raises(ValueError):
+            DeviceSpec.parse(device_str)
+
+    def test_is_cpu(self):
+        assert DeviceSpec.parse("cpu").is_cpu() is True
+        assert DeviceSpec.parse("xpu").is_cpu() is False
+
+    def test_is_auto(self):
+        assert DeviceSpec.parse("auto").is_auto() is True
+        assert DeviceSpec.parse("cpu").is_auto() is False
+
+    def test_is_cuda(self):
+        assert DeviceSpec.parse("cuda").is_cuda() is True
+        assert DeviceSpec.parse("cuda-1").is_cuda() is True
+        assert DeviceSpec.parse("xpu").is_cuda() is False
+
+    def test_fixed_device_cpu(self):
+        assert DeviceSpec.parse("cpu").fixed_device() == DeviceInfo.cpu()
+
+    def test_fixed_device_auto(self):
+        assert DeviceSpec.parse("auto").fixed_device() == DeviceInfo.auto()
+
+    @pytest.mark.parametrize("device_str", ["xpu", "xpu-1", "cuda", "cuda-2"])
+    def test_fixed_device_none_for_catalog_devices(self, device_str):
+        """XPU/CUDA specs cannot be resolved without consulting a catalog"""
+        assert DeviceSpec.parse(device_str).fixed_device() is None
+
+    @pytest.mark.parametrize(
+        "device_str, device, expected",
+        [
+            ("xpu-0", DeviceInfo(type=DeviceType.XPU, name="Intel GPU", memory=1024, index=0), True),
+            ("xpu-1", DeviceInfo(type=DeviceType.XPU, name="Intel GPU", memory=1024, index=0), False),
+            ("xpu", DeviceInfo(type=DeviceType.XPU, name="Intel GPU", memory=1024, index=0), True),  # default index 0
+            ("cuda-0", DeviceInfo(type=DeviceType.XPU, name="Intel GPU", memory=1024, index=0), False),  # type mismatch
+            ("cpu", DeviceInfo(type=DeviceType.CPU, name="CPU", memory=None, index=None), True),
+        ],
+    )
+    def test_matches(self, device_str, device, expected):
+        assert DeviceSpec.parse(device_str).matches(device) is expected
+
+    def test_str(self):
+        assert str(DeviceSpec.parse("xpu-2")) == "xpu-2"
+        assert str(DeviceSpec.parse("cpu")) == "cpu-0"

--- a/application/backend/tests/unit/models/test_device_spec.py
+++ b/application/backend/tests/unit/models/test_device_spec.py
@@ -28,7 +28,10 @@ class TestDeviceSpec:
         spec = DeviceSpec.parse(device_str)
 
         assert spec.type == expected_type
-        assert str(spec) == f"{expected_type.value}-{expected_index}"
+        if spec.is_auto() or spec.is_cpu():
+            assert str(spec) == f"{expected_type.value}"
+        else:
+            assert str(spec) == f"{expected_type.value}-{expected_index}"
 
     @pytest.mark.parametrize(
         "device_str",
@@ -91,4 +94,5 @@ class TestDeviceSpec:
 
     def test_str(self):
         assert str(DeviceSpec.parse("xpu-2")) == "xpu-2"
-        assert str(DeviceSpec.parse("cpu")) == "cpu-0"
+        assert str(DeviceSpec.parse("cpu")) == "cpu"
+        assert str(DeviceSpec.parse("auto")) == "auto"

--- a/application/backend/tests/unit/services/test_active_model_service.py
+++ b/application/backend/tests/unit/services/test_active_model_service.py
@@ -40,7 +40,7 @@ def fxt_active_model_service(fxt_model_activation_state) -> Iterator[ActiveModel
         tempfile.TemporaryDirectory() as tmpdir,
         patch.object(ActiveModelService, "_load_state", return_value=fxt_model_activation_state),
     ):
-        yield ActiveModelService(data_dir=Path(tmpdir))
+        yield ActiveModelService(data_dir=Path(tmpdir), system_service=Mock())
 
 
 class TestActiveModelServiceUnit:

--- a/application/backend/tests/unit/services/test_system_service.py
+++ b/application/backend/tests/unit/services/test_system_service.py
@@ -271,6 +271,12 @@ class TestSystemService:
         with pytest.raises(ValueError):
             _ = fxt_system_service.inference_device("gpu")
 
+    def test_inference_device_fallback_to_cpu(self, fxt_system_service: SystemService) -> None:
+        """Malformed, CUDA, and unavailable inference devices fall back to CPU when fallback_to_cpu=True."""
+        assert fxt_system_service.inference_device("not-a-device!!", fallback_to_cpu=True) == DeviceInfo.cpu()
+        assert fxt_system_service.inference_device("cuda", fallback_to_cpu=True) == DeviceInfo.cpu()
+        assert fxt_system_service.inference_device("xpu-2", fallback_to_cpu=True) == DeviceInfo.cpu()
+
     def test_list_cameras(self, fxt_system_service: SystemService):
         """Test listing camera devices"""
         with patch("app.services.system_service.enumerate_cameras") as mock_enumerate_cameras:

--- a/application/backend/tests/unit/services/test_system_service.py
+++ b/application/backend/tests/unit/services/test_system_service.py
@@ -5,7 +5,25 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.services.system_service import SystemService
+from app.models.system import DeviceInfo, DeviceType
+from app.services.system_service import DeviceSpec, SystemService
+
+
+class FakeDeviceCatalog:
+    """Test double for `DeviceCatalog` — no torch/openvino involved."""
+
+    def __init__(self, devices: list[DeviceInfo]) -> None:
+        self._devices = devices
+
+    def devices(self) -> list[DeviceInfo]:
+        return self._devices
+
+    def find(self, spec: DeviceSpec) -> DeviceInfo | None:
+        if spec.is_cpu():
+            return DeviceInfo.cpu()
+        if spec.is_auto():
+            return DeviceInfo.auto()
+        return next((device for device in self._devices if spec.matches(device)), None)
 
 
 class TestSystemService:
@@ -29,151 +47,100 @@ class TestSystemService:
 
         assert cpu_usage >= 0.0
 
-    def test_get_devices_cpu_only(self, fxt_system_service: SystemService):
+    def test_training_devices_cpu_only(self):
         """Test getting devices when only CPU is available"""
-        with patch("app.services.system_service.torch") as mock_torch:
-            # Simulate torch not being available
-            mock_torch.xpu.is_available.return_value = False
-            mock_torch.cuda.is_available.return_value = False
+        service = SystemService(training_catalog=FakeDeviceCatalog([DeviceInfo.cpu()]))
 
-            devices = fxt_system_service.get_devices()
+        devices = service.training_devices()
 
-            assert len(devices) == 1
-            assert devices[0].name == "CPU"
-            assert devices[0].memory is None
-            assert devices[0].index is None
+        assert len(devices) == 1
+        assert devices[0].name == "CPU"
+        assert devices[0].memory is None
+        assert devices[0].index is None
 
-    def test_get_devices_with_xpu(self, fxt_system_service: SystemService):
+    def test_training_devices_with_xpu(self, fxt_system_service: SystemService):
         """Test getting devices when Intel XPU is available"""
-        with patch("app.services.system_service.torch") as mock_torch:
-            # Mock XPU device
-            mock_dp = MagicMock()
-            mock_dp.name = "Intel(R) Graphics [0x7d41]"
-            mock_dp.total_memory = 36022263808
+        xpu_device = DeviceInfo(type=DeviceType.XPU, name="Intel(R) Graphics [0x7d41]", memory=36022263808, index=0)
+        service = SystemService(training_catalog=FakeDeviceCatalog([DeviceInfo.cpu(), xpu_device]))
 
-            mock_torch.xpu.is_available.return_value = True
-            mock_torch.xpu.device_count.return_value = 1
-            mock_torch.xpu.get_device_properties.return_value = mock_dp
+        devices = service.training_devices()
 
-            # CUDA not available
-            mock_torch.cuda.is_available.return_value = False
+        assert len(devices) == 2
+        assert devices[1].name == "Intel(R) Graphics [0x7d41]"
+        assert devices[1].memory == 36022263808
+        assert devices[1].index == 0
 
-            devices = fxt_system_service.get_devices()
-
-            assert len(devices) == 2
-            assert devices[1].name == "Intel(R) Graphics [0x7d41]"
-            assert devices[1].memory == 36022263808
-            assert devices[1].index == 0
-
-    def test_get_devices_with_cuda(self, fxt_system_service: SystemService):
+    def test_training_devices_with_cuda(self, fxt_system_service: SystemService):
         """Test getting devices when NVIDIA CUDA is available"""
-        with patch("app.services.system_service.torch") as mock_torch:
-            # XPU not available
-            mock_torch.xpu.is_available.return_value = False
+        cuda_device = DeviceInfo(type=DeviceType.CUDA, name="NVIDIA GeForce RTX 4090", memory=25769803776, index=0)
+        service = SystemService(training_catalog=FakeDeviceCatalog([DeviceInfo.cpu(), cuda_device]))
 
-            # Mock CUDA device
-            mock_dp = MagicMock()
-            mock_dp.name = "NVIDIA GeForce RTX 4090"
-            mock_dp.total_memory = 25769803776
+        devices = service.training_devices()
 
-            mock_torch.cuda.is_available.return_value = True
-            mock_torch.cuda.device_count.return_value = 1
-            mock_torch.cuda.get_device_properties.return_value = mock_dp
+        assert len(devices) == 2
+        assert devices[1].name == "NVIDIA GeForce RTX 4090"
+        assert devices[1].memory == 25769803776
+        assert devices[1].index == 0
 
-            devices = fxt_system_service.get_devices()
-
-            assert len(devices) == 2
-            assert devices[1].name == "NVIDIA GeForce RTX 4090"
-            assert devices[1].memory == 25769803776
-            assert devices[1].index == 0
-
-    def test_get_devices_with_multiple_devices(self, fxt_system_service: SystemService):
+    def test_training_devices_with_multiple_devices(self, fxt_system_service: SystemService):
         """Test getting devices when multiple GPUs are available"""
-        with patch("app.services.system_service.torch") as mock_torch:
-            # Mock XPU device
-            mock_xpu_dp = MagicMock()
-            mock_xpu_dp.name = "Intel(R) Graphics [0x7d41]"
-            mock_xpu_dp.total_memory = 36022263808
+        xpu_device = DeviceInfo(type=DeviceType.XPU, name="Intel(R) Graphics [0x7d41]", memory=36022263808, index=0)
+        cuda_device = DeviceInfo(type=DeviceType.CUDA, name="NVIDIA GeForce RTX 4090", memory=25769803776, index=0)
+        service = SystemService(training_catalog=FakeDeviceCatalog([DeviceInfo.cpu(), xpu_device, cuda_device]))
 
-            mock_torch.xpu.is_available.return_value = True
-            mock_torch.xpu.device_count.return_value = 1
-            mock_torch.xpu.get_device_properties.return_value = mock_xpu_dp
+        devices = service.training_devices()
 
-            # Mock CUDA device
-            mock_cuda_dp = MagicMock()
-            mock_cuda_dp.name = "NVIDIA GeForce RTX 4090"
-            mock_cuda_dp.total_memory = 25769803776
+        assert len(devices) == 3
 
-            mock_torch.cuda.is_available.return_value = True
-            mock_torch.cuda.device_count.return_value = 1
-            mock_torch.cuda.get_device_properties.return_value = mock_cuda_dp
-
-            devices = fxt_system_service.get_devices()
-
-            assert len(devices) == 3
-
-    def test_validate_device_auto_always_valid(self, fxt_system_service: SystemService):
+    def test_is_valid_inference_device_auto_always_valid(self, fxt_system_service: SystemService):
         """Test that AUTO device is always valid"""
-        assert fxt_system_service.validate_device("auto") is True
+        assert fxt_system_service.is_valid_inference_device("auto") is True
 
-    def test_validate_device_cpu_always_valid(self, fxt_system_service: SystemService):
+    def test_is_valid_inference_device_cpu_always_valid(self, fxt_system_service: SystemService):
         """Test that CPU device is always valid"""
-        assert fxt_system_service.validate_device("cpu") is True
+        assert fxt_system_service.is_valid_inference_device("cpu") is True
 
-    def test_validate_device_xpu_available(self, fxt_system_service: SystemService):
+    def test_is_valid_inference_device_xpu_available(self, fxt_system_service: SystemService):
         """Test validating XPU device when available"""
-        mock_xpu_dp = MagicMock()
-        mock_xpu_dp.name = "Intel XPU"
-        mock_xpu_dp.total_memory = 36022263808
+        xpu_devices = [
+            DeviceInfo(type=DeviceType.XPU, name="Intel XPU", memory=36022263808, index=0),
+            DeviceInfo(type=DeviceType.XPU, name="Intel XPU", memory=36022263808, index=1),
+        ]
+        service = SystemService(inference_catalog=FakeDeviceCatalog(xpu_devices))
 
-        with patch("app.services.system_service.torch") as mock_torch:
-            mock_torch.xpu.is_available.return_value = True
-            mock_torch.cuda.is_available.return_value = False
-            mock_torch.xpu.device_count.return_value = 2
-            mock_torch.xpu.get_device_properties.return_value = mock_xpu_dp
+        assert service.is_valid_inference_device("xpu") is True
+        assert service.is_valid_inference_device("xpu-0") is True
+        assert service.is_valid_inference_device("xpu-1") is True
+        assert service.is_valid_inference_device("xpu-2") is False
 
-            assert fxt_system_service.validate_device("xpu") is True
-            assert fxt_system_service.validate_device("xpu-0") is True
-            assert fxt_system_service.validate_device("xpu-1") is True
-            assert fxt_system_service.validate_device("xpu-2") is False
-
-    def test_validate_device_xpu_not_available(self, fxt_system_service: SystemService):
+    def test_is_valid_inference_device_xpu_not_available(self, fxt_system_service: SystemService):
         """Test validating XPU device when not available"""
-        with patch("app.services.system_service.torch") as mock_torch:
-            mock_torch.xpu.is_available.return_value = False
-            mock_torch.cuda.is_available.return_value = False
+        service = SystemService(inference_catalog=FakeDeviceCatalog([]))
 
-            assert fxt_system_service.validate_device("xpu") is False
-            assert fxt_system_service.validate_device("xpu-0") is False
+        assert service.is_valid_inference_device("xpu") is False
+        assert service.is_valid_inference_device("xpu-0") is False
 
-    def test_validate_device_cuda_available(self, fxt_system_service: SystemService):
+    def test_is_valid_training_device_cuda_available(self, fxt_system_service: SystemService):
         """Test validating CUDA device when available"""
-        mock_cuda_dp = MagicMock()
-        mock_cuda_dp.name = "NVIDIA GPU"
-        mock_cuda_dp.total_memory = 25769803776
+        cuda_devices = [
+            DeviceInfo(type=DeviceType.CUDA, name="NVIDIA GPU", memory=25769803776, index=index) for index in range(3)
+        ]
+        service = SystemService(training_catalog=FakeDeviceCatalog(cuda_devices))
 
-        with patch("app.services.system_service.torch") as mock_torch:
-            mock_torch.xpu.is_available.return_value = False
-            mock_torch.cuda.is_available.return_value = True
-            mock_torch.cuda.device_count.return_value = 3
-            mock_torch.cuda.get_device_properties.return_value = mock_cuda_dp
+        assert service.is_valid_training_device("cuda") is True
+        assert service.is_valid_training_device("cuda-0") is True
+        assert service.is_valid_training_device("cuda-1") is True
+        assert service.is_valid_training_device("cuda-2") is True
+        assert service.is_valid_training_device("cuda-3") is False
 
-            assert fxt_system_service.validate_device("cuda") is True
-            assert fxt_system_service.validate_device("cuda-0") is True
-            assert fxt_system_service.validate_device("cuda-1") is True
-            assert fxt_system_service.validate_device("cuda-2") is True
-            assert fxt_system_service.validate_device("cuda-3") is False
-
-    def test_validate_device_cuda_not_available(self, fxt_system_service: SystemService):
+    def test_is_valid_training_device_cuda_not_available(self, fxt_system_service: SystemService):
         """Test validating CUDA device when not available"""
-        with patch("app.services.system_service.torch") as mock_torch:
-            mock_torch.xpu.is_available.return_value = False
-            mock_torch.cuda.is_available.return_value = False
+        service = SystemService(training_catalog=FakeDeviceCatalog([]))
 
-            assert fxt_system_service.validate_device("cuda") is False
-            assert fxt_system_service.validate_device("cuda-0") is False
+        assert service.is_valid_training_device("cuda") is False
+        assert service.is_valid_training_device("cuda-0") is False
 
-    def test_get_inference_devices_with_multiple_devices(self, fxt_system_service: SystemService):
+    def test_inference_devices_with_multiple_devices(self, fxt_system_service: SystemService):
         """Test getting inference devices via OpenVINO: CPU, integrated GPUs, and Intel discrete GPUs are returned"""
 
         def fake_get_property(device: str, prop: str):
@@ -199,7 +166,7 @@ class TestSystemService:
         mock_core.get_property.side_effect = fake_get_property
 
         with patch("openvino.Core", return_value=mock_core):
-            inference_devices = fxt_system_service.get_inference_devices()
+            inference_devices = SystemService().inference_devices()
 
         # The non-Intel discrete GPU (GPU.2) must be filtered out, leaving CPU, the integrated GPU,
         # and the Intel discrete GPU.
@@ -218,70 +185,62 @@ class TestSystemService:
         assert inference_devices[2].memory == 17179869184
         assert inference_devices[2].index == 1
 
-    def test_get_inference_devices_cpu_only(self, fxt_system_service: SystemService):
+    def test_inference_devices_cpu_only(self, fxt_system_service: SystemService):
         """Test getting inference devices when only CPU is available via OpenVINO"""
         mock_core = MagicMock()
         mock_core.available_devices = ["CPU"]
 
         with patch("openvino.Core", return_value=mock_core):
-            inference_devices = fxt_system_service.get_inference_devices()
+            inference_devices = fxt_system_service.inference_devices()
 
         assert len(inference_devices) == 1
         assert inference_devices[0].type == "cpu"
 
-    def test_get_inference_devices_fallback_on_error(self, fxt_system_service: SystemService):
+    def test_inference_devices_fallback_on_error(self, fxt_system_service: SystemService):
         """Test fallback to CPU-only when OpenVINO query fails"""
         with patch("openvino.Core", side_effect=RuntimeError("boom")):
-            inference_devices = fxt_system_service.get_inference_devices()
+            inference_devices = fxt_system_service.inference_devices()
 
         assert len(inference_devices) == 1
         assert inference_devices[0].type == "cpu"
 
-    def test_validate_device_invalid_type(self, fxt_system_service: SystemService):
+    def test_is_valid_inference_device_invalid_type(self, fxt_system_service: SystemService):
         """Test validating invalid device types"""
-        assert fxt_system_service.validate_device("cpu-cpu") is False
-        assert fxt_system_service.validate_device("cpu--1") is False
-        assert fxt_system_service.validate_device("cpu-") is False
-        assert fxt_system_service.validate_device("cpu-0.9") is False
-        assert fxt_system_service.validate_device("1") is False
-        assert fxt_system_service.validate_device("-1") is False
-        assert fxt_system_service.validate_device("gpu") is False
-        assert fxt_system_service.validate_device("tpu") is False
-        assert fxt_system_service.validate_device("invalid") is False
+        assert fxt_system_service.is_valid_inference_device("cpu-cpu") is False
+        assert fxt_system_service.is_valid_inference_device("cpu--1") is False
+        assert fxt_system_service.is_valid_inference_device("cpu-") is False
+        assert fxt_system_service.is_valid_inference_device("cpu-0.9") is False
+        assert fxt_system_service.is_valid_inference_device("1") is False
+        assert fxt_system_service.is_valid_inference_device("-1") is False
+        assert fxt_system_service.is_valid_inference_device("gpu") is False
+        assert fxt_system_service.is_valid_inference_device("tpu") is False
+        assert fxt_system_service.is_valid_inference_device("invalid") is False
 
-    def test_get_device_info(self, fxt_system_service: SystemService):
-        """Test getting device info"""
-        with patch("app.services.system_service.torch") as mock_torch:
-            # Mock XPU device
-            mock_xpu_dp = MagicMock()
-            mock_xpu_dp.name = "Intel(R) Graphics [0x7d41]"
-            mock_xpu_dp.total_memory = 36022263808
+    def test_training_device_info(self, fxt_system_service: SystemService):
+        """Test getting training device info"""
+        xpu_device = DeviceInfo(type=DeviceType.XPU, name="Intel(R) Graphics [0x7d41]", memory=36022263808, index=0)
+        service = SystemService(training_catalog=FakeDeviceCatalog([DeviceInfo.cpu(), xpu_device]))
 
-            mock_torch.xpu.is_available.return_value = True
-            mock_torch.xpu.device_count.return_value = 1
-            mock_torch.xpu.get_device_properties.return_value = mock_xpu_dp
+        device_info = service.training_device("cpu")
 
-            # CUDA not available
-            mock_torch.cuda.is_available.return_value = False
+        assert device_info.type == "cpu"
+        assert device_info.name == "CPU"
+        assert device_info.memory is None
+        assert device_info.index is None
 
-            device_info = fxt_system_service.get_device_info("cpu")
+        device_info = service.training_device("xpu-0")
 
-            assert device_info.type == "cpu"
-            assert device_info.name == "CPU"
-            assert device_info.memory is None
-            assert device_info.index is None
+        assert device_info.type == "xpu"
+        assert device_info.name == "Intel(R) Graphics [0x7d41]"
+        assert device_info.memory == 36022263808
+        assert device_info.index == 0
 
-            device_info = fxt_system_service.get_device_info("xpu-0")
-
-            assert device_info.type == "xpu"
-            assert device_info.name == "Intel(R) Graphics [0x7d41]"
-            assert device_info.memory == 36022263808
-            assert device_info.index == 0
-
-    def test_get_device_info_invalid(self, fxt_system_service: SystemService):
+    def test_training_device_info_invalid(self, fxt_system_service: SystemService):
         """Test getting device info for invalid device"""
+        service = SystemService(training_catalog=FakeDeviceCatalog([]))
+
         with pytest.raises(ValueError):
-            fxt_system_service.get_device_info("xpu-999")
+            service.training_device("xpu-999")
 
     @pytest.mark.parametrize(
         "raw_device_name, expected_ov_device_name",
@@ -293,29 +252,27 @@ class TestSystemService:
             ("xpu-1", "GPU.1"),
         ],
     )
-    def test_get_ov_device_name(
+    def test_get_inference_device_name(
         self, fxt_system_service: SystemService, raw_device_name, expected_ov_device_name
     ) -> None:
         """Test conversion of raw device names to OpenVINO device names."""
-        mock_xpu_dp = MagicMock()
-        mock_xpu_dp.name = "Intel(R) Graphics [0x7d41]"
-        mock_xpu_dp.total_memory = 36022263808
-        with patch("app.services.system_service.torch") as mock_torch:
-            mock_torch.cuda.is_available.return_value = False
-            mock_torch.xpu.is_available.return_value = True
-            mock_torch.xpu.device_count.return_value = 2
-            mock_torch.xpu.get_device_properties.return_value = mock_xpu_dp
+        xpu_devices = [
+            DeviceInfo(type=DeviceType.XPU, name="Intel(R) Graphics [0x7d41]", memory=36022263808, index=index)
+            for index in range(2)
+        ]
+        service = SystemService(inference_catalog=FakeDeviceCatalog(xpu_devices))
 
-            geti_device = fxt_system_service.get_device_info(raw_device_name)
+        geti_device = service.inference_device(raw_device_name)
+
         assert geti_device.as_openvino == expected_ov_device_name
 
     def test_get_ov_device_name_invalid(self, fxt_system_service: SystemService) -> None:
         """Test conversion of raw device names to OpenVINO device names."""
         with pytest.raises(ValueError):
-            _ = fxt_system_service.get_device_info("gpu")
+            _ = fxt_system_service.inference_device("gpu")
 
-    def test_get_camera_devices(self, fxt_system_service: SystemService):
-        """Test getting camera devices"""
+    def test_list_cameras(self, fxt_system_service: SystemService):
+        """Test listing camera devices"""
         with patch("app.services.system_service.enumerate_cameras") as mock_enumerate_cameras:
             # Mock camera device
             mock_camera = MagicMock()
@@ -324,7 +281,7 @@ class TestSystemService:
 
             mock_enumerate_cameras.return_value = [mock_camera]
 
-            camera_devices = fxt_system_service.get_camera_devices()
+            camera_devices = fxt_system_service.list_cameras()
 
             assert len(camera_devices) == 1
             assert camera_devices[0].name == "Integrated Camera [1400]"


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] Added `DeviceSpec`, a value object parsed from strings like `"xpu-1"` that owns its own `matches(DeviceInfo)` comparison, replacing `_parse_device` + scattered comparisons.
- [x] Added `DeviceCatalog` protocol with two implementations:
  - `TrainingDeviceCatalog` (PyTorch-backed: CPU/XPU/CUDA)
  - `OpenVinoInferenceDeviceCatalog` (OpenVINO-backed: CPU + Intel GPUs)
Each catalog knows how to list (`devices()`) and resolve (`find(spec)`) its own devices.
- [x] `SystemService` now takes optional `training_catalog` / `inference_catalog` constructor params (defaulting to the two catalogs above)
- [x] Fixed pipelines `PATCH` to validate against `OpenVinoInferenceDeviceCatalog` (it fixes the original issue when inference device was missing in the list initialized by torch.xpu backend)


### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
