### PR TITLE
Fix accuracy-aware quantization for multilabel classification

### DIFF
--- a/library/src/getitune/backend/openvino/models/base.py
+++ b/library/src/getitune/backend/openvino/models/base.py
@@ -416,6 +416,33 @@ class OVModel:
             keys.append(wrapper_keys[idx] if key is None else key)
         return keys
 
+    @staticmethod
+    def _select_primary_metric(results: dict[str, Any]) -> float:
+        """Select the accuracy indicator that accuracy-aware quantization is driven by.
+
+        The first scalar entry of the computed metrics is used. Non-scalar entries are
+        skipped because some metric collections emit one first, e.g. the multi-label
+        classification metric starts with a list of per-group confusion matrices.
+
+        Args:
+            results (dict[str, Any]): Computed metrics.
+
+        Returns:
+            float: Value of the first scalar metric.
+
+        Raises:
+            RuntimeError: If none of the computed metrics is a scalar.
+        """
+        for value in results.values():
+            if isinstance(value, Tensor):
+                if value.numel() == 1:
+                    return float(value.item())
+            elif isinstance(value, (int, float)) and not isinstance(value, bool):
+                return float(value)
+
+        msg = f"No scalar metric available to measure the accuracy drop against, got keys: {list(results)}"
+        raise RuntimeError(msg)
+
     def _create_validation_fn(
         self, data_module: DataModule
     ) -> Callable[[openvino.CompiledModel, Any], tuple[float, None]]:
@@ -495,12 +522,8 @@ class OVModel:
                     metric.update(**metric_inputs)
 
             results = self.compute_metrics(metric)
-            # Take the first scalar metric value as the accuracy indicator
-            metric_value = next(iter(results.values()))
-            if isinstance(metric_value, torch.Tensor):
-                metric_value = metric_value.item()
 
-            return float(metric_value), None
+            return self._select_primary_metric(results), None
 
         return validation_fn
 

--- a/library/tests/unit/backend/openvino/models/test_base.py
+++ b/library/tests/unit/backend/openvino/models/test_base.py
@@ -175,3 +175,34 @@ class TestMapCompiledOutputKeys:
         compiled_model = self._compiled([{"renamed_by_nncf"}, {"labels"}])
 
         assert OVModel._map_compiled_output_keys(wrapper, compiled_model) == ["boxes", "labels"]
+
+
+class TestSelectPrimaryMetric:
+    """Tests for choosing the accuracy indicator of accuracy-aware quantization."""
+
+    def test_returns_first_scalar_tensor(self) -> None:
+        results = {"map": torch.tensor(0.75), "map_50": torch.tensor(0.9)}
+
+        assert OVModel._select_primary_metric(results) == pytest.approx(0.75)
+
+    def test_returns_plain_number(self) -> None:
+        assert OVModel._select_primary_metric({"Dice": 0.5}) == pytest.approx(0.5)
+
+    def test_skips_leading_non_scalar_entries(self) -> None:
+        """The multi-label classification metric emits confusion matrices first."""
+        results = {
+            "conf_matrix": [torch.zeros(2, 2), torch.zeros(2, 2)],
+            "accuracy": torch.tensor(0.8),
+            "map": torch.tensor(0.6),
+        }
+
+        assert OVModel._select_primary_metric(results) == pytest.approx(0.8)
+
+    def test_skips_multi_element_tensors(self) -> None:
+        results = {"map_per_class": torch.tensor([0.1, 0.2]), "accuracy": torch.tensor(0.4)}
+
+        assert OVModel._select_primary_metric(results) == pytest.approx(0.4)
+
+    def test_raises_when_no_scalar_metric(self) -> None:
+        with pytest.raises(RuntimeError, match="No scalar metric"):
+            OVModel._select_primary_metric({"conf_matrix": [torch.zeros(2, 2)]})


### PR DESCRIPTION
### Summary

The metric to monitor must be scalar, while the old logic would incorrectly pick confusion matrix (non-scalar) for multilabel classification.

Fixes #7255 

### How to test

Run accuracy-aware quantization for each Geti task
- [x] ML Cls
- [x] MC Cls
- [x] Det
- [x] Inst Seg

<img width="1334" height="500" alt="image" src="https://github.com/user-attachments/assets/456116b2-7d4c-4041-990d-9f1b2cdd3e89" />

### Checklist

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
