### PR TITLE
Fix binary data transfer issue

### DIFF
--- a/application/backend/app/api/io_utils.py
+++ b/application/backend/app/api/io_utils.py
@@ -5,7 +5,7 @@ from io import BytesIO
 from pathlib import Path
 
 from PIL.Image import Image
-from starlette.responses import FileResponse, StreamingResponse
+from starlette.responses import FileResponse, Response, StreamingResponse
 
 
 def file_iterator(filepath: Path, chunk_size: int = 1024 * 1024) -> Generator[bytes]:
@@ -32,14 +32,14 @@ def file_iterator(filepath: Path, chunk_size: int = 1024 * 1024) -> Generator[by
 
 
 def write_bytes_to_response(
-    bytes: BytesIO | Generator[bytes], filename: str, media_type: str | None = None, cache_control: str | None = None
-) -> StreamingResponse:
+    content: bytes | Generator[bytes], filename: str, media_type: str | None = None, cache_control: str | None = None
+) -> Response:
     """
     Stream a binary content to FastAPI StreamingResponse.
     Additionally, method sets file name, MIME type and cache control headers if provided,
 
     Args:
-        bytes: Binary content.
+        content: Binary content.
         filename: File name.
         media_type: Content MIME type, optional.
         cache_control: Cache control header, optional.
@@ -50,10 +50,12 @@ def write_bytes_to_response(
     headers = {"Content-Disposition": f"inline; filename={filename}"}
     if cache_control:
         headers["Cache-Control"] = cache_control
-    return StreamingResponse(bytes, media_type=media_type, headers=headers)
+    if isinstance(content, bytes):
+        return Response(content=content, media_type=media_type, headers=headers)
+    return StreamingResponse(content, media_type=media_type, headers=headers)
 
 
-def write_image_to_response(image: Image, filename: str, cache_control: str | None = None) -> StreamingResponse:
+def write_image_to_response(image: Image, filename: str, cache_control: str | None = None) -> Response:
     """
     Stream a Pillow image as JPEG to FastAPI StreamingResponse.
     Additionally, method sets file name and cache control headers if provided.
@@ -68,9 +70,8 @@ def write_image_to_response(image: Image, filename: str, cache_control: str | No
     """
     buffer = BytesIO()
     image.save(buffer, format="JPEG")
-    buffer.seek(0)
     return write_bytes_to_response(
-        bytes=buffer, filename=filename, media_type="image/jpeg", cache_control=cache_control
+        content=buffer.getvalue(), filename=filename, media_type="image/jpeg", cache_control=cache_control
     )
 
 

--- a/application/backend/app/api/io_utils.py
+++ b/application/backend/app/api/io_utils.py
@@ -35,7 +35,7 @@ def write_bytes_to_response(
     content: bytes | Generator[bytes], filename: str, media_type: str | None = None, cache_control: str | None = None
 ) -> Response:
     """
-    Stream a binary content to FastAPI StreamingResponse.
+    Stream a binary content to FastAPI response.
     Additionally, method sets file name, MIME type and cache control headers if provided,
 
     Args:
@@ -45,7 +45,7 @@ def write_bytes_to_response(
         cache_control: Cache control header, optional.
 
     Returns:
-        FastAPI StreamingResponse.
+        FastAPI Response if content is bytes, StreamingResponse otherwise.
     """
     headers = {"Content-Disposition": f"inline; filename={filename}"}
     if cache_control:
@@ -57,7 +57,7 @@ def write_bytes_to_response(
 
 def write_image_to_response(image: Image, filename: str, cache_control: str | None = None) -> Response:
     """
-    Stream a Pillow image as JPEG to FastAPI StreamingResponse.
+    Return a Pillow image as JPEG in a FastAPI response.
     Additionally, method sets file name and cache control headers if provided.
 
     Args:
@@ -66,7 +66,7 @@ def write_image_to_response(image: Image, filename: str, cache_control: str | No
         cache_control: Cache control header, optional.
 
     Returns:
-        FastAPI StreamingResponse.
+        FastAPI ``Response`` containing the JPEG-encoded image.
     """
     buffer = BytesIO()
     image.save(buffer, format="JPEG")

--- a/application/backend/app/api/routers/dataset_revisions.py
+++ b/application/backend/app/api/routers/dataset_revisions.py
@@ -4,7 +4,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
 from fastapi.openapi.models import Example
-from starlette.responses import FileResponse, StreamingResponse
+from starlette.responses import FileResponse, Response
 
 from app.api.dependencies import get_dataset_revision, get_dataset_revision_service, get_project
 from app.api.io_utils import write_file_to_response, write_image_to_response
@@ -208,7 +208,7 @@ def get_dataset_revision_item_thumbnail(
     dataset_revision: Annotated[DatasetRevision, Depends(get_dataset_revision)],
     dataset_item_id: DatasetItemID,
     dataset_revision_service: Annotated[DatasetRevisionService, Depends(get_dataset_revision_service)],
-) -> StreamingResponse:
+) -> Response:
     """Get the thumbnail of an item in the dataset revision"""
     thumbnail = dataset_revision_service.get_dataset_revision_item_thumbnail(
         project_id=project.id,

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -3,13 +3,12 @@
 
 import os
 from datetime import datetime
-from io import BytesIO
 from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, UploadFile, status
 from fastapi.openapi.models import Example
-from starlette.responses import FileResponse, StreamingResponse
+from starlette.responses import Response
 
 from app.api.dependencies import (
     get_dataset_service,
@@ -348,7 +347,7 @@ def get_media_binary(
     media: Annotated[Media | NotAnnotatedVideoFrame, Depends(_get_request_media)],
     media_service: Annotated[MediaService, Depends(get_media_service)],
     raw: Annotated[bool, Query(description="Return the original file without normalization")] = False,
-) -> StreamingResponse | FileResponse:
+) -> Response:
     """Get media binary content"""
     if isinstance(media, NotAnnotatedVideoFrame):
         frame_binary = media_service.get_frame_binary(
@@ -368,7 +367,7 @@ def get_media_binary(
         and needs_display_normalization(binary_path)
     ):
         png_bytes = normalize_image_to_png_bytes(binary_path)
-        return write_bytes_to_response(bytes=BytesIO(png_bytes), filename=f"{media.name}.png", media_type="image/png")
+        return write_bytes_to_response(content=png_bytes, filename=f"{media.name}.png", media_type="image/png")
 
     filename = f"{media.name}.{media.format.value.lower()}"
 
@@ -388,7 +387,7 @@ def get_media_thumbnail(
     project: Annotated[Project, Depends(get_project)],
     media: Annotated[Media | NotAnnotatedVideoFrame, Depends(_get_request_media)],
     media_service: Annotated[MediaService, Depends(get_media_service)],
-) -> StreamingResponse | FileResponse:
+) -> Response:
     """Get media thumbnail binary content"""
     if isinstance(media, NotAnnotatedVideoFrame):
         frame_thumbnail = media_service.get_frame_thumbnail(


### PR DESCRIPTION
Passing a `BytesIO` to `StreamingResponse` makes Starlette iterate it line-by-line, splitting binary data on every 0x0A byte into possibly thousands of tiny chunks that each incur async send overhead; sending the raw bytes via a plain Response instead delivers the payload in a single Content-Length-sized response, cutting transfer time.