### PR TITLE
Fix accuracy-aware quantization failure with YOLO11/YOLO26 segmentation models

### DIFF
--- a/library/src/getitune/backend/openvino/models/base.py
+++ b/library/src/getitune/backend/openvino/models/base.py
@@ -9,7 +9,7 @@ import inspect
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 import nncf
 import numpy as np
@@ -391,6 +391,31 @@ class OVModel:
 
         return output_model_path
 
+    @staticmethod
+    def _map_compiled_output_keys(model: ImageModel, compiled_model: openvino.CompiledModel) -> list[Any]:
+        """Map the outputs of an externally compiled model onto the ModelAPI wrapper's output keys.
+
+        ModelAPI keys raw results by tensor name, but falls back to the output port object
+        itself when the tensor carries no name (as is the case for Ultralytics YOLO exports).
+        Outputs of a model compiled outside of ModelAPI, e.g. by NNCF during accuracy-aware
+        quantization, are therefore matched by name when possible and positionally otherwise.
+
+        Args:
+            model (ImageModel): ModelAPI wrapper whose ``postprocess`` consumes the raw results.
+            compiled_model (openvino.CompiledModel): Compiled model whose outputs must be mapped.
+
+        Returns:
+            list[Any]: The wrapper output key for each output of ``compiled_model``, in order.
+        """
+        wrapper_outputs = cast("dict[Any, Any]", model.outputs or {})
+        wrapper_keys = list(wrapper_outputs)
+        name_to_key = {name: key for key, metadata in wrapper_outputs.items() for name in metadata.names}
+        keys: list[Any] = []
+        for idx, output in enumerate(compiled_model.outputs):
+            key = next((name_to_key[name] for name in output.get_names() if name in name_to_key), None)
+            keys.append(wrapper_keys[idx] if key is None else key)
+        return keys
+
     def _create_validation_fn(
         self, data_module: DataModule
     ) -> Callable[[openvino.CompiledModel, Any], tuple[float, None]]:
@@ -425,16 +450,18 @@ class OVModel:
                 PredictionBatch with predictions from the compiled model.
             """
             numpy_inputs = self._customize_inputs(inputs)["inputs"]
+            model_ref: ImageModel = self.model.model if isinstance(self.model, Tiler) else self.model  # type: ignore[assignment]
+            output_keys = self._map_compiled_output_keys(model_ref, compiled_model)
             infer_request = compiled_model.create_infer_request()
             outputs: list[Result] = []
             for image in numpy_inputs:
-                model_ref: ImageModel = self.model.model if isinstance(self.model, Tiler) else self.model  # type: ignore[assignment]
                 resized = model_ref.resize(image, (model_ref.w, model_ref.h))
                 resized = model_ref.input_transform(resized)
                 input_tensor = model_ref._change_layout(resized)  # noqa: SLF001
                 infer_request.infer({0: input_tensor})
                 raw_result = {
-                    out.get_any_name(): infer_request.get_tensor(out).data.copy() for out in compiled_model.outputs
+                    key: infer_request.get_tensor(out).data.copy()
+                    for key, out in zip(output_keys, compiled_model.outputs, strict=True)
                 }
                 result = model_ref.postprocess(raw_result, {"original_shape": image.shape})
                 outputs.append(result)

--- a/library/tests/unit/backend/openvino/models/test_base.py
+++ b/library/tests/unit/backend/openvino/models/test_base.py
@@ -12,6 +12,7 @@ import numpy as np
 import openvino as ov
 import pytest
 import torch
+from model_api.adapters.inference_adapter import Metadata
 from model_api.models.result import ClassificationResult
 
 from getitune.backend.openvino.models import OVModel
@@ -131,3 +132,46 @@ class TestResolveModelType:
         ov_model._model_adapter = mock_adapter
         result = ov_model.model_type
         assert result == "YOLO11"
+
+
+class TestMapCompiledOutputKeys:
+    """Tests for mapping externally compiled model outputs to ModelAPI output keys."""
+
+    @staticmethod
+    def _wrapper(outputs: dict) -> MagicMock:
+        model = MagicMock()
+        model.outputs = outputs
+        return model
+
+    @staticmethod
+    def _compiled(names: list[set[str]]) -> MagicMock:
+        compiled_model = MagicMock()
+        compiled_model.outputs = []
+        for output_names in names:
+            output = MagicMock()
+            output.get_names.return_value = output_names
+            compiled_model.outputs.append(output)
+        return compiled_model
+
+    def test_maps_named_outputs_by_name(self) -> None:
+        wrapper = self._wrapper(
+            {"boxes": Metadata(names={"boxes"}), "labels": Metadata(names={"labels"})},
+        )
+        # NNCF may return the outputs in a different order than the wrapper.
+        compiled_model = self._compiled([{"labels"}, {"boxes"}])
+
+        assert OVModel._map_compiled_output_keys(wrapper, compiled_model) == ["labels", "boxes"]
+
+    def test_maps_unnamed_outputs_positionally(self) -> None:
+        """Ultralytics YOLO-seg exports have unnamed output tensors, keyed by port object."""
+        det_port, proto_port = object(), object()
+        wrapper = self._wrapper({det_port: Metadata(names=set()), proto_port: Metadata(names=set())})
+        compiled_model = self._compiled([set(), set()])
+
+        assert OVModel._map_compiled_output_keys(wrapper, compiled_model) == [det_port, proto_port]
+
+    def test_maps_unknown_names_positionally(self) -> None:
+        wrapper = self._wrapper({"boxes": Metadata(names={"boxes"}), "labels": Metadata(names={"labels"})})
+        compiled_model = self._compiled([{"renamed_by_nncf"}, {"labels"}])
+
+        assert OVModel._map_compiled_output_keys(wrapper, compiled_model) == ["boxes", "labels"]


### PR DESCRIPTION
### Summary

Context: NNCF accuracy-aware quantization (`nncf.quantize_with_accuracy_control`) needs to monitor the model accuracy during the process, and it does it through a `validation_fn` supplied by the caller. Normally, getitune evaluates models by performing the inference through ModelAPI, however NNCF hands `validation_fn` a raw `openvino.CompiledModel` (instead of a ModelAPI model) so our `OVModel` contains some glue to re-implement what ModelAPI `OpenvinoAdapter` normally does (preprocess -> infer -> build a `output_key: ndarray}` dict -> postprocess).

A bug occurred for Ultralytics segmentation models, which are the only models that verify these two conditions simultaneously: 1) they have multiple output nodes (det + proto); 2) they don't assign a name to the output tensors. Under these specific conditions, an unconditional call to `get_any_name()` in the aforementioned glue code would raise the error "Attempt to get a name for a Tensor without names.", whereas the original Model API implementation has a fallback path for this scenario ([source](https://github.com/open-edge-platform/model_api/blob/5d3902f4edb303a39dcea8acda9e7948225bec1c/model_api/src/model_api/adapters/openvino_adapter.py#L314)).

Why the other models were not affected by the bug:
- Classification and detection models: they only have 1 output tensor
- Other non-Ultralytics segmentation models: they use named tensors

Fixes #7234

### How to test

- [x] Run accuracy-aware quantization with YOLO26 Seg
- [x] Run accuracy-aware quantization with YOLO11 Seg
- [x] Run accuracy-aware quantization with YOLO26 Det
- [x] Run accuracy-aware quantization with MaskRCNN (seg)

<img width="1273" height="453" alt="image" src="https://github.com/user-attachments/assets/d50a1286-53ac-420f-b424-d005e0fb5b8d" />

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
