### PR TITLE
Validation fn fix for quantization

### DIFF
--- a/library/src/getitune/backend/openvino/models/base.py
+++ b/library/src/getitune/backend/openvino/models/base.py
@@ -510,16 +510,6 @@ class OVModel:
                decide which quantizers to revert to floating point during accuracy-aware
                quantization.
 
-            Previously this function ignored ``validation_dataset`` entirely and instead
-            re-created and fully re-iterated ``data_module.val_dataloader()`` on *every* call.
-            Since NNCF invokes this function once per batch during per-item collection, that meant
-            a brand new multi-worker ``DataLoader`` (with its own worker processes and pinned-memory
-            thread) was spun up and torn down, and the *entire* validation set was re-scanned, once
-            per batch of the validation set -- i.e. roughly ``num_batches`` full passes instead of
-            one. This was extremely slow and, in resource-constrained (e.g. containerized)
-            environments, could exhaust shared memory / worker processes and crash with
-            ``RuntimeError: Pin memory thread exited unexpectedly``.
-
             Args:
                 compiled_model: Compiled OpenVINO model provided by NNCF during
                     accuracy-aware quantization.

--- a/library/src/getitune/backend/openvino/models/base.py
+++ b/library/src/getitune/backend/openvino/models/base.py
@@ -34,7 +34,7 @@ from getitune.types.task import TaskType
 from .utils import get_default_num_async_infer_requests
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
 
     from model_api.models.result import Result
     from torchmetrics import Metric, MetricCollection
@@ -496,23 +496,42 @@ class OVModel:
 
         def validation_fn(
             compiled_model: openvino.CompiledModel,
-            validation_dataset: nncf.Dataset,  # noqa: ARG001 required by NNCF signature
+            validation_dataset: Iterable[SampleBatch],
         ) -> tuple[float, None]:
-            """Evaluate the compiled OpenVINO model on the validation dataset.
+            """Evaluate the compiled OpenVINO model on the given batches of data.
+
+            NNCF calls this function in two different modes, both of which must be honored:
+
+            1. Once with the *entire* validation dataset, to compute the overall metric of a
+               candidate model (``Evaluator.validate_prepared_model``).
+            2. Once per data item/batch (each call passing only a single-item iterable), to rank
+               how much each item contributes to the accuracy drop
+               (``Evaluator.collect_values_for_each_item_using_prepared_model``). This is used to
+               decide which quantizers to revert to floating point during accuracy-aware
+               quantization.
+
+            Previously this function ignored ``validation_dataset`` entirely and instead
+            re-created and fully re-iterated ``data_module.val_dataloader()`` on *every* call.
+            Since NNCF invokes this function once per batch during per-item collection, that meant
+            a brand new multi-worker ``DataLoader`` (with its own worker processes and pinned-memory
+            thread) was spun up and torn down, and the *entire* validation set was re-scanned, once
+            per batch of the validation set -- i.e. roughly ``num_batches`` full passes instead of
+            one. This was extremely slow and, in resource-constrained (e.g. containerized)
+            environments, could exhaust shared memory / worker processes and crash with
+            ``RuntimeError: Pin memory thread exited unexpectedly``.
 
             Args:
                 compiled_model: Compiled OpenVINO model provided by NNCF during
                     accuracy-aware quantization.
-                validation_dataset: Validation NNCF dataset (unused, we iterate
-                    via the dataloader for proper batching and transforms).
+                validation_dataset: The batches of data to evaluate, as selected by NNCF for this
+                    particular call (either the whole validation set or a single batch).
 
             Returns:
                 Tuple of (metric_value, None).
             """
             metric = self.metric_callable(data_module.label_info)
 
-            val_dataloader = data_module.val_dataloader()
-            for data_batch in val_dataloader:
+            for data_batch in validation_dataset:
                 preds = _infer_compiled_model(compiled_model, data_batch)
                 metric_inputs = self.prepare_metric_inputs(preds, data_batch)
                 if isinstance(metric_inputs, list):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

validation_fn now iterates directly over the validation_dataset batches it's actually given (matching what NNCF intends), instead of re-fetching/re-scanning the whole val set every call. This fixes both correctness (per-item metric values now genuinely reflect the item(s) being evaluated) and performance/stability (only ~2 full dataset passes total instead of dozens, and no repeated DataLoader spin-up storm). This stops the excessive loading/unloading of the dataloader which caused the freezing and the hanging.

<img width="1624" height="616" alt="image" src="https://github.com/user-attachments/assets/8ffaf9fd-1154-41f3-a971-8e0ea1c1b641" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
