### PR TITLE
Fix multiclass project created instead of multilabel when importing COCO detection dataset

### DIFF
--- a/application/backend/app/execution/dataset_import/import_as_new_project.py
+++ b/application/backend/app/execution/dataset_import/import_as_new_project.py
@@ -143,8 +143,8 @@ class ImportDatasetAsNewProject(BaseDatasetImport[ImportDatasetAsNewProjectJobPa
         """
         Check if the dataset's 'label' or 'labels' attribute is represented as a NumPy array.
 
-        This method inspects the schema definition of the 'label' attribute to check if its type is or contains
-        `np.ndarray` (such as `np.ndarray | None`).
+        This method inspects the schema definition of the 'label' or 'labels' attribute to check if its type is or
+        contains `np.ndarray` (such as `np.ndarray | None`).
 
         The result impacts how the project is created: if the dataset has array labels, the newly created project will
         configure its task with non-exclusive labels (i.e., a multi-label classification project).

--- a/application/backend/app/execution/dataset_import/import_as_new_project.py
+++ b/application/backend/app/execution/dataset_import/import_as_new_project.py
@@ -141,7 +141,7 @@ class ImportDatasetAsNewProject(BaseDatasetImport[ImportDatasetAsNewProjectJobPa
     @staticmethod
     def _has_array_label(dataset: Dataset) -> bool:
         """
-        Check if the dataset's 'label' attribute is represented as a NumPy array.
+        Check if the dataset's 'label' or 'labels' attribute is represented as a NumPy array.
 
         This method inspects the schema definition of the 'label' attribute to check if its type is or contains
         `np.ndarray` (such as `np.ndarray | None`).
@@ -156,10 +156,14 @@ class ImportDatasetAsNewProject(BaseDatasetImport[ImportDatasetAsNewProjectJobPa
             True if the dataset's 'label' attribute schema type contains `np.ndarray`,
             False otherwise.
         """
-        if "label" not in dataset.schema.attributes:
+        attribute_name = next(
+            (name for name in ("label", "labels") if name in dataset.schema.attributes),
+            None,
+        )
+        if attribute_name is None:
             return False
 
-        label_type = dataset.schema.attributes["label"].type
+        label_type = dataset.schema.attributes[attribute_name].type
 
         def _is_numpy_array_type(tp: object) -> bool:
             return tp is np.ndarray or get_origin(tp) is np.ndarray

--- a/application/backend/tests/unit/execution/dataset_import/test_import_as_new_project.py
+++ b/application/backend/tests/unit/execution/dataset_import/test_import_as_new_project.py
@@ -188,7 +188,6 @@ class TestImportDatasetAsNewProject:
     ) -> None:
         dataset = MagicMock(spec=Dataset)
         dataset.schema = Mock()
-        dataset.schema.attributes = attributes
 
         def _attr(tp: object) -> Mock:
             attr = Mock()

--- a/application/backend/tests/unit/execution/dataset_import/test_import_as_new_project.py
+++ b/application/backend/tests/unit/execution/dataset_import/test_import_as_new_project.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 from uuid import uuid4
 
+import numpy as np
 import polars as pl
 import pytest
 from datumaro.experimental import Dataset
@@ -165,6 +166,41 @@ class TestImportDatasetAsNewProject:
                 include_unannotated=False,
                 start_progress=15.0,
             )
+
+    @pytest.mark.parametrize(
+        "attributes, expected",
+        [
+            ({}, False),  # no label attribute at all
+            ({"label": str}, False),  # plain scalar label
+            ({"label": np.ndarray}, True),  # array label under "label"
+            ({"label": np.ndarray | None}, True),  # optional array label under "label"
+            ({"labels": np.ndarray}, True),  # array label under "labels"
+            ({"labels": np.ndarray | None}, True),  # optional array label under "labels"
+            ({"labels": str}, False),  # plain scalar under "labels"
+            ({"other": np.ndarray}, False),  # unrelated attribute name
+        ],
+    )
+    def test_has_array_label(
+        self,
+        attributes: dict,
+        expected: bool,
+        fxt_import: ImportDatasetAsNewProject,
+    ) -> None:
+        dataset = MagicMock(spec=Dataset)
+        dataset.schema = Mock()
+        dataset.schema.attributes = attributes
+
+        def _attr(tp: object) -> Mock:
+            attr = Mock()
+            attr.type = tp
+            return attr
+
+        # wrap raw types into mock attribute objects with a `.type`
+        dataset.schema.attributes = {name: _attr(tp) for name, tp in attributes.items()}
+
+        result = fxt_import._has_array_label(dataset=dataset)
+
+        assert result is expected
 
     def test_execute(
         self, fxt_import: ImportDatasetAsNewProject, fxt_import_params: ImportDatasetAsNewProjectJobParams


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] Additional check for `labels` attribute in dataset schema during dataset import

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
