### PR TITLE
Fix lost annotations when importing COCO bbox dataset to segmentation project

### DIFF
--- a/application/backend/app/execution/dataset_export/export.py
+++ b/application/backend/app/execution/dataset_export/export.py
@@ -93,7 +93,6 @@ class ExportDataset(Execution[ExportDatasetJobParams]):
                     data_format=get_dm_format(export_format),
                     output_path=str(target_dir / f"dataset-{export_format}.zip"),
                     as_zip=True,
-                    direct_only=True,
                 )
             case DatasetFormat.GETI:
                 export_dataset(

--- a/application/backend/tests/unit/execution/dataset_export/test_export.py
+++ b/application/backend/tests/unit/execution/dataset_export/test_export.py
@@ -158,7 +158,6 @@ class TestDatasetExporter:
                 data_format=data_format,
                 output_path=str(fxt_staged_datasets_dir / str(dataset_id) / f"dataset-{export_format}.zip"),
                 as_zip=True,
-                direct_only=True,
             )
 
     def test_export_dataset_geti(self, fxt_export: ExportDataset, fxt_staged_datasets_dir: Path):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

- [x] Remove `direct_only` from export

This option was originally introduced to attempt to fix an issue where both `bboxes` and `polygons` were present in exported datasets (specifically for the `COCO` format), in order to suggest the appropriate task type based on the dataset structure. When multiple annotation attributes are present, it is not possible to automatically determine which task type applies. However, this option provides no value because we already explicitly limit the suggested task type based on the annotation type in `staged_dataset_service`: 

https://github.com/open-edge-platform/geti/blob/1907a28cdfb34f6d397b72b4f7b858389d5c3e8e/application/backend/app/services/staged_dataset_service.py#L45

The proposal is to revert this option as it does not function as intended - `polygons` are still exported as empty while preserving shape - and it also causes the spotted issue during import.

Affected datasets will need to be re-exported.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
