### PR TITLE
fix: Handle tiling batch size to prevent memory issues

### DIFF
--- a/application/backend/app/execution/training/getitune_trainer.py
+++ b/application/backend/app/execution/training/getitune_trainer.py
@@ -445,10 +445,12 @@ class GetiTuneTrainer(Execution[TrainingJobParams]):
         logger.info("Instantiating model for training (model_id={})", model_id)
         model_cfg = training_config["model"]
         model_cfg["init_args"]["label_info"] = datamodule.label_info.label_names
+        # NOTE: pass mean/std through as-is. None when the CPU augmentation pipeline has no torchvision Normalize to
+        # derive them from, such as when normalization lives in augmentations_gpu instead
         model_cfg["init_args"]["data_input_params"] = DataInputParams(
             input_size=cast(tuple[int, int], datamodule.input_size),
-            mean=datamodule.input_mean if datamodule.input_mean is not None else (0.0, 0.0, 0.0),
-            std=datamodule.input_std if datamodule.input_std is not None else (1.0, 1.0, 1.0),
+            mean=datamodule.input_mean,
+            std=datamodule.input_std,
             intensity_config=datamodule.input_intensity_config,
         ).as_dict()
         logger.info("Initializing engine for training (model_id={})", model_id)

--- a/library/src/getitune/backend/lightning/models/base.py
+++ b/library/src/getitune/backend/lightning/models/base.py
@@ -92,8 +92,8 @@ class DataInputParams:
     """
 
     input_size: tuple[int, int]
-    mean: tuple[float, float, float]
-    std: tuple[float, float, float]
+    mean: tuple[float, float, float] | None
+    std: tuple[float, float, float] | None
     intensity_config: IntensityConfig | None = None
 
     def as_dict(self) -> dict[str, Any]:
@@ -1016,9 +1016,11 @@ class LightningModel(LightningModule):
 
                 intensity_cfg = IntensityConfig(**intensity_cfg)
             data_input_params = DataInputParams(
-                input_size=preprocessing_params.get("input_size") or default.input_size,
-                mean=preprocessing_params.get("mean") or default.mean,
-                std=preprocessing_params.get("std") or default.std,
+                input_size=preprocessing_params.get("input_size")
+                if preprocessing_params.get("input_size") is not None
+                else default.input_size,
+                mean=preprocessing_params.get("mean") if preprocessing_params.get("mean") is not None else default.mean,
+                std=preprocessing_params.get("std") if preprocessing_params.get("std") is not None else default.std,
                 intensity_config=intensity_cfg,
             )
         elif isinstance(preprocessing_params, DataInputParams):

--- a/library/src/getitune/tools/auto_configurator.py
+++ b/library/src/getitune/tools/auto_configurator.py
@@ -248,10 +248,12 @@ class AutoConfigurator:
                     "Input size is not specified in the datamodule. Ensure that the datamodule has a valid input size."
                 )
                 raise ValueError(msg)
+            # NOTE: pass mean/std through as-is. None when the CPU augmentation pipeline has no torchvision Normalize to
+            # derive them from, such as when normalization lives in augmentations_gpu instead
             model_config["init_args"]["data_input_params"] = DataInputParams(
                 input_size=datamodule.input_size,
-                mean=datamodule.input_mean if datamodule.input_mean is not None else (0.0, 0.0, 0.0),
-                std=datamodule.input_std if datamodule.input_std is not None else (1.0, 1.0, 1.0),
+                mean=datamodule.input_mean,
+                std=datamodule.input_std,
             ).as_dict()
 
         model_cls = get_model_cls_from_config(Namespace(model_config))

--- a/library/src/getitune/tools/auto_configurator.py
+++ b/library/src/getitune/tools/auto_configurator.py
@@ -383,6 +383,33 @@ class AutoConfigurator:
             # pipeline prepends its intensity transform independently of Resize).
             self._strip_resize_transforms(subset_config.augmentations_cpu)
             self._strip_resize_transforms(subset_config.augmentations_gpu)
+
+            # IMPORTANT: the OV recipe's batch_size (e.g. 64) is tuned for *non-tiled*
+            # evaluation, where one dataset item == one model input. With tiling
+            # enabled, a single original image expands into *every* grid tile inside
+            # the dataset (see DataModule._eval_loader_kwargs), so a loader batch_size
+            # of N images can balloon into N * num_tiles tiles collated into a single
+            # in-memory batch. With tile_size=400/overlap=0.2 on large images this can
+            # produce a batch so large that building/collating it appears to hang
+            # (severe memory pressure / thrashing) rather than raising an error.
+            # The model still groups tiles into TileConfig.tile_inference_batch_size
+            # chunks for the actual forward passes, so the loader batch_size can (and
+            # must) stay small here regardless of what the OV recipe specifies.
+            if subset_config.batch_size != 1:
+                logger.info(
+                    "update_ov_subset_pipeline: tiling is enabled, overriding OV recipe "
+                    "%s_subset.batch_size (%d) -> 1 to avoid collating %d images' worth of "
+                    "tiles (tile_size=%s, overlap=%s) into a single dataloader batch, which "
+                    "can hang/OOM. Tile-level batching for the model forward pass is still "
+                    "controlled independently via tile_config.tile_inference_batch_size=%d.",
+                    subset,
+                    subset_config.batch_size,
+                    subset_config.batch_size,
+                    datamodule.tile_config.tile_size,
+                    datamodule.tile_config.overlap,
+                    datamodule.tile_config.tile_inference_batch_size,
+                )
+                subset_config.batch_size = 1
         else:
             datamodule.tile_config.enable_tiler = False
 

--- a/library/tests/unit/backend/lightning/models/test_base.py
+++ b/library/tests/unit/backend/lightning/models/test_base.py
@@ -212,3 +212,76 @@ class TestDataInputParams:
         params = DataInputParams(input_size=(224, 224), mean=(0.485, 0.456, 0.406), std=(0.229, 0.224, 0.225))
         ncwh = params.as_ncwh(batch_size=4)
         assert ncwh == (4, 3, 224, 224)
+
+
+class TestConfigurePreprocessingParams:
+    """Regression tests for LightningModel._configure_preprocessing_params.
+
+    Guards against reintroducing the 0% mAP bug where callers (e.g.
+    AutoConfigurator, getitune_trainer) substitute a hardcoded (0.0, 0.0, 0.0) /
+    (1.0, 1.0, 1.0) whenever the DataModule cannot derive mean/std from its CPU
+    augmentation pipeline (the common case when normalization instead lives in
+    augmentations_gpu). Such a substitution is a *truthy* tuple that must not
+    permanently shadow a model's own `_default_preprocessing_params` fallback
+    (e.g. YOLOX-S/L/X's std=(1/255, 1/255, 1/255), needed to undo the CPU
+    pipeline's [0, 1] scaling before OV/ONNX export).
+    """
+
+    @pytest.fixture
+    def model_default_std_1_over_255(self, mocker: MockerFixture) -> LightningModel:
+        """A LightningModel whose model-specific default mimics YOLOX-S/L/X."""
+        with mocker.patch.object(LightningModel, "_create_model", return_value=MockNNModule(3)):
+            model = LightningModel(
+                label_info=3,
+                data_input_params=DataInputParams((640, 640), (0.0, 0.0, 0.0), (1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0)),
+            )
+        mocker.patch.object(
+            LightningModel,
+            "_default_preprocessing_params",
+            new_callable=mocker.PropertyMock,
+            return_value=DataInputParams((640, 640), (0.0, 0.0, 0.0), (1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0)),
+        )
+        return model
+
+    def test_none_mean_std_falls_back_to_model_default(self, model_default_std_1_over_255: LightningModel) -> None:
+        """mean=None/std=None (e.g. datamodule couldn't derive them) must use the model default."""
+        result = model_default_std_1_over_255._configure_preprocessing_params(
+            {"input_size": (640, 640), "mean": None, "std": None},
+        )
+        assert result.mean == (0.0, 0.0, 0.0)
+        assert result.std == (1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0)
+
+    def test_missing_mean_std_keys_fall_back_to_model_default(
+        self,
+        model_default_std_1_over_255: LightningModel,
+    ) -> None:
+        """A partial dict (mean/std keys absent entirely) must also use the model default."""
+        result = model_default_std_1_over_255._configure_preprocessing_params({"input_size": (640, 640)})
+        assert result.std == (1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0)
+
+    def test_hardcoded_identity_fallback_does_not_shadow_model_default(
+        self,
+        model_default_std_1_over_255: LightningModel,
+    ) -> None:
+        """Regression guard: callers must NOT substitute (1.0, 1.0, 1.0) for a missing std.
+
+        A caller that (incorrectly) substitutes the generic identity std=(1.0, 1.0, 1.0)
+        for a missing value defeats the model-specific default, since a non-empty tuple
+        is truthy and therefore looks "provided". This test documents/pins the (bad)
+        outcome of doing that, to make the anti-pattern obvious if it's reintroduced
+        upstream: callers must pass None through, not (1.0, 1.0, 1.0).
+        """
+        result = model_default_std_1_over_255._configure_preprocessing_params(
+            {"input_size": (640, 640), "mean": (0.0, 0.0, 0.0), "std": (1.0, 1.0, 1.0)},
+        )
+        assert result.std == (1.0, 1.0, 1.0)
+        assert result.std != (1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0)
+
+    def test_explicit_zero_mean_is_respected(self, model_default_std_1_over_255: LightningModel) -> None:
+        """A genuinely-intentional, explicit mean/std must still be honored (not overridden)."""
+        result = model_default_std_1_over_255._configure_preprocessing_params(
+            {"input_size": (640, 640), "mean": (0.1, 0.2, 0.3), "std": (0.5, 0.5, 0.5)},
+        )
+        assert result.mean == (0.1, 0.2, 0.3)
+        assert result.std == (0.5, 0.5, 0.5)
+

--- a/library/tests/unit/backend/lightning/models/test_base.py
+++ b/library/tests/unit/backend/lightning/models/test_base.py
@@ -284,4 +284,3 @@ class TestConfigurePreprocessingParams:
         )
         assert result.mean == (0.1, 0.2, 0.3)
         assert result.std == (0.5, 0.5, 0.5)
-

--- a/library/tests/unit/tools/test_auto_configurator.py
+++ b/library/tests/unit/tools/test_auto_configurator.py
@@ -148,11 +148,18 @@ class TestAutoConfigurator:
         # The detection base config has augmentations_cpu with Resize
         assert any("Resize" in aug.get("class_path", "") for aug in datamodule.test_subset.augmentations_cpu)
 
+        ov_config_path = DEFAULT_CONFIG_PER_TASK[TaskType.DETECTION].parent / "openvino_model.yaml"
+        ov_recipe_batch_size = auto_configurator._load_default_config(config_path=ov_config_path)["data"][
+            "test_subset"
+        ]["batch_size"]
+
         updated_datamodule = auto_configurator.update_ov_subset_pipeline(datamodule, subset="test")
         # OV recipes now use Resize (preprocessing moved from ModelAPI to getitune)
         assert len(updated_datamodule.test_subset.augmentations_cpu) == 1
         assert "Resize" in updated_datamodule.test_subset.augmentations_cpu[0]["class_path"]
         assert not updated_datamodule.tile_config.enable_tiler
+        # Without tiling, the OV recipe's batch_size is used as-is (no override).
+        assert updated_datamodule.test_subset.batch_size == ov_recipe_batch_size
 
     def test_update_ov_subset_pipeline_tiling_keeps_tiler_and_strips_resize(self) -> None:
         """With tiling enabled, the OV pipeline keeps the tiler on and removes the tile Resize.
@@ -167,7 +174,26 @@ class TestAutoConfigurator:
         datamodule = auto_configurator.get_datamodule()
         datamodule.tile_config.enable_tiler = True
 
+        # Sanity-check the precondition this regression test relies on: the OV recipe's
+        # non-tiled batch_size must be > 1, otherwise the batch_size==1 assertion below
+        # would pass trivially even if the override logic were removed.
+        ov_config_path = DEFAULT_CONFIG_PER_TASK[TaskType.DETECTION].parent / "openvino_model.yaml"
+        ov_recipe_batch_size = auto_configurator._load_default_config(config_path=ov_config_path)["data"][
+            "test_subset"
+        ]["batch_size"]
+        assert ov_recipe_batch_size > 1, (
+            "This test expects the OV recipe's test_subset.batch_size to be > 1 "
+            "(currently 64) so it can verify that tiling forces it down to 1."
+        )
+
         updated_datamodule = auto_configurator.update_ov_subset_pipeline(datamodule, subset="test")
+
+        # Tiling forces the loader batch_size down to 1 regardless of the OV recipe's
+        # configured batch_size: with tiling enabled, a single dataset item expands into
+        # every grid tile of the native-resolution image, so a larger loader batch_size
+        # would collate many images' worth of tiles into one in-memory batch, which can
+        # hang or OOM (see DataModule._eval_loader_kwargs and update_ov_subset_pipeline).
+        assert updated_datamodule.test_subset.batch_size == 1
 
         # Tiling stays enabled: ModelAPI performs tiled inference via forward_tiles.
         assert updated_datamodule.tile_config.enable_tiler


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Sets the batchsize for evaluation to 1 when tiling is enabled.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
