### PR TITLE
Add gallery selection behavior

### DIFF
--- a/application/ui/src/components/virtualizer-grid-layout/virtualizer-grid-layout.component.tsx
+++ b/application/ui/src/components/virtualizer-grid-layout/virtualizer-grid-layout.component.tsx
@@ -18,6 +18,7 @@ type SelectionStateOptions = {
     selectOnFocus?: boolean;
 };
 
+// TODO: Extends types on @geti-ui/ui
 const ListBox = AriaComponentsListBox as ComponentType<AriaComponentsListBoxProps & SelectionStateOptions>;
 
 interface GridItem {

--- a/application/ui/src/components/virtualizer-grid-layout/virtualizer-grid-layout.component.tsx
+++ b/application/ui/src/components/virtualizer-grid-layout/virtualizer-grid-layout.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { ComponentProps, ReactNode, useRef } from 'react';
+import { ComponentProps, ComponentType, ReactNode, useRef } from 'react';
 
 import { AriaComponentsListBox, AriaListBoxItem, GridLayout, Loading, View, Virtualizer } from '@geti-ui/ui';
 import { useLoadMore } from '@react-aria/utils';
@@ -13,15 +13,22 @@ import classes from './virtualizer-grid-layout.module.scss';
 
 type AriaComponentsListBoxProps = ComponentProps<typeof AriaComponentsListBox>;
 
+type SelectionStateOptions = {
+    allowDuplicateSelectionEvents?: boolean;
+    selectOnFocus?: boolean;
+};
+
+const ListBox = AriaComponentsListBox as ComponentType<AriaComponentsListBoxProps & SelectionStateOptions>;
+
 interface GridItem {
     id: string;
     [key: string]: unknown;
 }
 
-interface VirtualizerGridLayoutProps<T extends GridItem> extends Pick<
-    AriaComponentsListBoxProps,
-    'selectedKeys' | 'onSelectionChange'
-> {
+interface VirtualizerGridLayoutProps<T extends GridItem>
+    extends
+        Pick<AriaComponentsListBoxProps, 'selectedKeys' | 'onSelectionChange' | 'selectionBehavior'>,
+        SelectionStateOptions {
     items: T[];
     ariaLabel: string;
     scrollToIndex?: number;
@@ -43,11 +50,14 @@ export const VirtualizerGridLayout = <T extends GridItem>({
     isPending = false,
     isLoadingMore,
     selectionMode,
+    selectionBehavior,
     layoutOptions,
     scrollToIndex,
     onLoadMore,
     contentItem,
     onSelectionChange,
+    allowDuplicateSelectionEvents,
+    selectOnFocus,
     getItemId = (item) => item.id,
 }: VirtualizerGridLayoutProps<T>) => {
     const ref = useRef<HTMLDivElement | null>(null);
@@ -71,14 +81,17 @@ export const VirtualizerGridLayout = <T extends GridItem>({
     return (
         <View UNSAFE_className={classes.mainContainer}>
             <Virtualizer layout={GridLayout} layoutOptions={layoutOptions}>
-                <AriaComponentsListBox
+                <ListBox
                     ref={ref}
                     layout='grid'
                     aria-label={ariaLabel}
                     className={classes.container}
                     selectedKeys={selectedKeys}
                     selectionMode={selectionMode}
+                    selectionBehavior={selectionBehavior}
                     onSelectionChange={onSelectionChange}
+                    allowDuplicateSelectionEvents={allowDuplicateSelectionEvents}
+                    selectOnFocus={selectOnFocus}
                 >
                     {items.map((item, index) => {
                         const itemId = getItemId(item);
@@ -99,7 +112,7 @@ export const VirtualizerGridLayout = <T extends GridItem>({
                             <Loading mode='overlay' />
                         </AriaListBoxItem>
                     )}
-                </AriaComponentsListBox>
+                </ListBox>
             </Virtualizer>
             {isPending && <Loading mode='overlay' />}
         </View>

--- a/application/ui/src/features/dataset/gallery/gallery.component.test.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.test.tsx
@@ -24,26 +24,12 @@ vi.mock('../../../shared/drop-zone.utils', () => ({
     getFilesFromDropEvent: ({ files }: { files: File[] }) => Promise.resolve(files),
 }));
 
-vi.mock('../../../components/virtualizer-grid-layout/virtualizer-grid-layout.component', () => ({
-    VirtualizerGridLayout: ({
-        items,
-        contentItem,
-    }: {
-        items: Array<{ id: string }>;
-        contentItem: (item: unknown) => ReactNode;
-    }) => (
-        <>
-            {items.map((item) => (
-                <div key={item.id}>{contentItem(item)}</div>
-            ))}
-        </>
-    ),
-}));
-
 vi.mock('@geti-ui/ui', async (importOriginal) => {
     const actual = await importOriginal<typeof import('@geti-ui/ui')>();
     return {
         ...actual,
+        // Virtualized items are laid out from measurements jsdom does not provide, so they never render
+        Virtualizer: ({ children }: { children: ReactNode }) => <>{children}</>,
         AriaDropZone: ({
             children,
             onDrop,
@@ -183,5 +169,117 @@ describe('Gallery item deletion and selection', () => {
         await screen.findByText('1 item deleted successfully');
 
         expect(screen.queryByText(/\d+ selected/)).not.toBeInTheDocument();
+    });
+
+    describe('multi selection', () => {
+        const items = ['item-1', 'item-2', 'item-3', 'item-4'].map((id) => getMockedMediaImage({ id }));
+
+        const getItem = (index: number) => screen.getAllByRole('option')[index];
+
+        const getCheckbox = (id: string) => screen.getByRole('checkbox', { name: `Select media item ${id}` });
+
+        const clickWithModifier = async (
+            user: ReturnType<typeof userEvent.setup>,
+            modifier: 'Shift' | 'Control',
+            index: number
+        ) => {
+            await user.keyboard(`{${modifier}>}`);
+            await user.click(getItem(index));
+            await user.keyboard(`{/${modifier}}`);
+        };
+
+        it('selects an item by clicking anywhere on it', async () => {
+            const user = userEvent.setup();
+            await renderGalleryWithItems(items);
+
+            await user.click(getItem(0));
+
+            expect(screen.getByText('1 selected')).toBeInTheDocument();
+            expect(getCheckbox('item-1')).toBeChecked();
+        });
+
+        it('replaces the selection when clicking another item without a modifier', async () => {
+            const user = userEvent.setup();
+            await renderGalleryWithItems(items);
+
+            await user.click(getItem(0));
+            await user.click(getItem(2));
+
+            expect(screen.getByText('1 selected')).toBeInTheDocument();
+            expect(getCheckbox('item-1')).not.toBeChecked();
+            expect(getCheckbox('item-3')).toBeChecked();
+        });
+
+        it('deselects the item when clicking it again', async () => {
+            const user = userEvent.setup();
+            await renderGalleryWithItems(items);
+
+            await user.click(getItem(0));
+            await user.click(getItem(0));
+
+            expect(screen.queryByText(/\d+ selected/)).not.toBeInTheDocument();
+            expect(getCheckbox('item-1')).not.toBeChecked();
+        });
+
+        it('adds an item to the selection when clicking with the ctrl key', async () => {
+            const user = userEvent.setup();
+            await renderGalleryWithItems(items);
+
+            await user.click(getItem(0));
+            await clickWithModifier(user, 'Control', 2);
+
+            expect(screen.getByText('2 selected')).toBeInTheDocument();
+            expect(getCheckbox('item-1')).toBeChecked();
+            expect(getCheckbox('item-3')).toBeChecked();
+        });
+
+        it('selects every item between the previously selected item and the shift clicked one', async () => {
+            const user = userEvent.setup();
+            await renderGalleryWithItems(items);
+
+            await user.click(getItem(1));
+            await clickWithModifier(user, 'Shift', 3);
+
+            expect(screen.getByText('3 selected')).toBeInTheDocument();
+            expect(getCheckbox('item-1')).not.toBeChecked();
+            expect(getCheckbox('item-2')).toBeChecked();
+            expect(getCheckbox('item-3')).toBeChecked();
+            expect(getCheckbox('item-4')).toBeChecked();
+        });
+
+        it('selects the range when shift clicking an item above the previously selected one', async () => {
+            const user = userEvent.setup();
+            await renderGalleryWithItems(items);
+
+            await user.click(getItem(2));
+            await clickWithModifier(user, 'Shift', 0);
+
+            expect(screen.getByText('3 selected')).toBeInTheDocument();
+            expect(getCheckbox('item-4')).not.toBeChecked();
+        });
+
+        it('toggles a single item through its checkbox', async () => {
+            const user = userEvent.setup();
+            await renderGalleryWithItems(items);
+
+            await user.click(getCheckbox('item-1'));
+            expect(screen.getByText('1 selected')).toBeInTheDocument();
+
+            await user.click(getCheckbox('item-2'));
+            expect(screen.getByText('2 selected')).toBeInTheDocument();
+
+            await user.click(getCheckbox('item-1'));
+            expect(screen.getByText('1 selected')).toBeInTheDocument();
+        });
+
+        it('does not select an item when using its actions menu', async () => {
+            const user = userEvent.setup();
+            await renderGalleryWithItems([item]);
+
+            await user.click(screen.getByRole('button', { name: 'Media actions' }));
+
+            expect(await screen.findByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
+            expect(screen.queryByText(/\d+ selected/)).not.toBeInTheDocument();
+        });
     });
 });

--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Media } from '@/api/types';
-import { Checkbox, DialogContainer, dimensionValue, Flex, Size, ViewModes } from '@geti-ui/ui';
+import { Checkbox, DialogContainer, dimensionValue, Flex, Selection, Size, ViewModes } from '@geti-ui/ui';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
-import { isEmpty } from 'lodash-es';
+import { isEmpty, isEqual } from 'lodash-es';
 import { GridLayoutOptions } from 'react-aria-components';
 
 import { MediaItem } from '../../../components/media-item/media-item.component';
@@ -59,14 +59,26 @@ const GalleryList = ({
     isMediaItemReviewedById,
 }: GalleryListProps) => {
     const projectId = useProjectIdentifier();
-    const { selectedKeys, toggleSelectedKeys, isSelected } = useSelectedData();
+    const { selectedKeys, setSelectedKeys, toggleSelectedKeys, isSelected } = useSelectedData();
+
+    const handleSelectionChange = (keys: Selection) => {
+        setSelectedKeys((previousKeys) => {
+            const isSameItem = keys !== 'all' && keys.size === 1 && isEqual(previousKeys, keys);
+
+            return isSameItem ? new Set() : keys;
+        });
+    };
 
     return (
         <VirtualizerGridLayout
             items={items}
             ariaLabel='data-collection-grid'
             selectionMode='multiple'
+            selectionBehavior='replace'
+            allowDuplicateSelectionEvents
+            selectOnFocus={false}
             selectedKeys={selectedKeys}
+            onSelectionChange={handleSelectionChange}
             layoutOptions={VIEW_MODE_SETTINGS[viewMode]}
             isPending={isPending}
             isLoadingMore={isFetchingNextPage}


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Selecting a media item can be done by clicking on the checkbox or anywhere else in the thumbnail
* Clicking on a media item should act as toggle, select/deselect
* Selecting a media then selecting more while pressing cmd/ctrl should add to the selection
* Selecting a media then selecting more while pressing shift should select all items between the first media item and the second

Closes https://github.com/open-edge-platform/geti/issues/7284

All above are standard gallery media selection behavior

<img width="1280" height="622" alt="rec" src="https://github.com/user-attachments/assets/5a6f73c7-aab8-45ce-9740-480255653e55" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
