### PR TITLE
Update installer tags for v3.1.0

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -73,7 +73,7 @@ $ErrorActionPreference = "Stop"
 $GIT_URL = "https://github.com/open-edge-platform/geti.git"
 # GIT_BRANCH can be overridden via the GIT_BRANCH environment variable or the
 # -GitBranch parameter (for testing purposes).
-$GIT_BRANCH = "nightly-2026.06.19"
+$GIT_BRANCH = "app/v3.1.0"
 if ($GitBranch) {
     $GIT_BRANCH = $GitBranch
 }

--- a/install.sh
+++ b/install.sh
@@ -22,7 +22,7 @@ trap 'echo ""; echo "Installation interrupted."; exit 130' INT TERM
 GIT_URL="https://github.com/open-edge-platform/geti.git"
 # GIT_BRANCH can be overridden via the GIT_BRANCH environment variable or the
 # --git-branch flag (for testing purposes).
-GIT_BRANCH="${GIT_BRANCH:-nightly-2026.06.19}"
+GIT_BRANCH="${GIT_BRANCH:-app/v3.1.0}"
 
 # Exit code the backend uses for a fatal, non-restartable migration failure
 # (see application/backend/app/lifecycle.py:MIGRATION_FATAL_EXIT_CODE). It lets


### PR DESCRIPTION
### Summary

Update the installer tags to point to the latest release v3.1.0.

### How to test

- `curl -fsSL https://raw.githubusercontent.com/open-edge-platform/geti/leonardo/update-tags-310/install.sh | bash -s -- --yes`

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
