### PR TITLE
fix(ci): update zap config to reduce scan time

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -103,7 +103,7 @@ jobs:
 
   dast-scan:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    timeout-minutes: 90
+    timeout-minutes: 360
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -175,7 +175,8 @@ jobs:
         uses: zaproxy/action-full-scan@3c58388149901b9a03b7718852c5ba889646c27c # v0.13.0
         with:
           target: "https://localhost:7860"
-          cmd_options: '-a -j -z "-config connection.ssl.skipCertVerification=true"'
+          # -m 20: cap spider at 20 min; ascan cap at 60 min
+          cmd_options: '-a -m 20 -z "-config connection.ssl.skipCertVerification=true -config ascan.maxScanDurationInMins=60"'
           allow_issue_writing: false
           fail_action: false
           artifact_name: zapfull


### PR DESCRIPTION
### Summary

This PR updates ZAP configuration in order to reduce scan time ([current log](https://github.com/open-edge-platform/geti/actions/runs/31355906171)):

- removed `-j` - eliminates the unbounded Ajax spider
- added `-m 20` - caps the traditional spider crawl at 20 minutes
- added `-config ascan.maxScanDurationInMins=60`  - caps the active scan phase at 60 minutes

### How to test

Was tested in fork -- see this [log](https://github.com/AlexanderBarabanov/geti/actions/runs/31416393229/job/93546331428)

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
