### PR TITLE
feat: Add BoT-SORT tracker (appearance ReID + camera-motion compensation)

### DIFF
--- a/libraries/getitrack/Justfile
+++ b/libraries/getitrack/Justfile
@@ -17,7 +17,7 @@ _ensure_uv:
 # Create a virtual environment and install dependencies
 venv: _ensure_uv
     uv lock --check
-    uv sync --frozen
+    uv sync --frozen --all-extras
 
 # Generate or update the uv lock file
 venv-lock: _ensure_uv

--- a/libraries/getitrack/configs/botsort.yaml
+++ b/libraries/getitrack/configs/botsort.yaml
@@ -1,0 +1,42 @@
+# BoT-SORT sample configuration: ByteTrack association + appearance (ReID) + GMC.
+algorithm: botsort
+verbose: false
+# Detection filtering, applied before tracking.
+score_threshold: 0.1
+class_filter: null
+# Detection-to-track matching.
+match_threshold: 0.8
+high_score_threshold: 0.5
+match_class_only: true
+lifecycle:
+  max_age: 30
+  min_hits: 2
+  tentative_max_age: 0
+motion:
+  process_noise: 1.0
+  measurement_noise: 1.0
+  velocity_decay: 1.0
+# Appearance fusion: cosine appearance cost blended with IoU under a proximity gate.
+appearance_weight: 0.25
+appearance_iou_floor: 0.5
+gallery_size: 50
+appearance_threshold: 0.25
+use_ema: true
+ema_alpha: 0.9
+# ReID model. backend: torch runs the torchreid model natively; openvino runs an
+# IR auto-exported from it (or a prebuilt .xml when model_name is null).
+reid:
+  enabled: true
+  backend: torch
+  model_name: osnet_x1_0
+  model_path: null
+  device: CPU
+  input_size: [256, 128]
+  cache_dir: null
+# Camera-motion (global motion) compensation. Feed frames via
+# tracker.apply_camera_motion(frame) before each update.
+# method: sparse_opt_flow (default), ecc, orb, or sift.
+gmc:
+  enabled: true
+  method: sparse_opt_flow
+  downscale: 2

--- a/libraries/getitrack/pyproject.toml
+++ b/libraries/getitrack/pyproject.toml
@@ -39,6 +39,11 @@ reid = [
     "torch>=2.0",
     "torchvision>=0.15",
     "torchreid>=0.2.5",
+    # torchreid 0.2.5 imports gdown eagerly at package load and calls it to fetch
+    # pretrained weights, but declares it too loosely to lock. Its other eager
+    # import, torch.utils.tensorboard, is stubbed in _torchreid_compat so the
+    # training-only tensorboard package is not required for inference.
+    "gdown>=4.0",
 ]
 
 [dependency-groups]

--- a/libraries/getitrack/pyproject.toml
+++ b/libraries/getitrack/pyproject.toml
@@ -28,10 +28,27 @@ dependencies = [
     "scipy~=1.13",
 ]
 
+[project.optional-dependencies]
+# Appearance / ReID extra. The core library stays importable without it: the
+# providers import their backend (openvino / torch / torchreid) lazily, so this
+# stack is only required to actually run ReID embedding or export. torchreid
+# sources the models; torch runs them natively and openvino runs an IR exported
+# from them (or a prebuilt one).
+reid = [
+    "openvino>=2024.0",
+    "torch>=2.0",
+    "torchvision>=0.15",
+    "torchreid>=0.2.5",
+]
+
 [dependency-groups]
 dev = [
     "pytest~=9.0.3",
     "pytest-mock",
+    "openvino>=2024.0",
+    # torch is used only to export a tiny IR in the ReID provider test; the
+    # library itself never imports it, and the test skips when it is absent.
+    "torch>=2.0",
 ]
 
 lint = [

--- a/libraries/getitrack/pyproject.toml
+++ b/libraries/getitrack/pyproject.toml
@@ -45,10 +45,6 @@ reid = [
 dev = [
     "pytest~=9.0.3",
     "pytest-mock",
-    "openvino>=2024.0",
-    # torch is used only to export a tiny IR in the ReID provider test; the
-    # library itself never imports it, and the test skips when it is absent.
-    "torch>=2.0",
 ]
 
 lint = [

--- a/libraries/getitrack/scripts/botsort_reid_demo.py
+++ b/libraries/getitrack/scripts/botsort_reid_demo.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import logging
 import shutil
 import subprocess
 import time
@@ -35,6 +36,7 @@ from getitrack.algorithms.configs.botsort import BotSortConfig
 from getitrack.config import GMCConfig, GMCMethod, LifecycleConfig, ReIDBackend, ReIDConfig
 from getitrack.core.detection import Detections, TrackedDetections
 
+_LOGGER = logging.getLogger(__name__)
 _RESULTS_ROOT = Path(__file__).resolve().parents[1] / "results" / "botsort_reid_demo"
 
 
@@ -141,7 +143,7 @@ def run(args: argparse.Namespace) -> None:
         raw_path.unlink(missing_ok=True)
     else:
         final_path = raw_path
-        print("WARNING: ffmpeg not found or failed; leaving mp4v output (may not play in some viewers).")
+        _LOGGER.warning("ffmpeg not found or failed; leaving mp4v output (may not play in some viewers).")
 
     with (out_dir / "frames.csv").open("w", newline="") as handle:
         fieldnames = ["frame", "detections", "tracks", "warp_tx", "warp_ty"]

--- a/libraries/getitrack/scripts/botsort_reid_demo.py
+++ b/libraries/getitrack/scripts/botsort_reid_demo.py
@@ -1,0 +1,172 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end BoT-SORT demo: appearance (ReID) + camera-motion compensation.
+
+Runs BoT-SORT over a video and writes an annotated H.264 clip plus a run log.
+Detections come from OpenCV's built-in HOG people detector, so the only model
+weights needed are torchreid's (downloaded on first use). Use it to smoke both
+ReID backends and GMC on real footage::
+
+    python scripts/botsort_reid_demo.py --video clip.mp4 --backend torch --model-name osnet_x1_0
+    python scripts/botsort_reid_demo.py --video clip.mp4 --backend openvino --model-name osnet_x1_0 --no-gmc
+
+The torch backend runs the torchreid model natively; the openvino backend runs
+an IR auto-exported and cached from it. Install the extra first: ``pip install
+-e ".[reid]"``. H.264 output requires ``ffmpeg`` on PATH (falls back to mp4v with
+a warning otherwise).
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import shutil
+import subprocess
+import time
+from dataclasses import replace
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from getitrack.algorithms import BotSortTracker
+from getitrack.algorithms.configs.botsort import BotSortConfig
+from getitrack.config import GMCConfig, GMCMethod, LifecycleConfig, ReIDBackend, ReIDConfig
+from getitrack.core.detection import Detections
+
+_RESULTS_ROOT = Path(__file__).resolve().parents[1] / "results" / "botsort_reid_demo"
+
+
+def _palette(track_id: int) -> tuple[int, int, int]:
+    """Deterministic BGR colour per track id."""
+    rng = np.random.default_rng(track_id * 2654435761 % (2**32))
+    r, g, b = (int(c) for c in rng.integers(64, 256, size=3))
+    return (b, g, r)
+
+
+def _detect_people(hog: cv2.HOGDescriptor, frame: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Return ``(xyxy boxes, scores)`` for people detected by HOG in ``frame``."""
+    rects, weights = hog.detectMultiScale(frame, winStride=(8, 8), padding=(8, 8), scale=1.05)
+    if len(rects) == 0:
+        return np.empty((0, 4), dtype=np.float32), np.empty((0,), dtype=np.float32)
+    boxes = np.array([[x, y, x + w, y + h] for (x, y, w, h) in rects], dtype=np.float32)
+    scores = 1.0 / (1.0 + np.exp(-np.asarray(weights, dtype=np.float32).reshape(-1)))
+    return boxes, scores
+
+
+def _build_tracker(backend: str, model_name: str, *, use_gmc: bool) -> BotSortTracker:
+    reid = ReIDConfig(enabled=True, backend=ReIDBackend(backend), model_name=model_name)
+    gmc = GMCConfig(enabled=use_gmc, method=GMCMethod.SPARSE_OPT_FLOW)
+    config = BotSortConfig(reid=reid, gmc=gmc, lifecycle=LifecycleConfig(min_hits=2, max_age=30))
+    return BotSortTracker(config)
+
+
+def _transcode_h264(src: Path, dst: Path) -> bool:
+    """Transcode ``src`` to H.264 yuv420p ``dst`` with ffmpeg; return success."""
+    if shutil.which("ffmpeg") is None:
+        return False
+    cmd = ["ffmpeg", "-y", "-i", str(src), "-c:v", "libx264", "-pix_fmt", "yuv420p", str(dst)]
+    return subprocess.run(cmd, capture_output=True, check=False).returncode == 0  # noqa: S603  # fixed command
+
+
+def run(args: argparse.Namespace) -> None:
+    """Track the video with BoT-SORT and write the annotated clip plus the run log."""
+    out_dir = _RESULTS_ROOT / f"{args.backend}{'_gmc' if not args.no_gmc else ''}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    capture = cv2.VideoCapture(args.video)
+    if not capture.isOpened():
+        msg = f"could not open video: {args.video}"
+        raise SystemExit(msg)
+    fps = capture.get(cv2.CAP_PROP_FPS) or 30.0
+    width = int(capture.get(cv2.CAP_PROP_FRAME_WIDTH))
+    height = int(capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
+
+    hog = cv2.HOGDescriptor()
+    hog.setSVMDetector(cv2.HOGDescriptor_getDefaultPeopleDetector())
+    tracker = _build_tracker(args.backend, args.model_name, use_gmc=not args.no_gmc)
+
+    raw_path = out_dir / "annotated_raw.mp4"
+    writer = cv2.VideoWriter(str(raw_path), cv2.VideoWriter_fourcc(*"mp4v"), fps, (width, height))
+
+    rows: list[dict[str, object]] = []
+    frame_id = 0
+    started = time.perf_counter()
+    while True:
+        ok, frame = capture.read()
+        if not ok or (args.max_frames and frame_id >= args.max_frames):
+            break
+        boxes, scores = _detect_people(hog, frame)
+        dets = Detections(
+            bboxes=boxes,
+            scores=scores,
+            class_ids=np.zeros(len(boxes), dtype=np.int64),
+            frame_id=frame_id,
+        )
+        provider = tracker.reid_provider
+        if provider is not None and len(boxes) > 0:
+            dets = replace(dets, embeddings=provider.extract(frame, dets.bboxes))
+        warp = tracker.apply_camera_motion(frame)
+        tracked = tracker.update(dets)
+        for box, tid in zip(tracked.bboxes.astype(int), tracked.track_ids.tolist(), strict=True):
+            colour = _palette(tid)
+            cv2.rectangle(frame, (box[0], box[1]), (box[2], box[3]), colour, 2)
+            cv2.putText(frame, f"id {tid}", (box[0], box[1] - 6), cv2.FONT_HERSHEY_SIMPLEX, 0.6, colour, 2)
+        writer.write(frame)
+        rows.append(
+            {
+                "frame": frame_id,
+                "detections": len(boxes),
+                "tracks": len(tracked.track_ids),
+                "warp_tx": None if warp is None else round(float(warp[0, 2]), 3),
+                "warp_ty": None if warp is None else round(float(warp[1, 2]), 3),
+            }
+        )
+        frame_id += 1
+
+    capture.release()
+    writer.release()
+    elapsed = time.perf_counter() - started
+
+    final_path = out_dir / "annotated.mp4"
+    if _transcode_h264(raw_path, final_path):
+        raw_path.unlink(missing_ok=True)
+    else:
+        final_path = raw_path
+        print("WARNING: ffmpeg not found or failed; leaving mp4v output (may not play in some viewers).")
+
+    with (out_dir / "frames.csv").open("w", newline="") as handle:
+        fieldnames = ["frame", "detections", "tracks", "warp_tx", "warp_ty"]
+        csv_writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        csv_writer.writeheader()
+        csv_writer.writerows(rows)
+    summary = {
+        "video": args.video,
+        "backend": args.backend,
+        "model_name": args.model_name,
+        "gmc": not args.no_gmc,
+        "frames": frame_id,
+        "total_detections": sum(int(r["detections"]) for r in rows),
+        "max_track_id": max((int(r["tracks"]) for r in rows), default=0),
+        "elapsed_s": round(elapsed, 2),
+        "fps": round(frame_id / elapsed, 2) if elapsed > 0 else None,
+        "output_video": str(final_path),
+    }
+    (out_dir / "summary.json").write_text(json.dumps(summary, indent=2))
+    print(json.dumps(summary, indent=2))
+
+
+def main() -> None:
+    """Parse arguments and run the demo."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--video", required=True, help="Path to the input video.")
+    parser.add_argument("--backend", choices=["torch", "openvino"], default="torch", help="ReID inference backend.")
+    parser.add_argument("--model-name", default="osnet_x1_0", help="torchreid architecture name.")
+    parser.add_argument("--no-gmc", action="store_true", help="Disable camera-motion compensation.")
+    parser.add_argument("--max-frames", type=int, default=0, help="Process at most this many frames (0 = all).")
+    run(parser.parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/libraries/getitrack/scripts/botsort_reid_demo.py
+++ b/libraries/getitrack/scripts/botsort_reid_demo.py
@@ -33,7 +33,7 @@ import numpy as np
 from getitrack.algorithms import BotSortTracker
 from getitrack.algorithms.configs.botsort import BotSortConfig
 from getitrack.config import GMCConfig, GMCMethod, LifecycleConfig, ReIDBackend, ReIDConfig
-from getitrack.core.detection import Detections
+from getitrack.core.detection import Detections, TrackedDetections
 
 _RESULTS_ROOT = Path(__file__).resolve().parents[1] / "results" / "botsort_reid_demo"
 
@@ -45,14 +45,27 @@ def _palette(track_id: int) -> tuple[int, int, int]:
     return (b, g, r)
 
 
-def _detect_people(hog: cv2.HOGDescriptor, frame: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    """Return ``(xyxy boxes, scores)`` for people detected by HOG in ``frame``."""
+def _detect_people(hog: cv2.HOGDescriptor, frame: np.ndarray, frame_id: int) -> Detections:
+    """Detect people in ``frame`` with HOG and return them as `Detections`."""
     rects, weights = hog.detectMultiScale(frame, winStride=(8, 8), padding=(8, 8), scale=1.05)
     if len(rects) == 0:
-        return np.empty((0, 4), dtype=np.float32), np.empty((0,), dtype=np.float32)
+        return Detections.create_empty(frame_id=frame_id)
     boxes = np.array([[x, y, x + w, y + h] for (x, y, w, h) in rects], dtype=np.float32)
     scores = 1.0 / (1.0 + np.exp(-np.asarray(weights, dtype=np.float32).reshape(-1)))
-    return boxes, scores
+    return Detections(
+        bboxes=boxes,
+        scores=scores.astype(np.float32),
+        class_ids=np.zeros(len(boxes), dtype=np.int64),
+        frame_id=frame_id,
+    )
+
+
+def _draw_tracks(frame: np.ndarray, tracked: TrackedDetections) -> None:
+    """Draw each track's box and id onto ``frame`` in place."""
+    for box, tid in zip(tracked.bboxes.astype(int), tracked.track_ids.tolist(), strict=True):
+        colour = _palette(tid)
+        cv2.rectangle(frame, (box[0], box[1]), (box[2], box[3]), colour, 2)
+        cv2.putText(frame, f"id {tid}", (box[0], box[1] - 6), cv2.FONT_HERSHEY_SIMPLEX, 0.6, colour, 2)
 
 
 def _build_tracker(backend: str, model_name: str, *, use_gmc: bool) -> BotSortTracker:
@@ -97,27 +110,18 @@ def run(args: argparse.Namespace) -> None:
         ok, frame = capture.read()
         if not ok or (args.max_frames and frame_id >= args.max_frames):
             break
-        boxes, scores = _detect_people(hog, frame)
-        dets = Detections(
-            bboxes=boxes,
-            scores=scores,
-            class_ids=np.zeros(len(boxes), dtype=np.int64),
-            frame_id=frame_id,
-        )
+        dets = _detect_people(hog, frame, frame_id)
         provider = tracker.reid_provider
-        if provider is not None and len(boxes) > 0:
+        if provider is not None and len(dets.bboxes) > 0:
             dets = replace(dets, embeddings=provider.extract(frame, dets.bboxes))
         warp = tracker.apply_camera_motion(frame)
         tracked = tracker.update(dets)
-        for box, tid in zip(tracked.bboxes.astype(int), tracked.track_ids.tolist(), strict=True):
-            colour = _palette(tid)
-            cv2.rectangle(frame, (box[0], box[1]), (box[2], box[3]), colour, 2)
-            cv2.putText(frame, f"id {tid}", (box[0], box[1] - 6), cv2.FONT_HERSHEY_SIMPLEX, 0.6, colour, 2)
+        _draw_tracks(frame, tracked)
         writer.write(frame)
         rows.append(
             {
                 "frame": frame_id,
-                "detections": len(boxes),
+                "detections": len(dets.bboxes),
                 "tracks": len(tracked.track_ids),
                 "warp_tx": None if warp is None else round(float(warp[0, 2]), 3),
                 "warp_ty": None if warp is None else round(float(warp[1, 2]), 3),

--- a/libraries/getitrack/scripts/botsort_reid_demo.py
+++ b/libraries/getitrack/scripts/botsort_reid_demo.py
@@ -105,6 +105,7 @@ def run(args: argparse.Namespace) -> None:
 
     rows: list[dict[str, object]] = []
     frame_id = 0
+    max_track_id = 0
     started = time.perf_counter()
     while True:
         ok, frame = capture.read()
@@ -116,6 +117,8 @@ def run(args: argparse.Namespace) -> None:
             dets = replace(dets, embeddings=provider.extract(frame, dets.bboxes))
         warp = tracker.apply_camera_motion(frame)
         tracked = tracker.update(dets)
+        if len(tracked.track_ids) > 0:
+            max_track_id = max(max_track_id, int(tracked.track_ids.max()))
         _draw_tracks(frame, tracked)
         writer.write(frame)
         rows.append(
@@ -152,7 +155,8 @@ def run(args: argparse.Namespace) -> None:
         "gmc": not args.no_gmc,
         "frames": frame_id,
         "total_detections": sum(int(r["detections"]) for r in rows),
-        "max_track_id": max((int(r["tracks"]) for r in rows), default=0),
+        "max_track_id": max_track_id,
+        "max_active_tracks": max((int(r["tracks"]) for r in rows), default=0),
         "elapsed_s": round(elapsed, 2),
         "fps": round(frame_id / elapsed, 2) if elapsed > 0 else None,
         "output_video": str(final_path),

--- a/libraries/getitrack/src/getitrack/algorithms/__init__.py
+++ b/libraries/getitrack/src/getitrack/algorithms/__init__.py
@@ -7,8 +7,9 @@ Importing this package registers every algorithm into
 `BaseTracker.from_config` can dispatch by name without explicit wiring.
 """
 
+from getitrack.algorithms.botsort import BotSortTracker
 from getitrack.algorithms.bytetrack import ByteTrackTracker
 from getitrack.algorithms.ocsort import OCSortTracker
 from getitrack.algorithms.sort import SortTracker
 
-__all__ = ["ByteTrackTracker", "OCSortTracker", "SortTracker"]
+__all__ = ["BotSortTracker", "ByteTrackTracker", "OCSortTracker", "SortTracker"]

--- a/libraries/getitrack/src/getitrack/algorithms/botsort.py
+++ b/libraries/getitrack/src/getitrack/algorithms/botsort.py
@@ -1,0 +1,277 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""BoT-SORT: ByteTrack association augmented with appearance (ReID).
+
+BoT-SORT reuses ByteTrack's two-stage detection-to-track association and adds an
+appearance stage: each confirmed track keeps a bounded appearance gallery
+(`getitrack.reid.gallery.AppearanceGallery`), and the first association
+(confirmed tracks vs high-score detections, which includes recovering LOST
+tracks) fuses a cosine appearance cost with the IoU cost under an IoU proximity
+gate. This lets appearance disambiguate matches and recover identities across
+occlusions where geometry alone would fail, while the gate prevents appearance
+from rescuing non-overlapping boxes. The low-score second stage stays IoU-only,
+matching the reference.
+
+BoT-SORT's second contribution, camera-motion (global motion) compensation, is
+also here: when ``gmc`` is enabled the tracker warps its predicted track states
+by the estimated frame-to-frame camera motion before association, so tracks stay
+aligned under a moving camera. The caller feeds frames to the estimator via
+`BotSortTracker.apply_camera_motion` (kept off the `update` path so ``update``
+stays frame-agnostic).
+
+Appearance features come from ``Detections.embeddings``. Callers populate them
+directly, or via the ReID provider exposed as `BotSortTracker.reid_provider`
+when ``reid`` is configured (kept separate so ``update`` stays frame-agnostic).
+
+Reference: Aharon et al., "BoT-SORT: Robust Associations Multi-Pedestrian
+Tracking" (2022).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar, cast
+
+import numpy as np
+
+from getitrack.algorithms.bytetrack import ByteTrackTracker
+from getitrack.algorithms.configs.botsort import BotSortConfig
+from getitrack.core.registry import register_algorithm
+from getitrack.matching import fuse_appearance_cost, fuse_score, linear_assignment
+from getitrack.reid.gallery import AppearanceGallery
+from getitrack.utils import xyah_to_xyxy
+
+if TYPE_CHECKING:
+    from getitrack.config import LifecycleConfig
+    from getitrack.core.detection import Detections, TrackedDetections
+    from getitrack.motion.gmc import BaseMotionEstimator
+    from getitrack.reid.base import ReIDProvider
+
+
+@register_algorithm("botsort", config=BotSortConfig)
+class BotSortTracker(ByteTrackTracker):
+    """BoT-SORT multi-object tracker (ByteTrack + appearance gallery).
+
+    Maintains ByteTrack's Kalman + lifecycle state and, in parallel, one
+    `AppearanceGallery` per track keyed by track id. High-confidence matched
+    detections feed their descriptor into the gallery; the first association
+    fuses the resulting appearance cost with IoU.
+    """
+
+    algorithm_name: ClassVar[str] = "botsort"
+
+    def __init__(self, config: BotSortConfig) -> None:
+        super().__init__(config)
+        self._appearance: dict[int, AppearanceGallery] = {}
+        self._reid_provider: ReIDProvider | None = None
+        self._cmc: BaseMotionEstimator | None = None
+        self._pending_warp: np.ndarray | None = None
+
+    @property
+    def _cfg(self) -> BotSortConfig:
+        """Return the config under its BoT-SORT type.
+
+        The base tracker stores ``config`` under the wider ``ByteTrackConfig``
+        type; this narrows it so the appearance-specific fields resolve without
+        weakening the base annotation.
+        """
+        return cast("BotSortConfig", self.config)
+
+    def reset(self) -> None:
+        """Reset the base tracker, galleries, and camera-motion estimator state."""
+        super().reset()
+        self._appearance.clear()
+        self._pending_warp = None
+        if self._cmc is not None:
+            self._cmc.reset()
+
+    @property
+    def reid_provider(self) -> ReIDProvider | None:
+        """Lazily-built ReID provider from ``config.reid``, or None if disabled.
+
+        Callers use it to fill ``Detections.embeddings`` before `update`::
+
+            dets = replace(dets, embeddings=tracker.reid_provider.extract(frame, dets.bboxes))
+
+        Kept off the `update` path so the tracker itself never needs a frame.
+        The backend (torch / OpenVINO / torchreid) is imported only on first
+        access, via `build_reid_provider`.
+        """
+        if self._reid_provider is None and self._cfg.reid.enabled:
+            # Lazy import keeps the ReID backends optional dependencies.
+            from getitrack.reid.factory import build_reid_provider
+
+            self._reid_provider = build_reid_provider(self._cfg.reid)
+        return self._reid_provider
+
+    @property
+    def cmc(self) -> BaseMotionEstimator | None:
+        """Lazily-built camera-motion estimator from ``config.gmc``, or None if disabled."""
+        if self._cmc is None and self._cfg.gmc.enabled:
+            # Lazy import keeps the GMC estimators off the import path when unused.
+            from getitrack.motion.gmc import BaseMotionEstimator
+
+            self._cmc = BaseMotionEstimator.from_config(self._cfg.gmc)
+        return self._cmc
+
+    def apply_camera_motion(self, frame_bgr: np.ndarray) -> np.ndarray | None:
+        """Estimate camera motion from ``frame_bgr`` and stage it for the next `update`.
+
+        Call once per frame before `update` when GMC is enabled::
+
+            tracker.apply_camera_motion(frame)
+            out = tracker.update(dets)
+
+        The staged warp is consumed (and cleared) during the next `update`'s
+        prediction step. Returns the ``2x3`` affine, or None when GMC is disabled.
+        """
+        estimator = self.cmc
+        if estimator is None:
+            return None
+        self._pending_warp = estimator.estimate(frame_bgr)
+        return self._pending_warp
+
+    def _predict_all(self) -> None:
+        # Warp the just-predicted track states by the staged camera motion, so
+        # association sees boxes in the current frame. Runs between predict and
+        # associate; the warp is consumed once (a frame without a staged warp
+        # gets no compensation).
+        super()._predict_all()
+        if self._pending_warp is not None:
+            self._apply_cmc(self._pending_warp)
+            self._pending_warp = None
+
+    def _apply_cmc(self, warp: np.ndarray) -> None:
+        """Transform every Kalman state (mean and covariance) by the affine ``warp``.
+
+        Follows BoT-SORT: the ``2x2`` linear part is applied blockwise to the
+        8-D state via ``kron(I4, R)`` and to the covariance, and the translation
+        is added to the position. The aspect component is scaled along with it (a
+        harmless approximation for near-unit camera scale, corrected by the next
+        Kalman update); the refreshed boxes feed association.
+        """
+        if not self._kalman_states:
+            return
+        linear = warp[:2, :2]
+        translation = warp[:2, 2]
+        block = np.kron(np.eye(4, dtype=np.float32), linear)
+        tids = list(self._kalman_states)
+        for tid in tids:
+            mean, cov = self._kalman_states[tid]
+            mean = block @ mean
+            mean[:2] += translation
+            cov = block @ cov @ block.T
+            self._kalman_states[tid] = (mean, cov)
+        boxes = xyah_to_xyxy(np.stack([self._kalman_states[tid][0][:4] for tid in tids], axis=0)).astype(np.float32)
+        for i, tid in enumerate(tids):
+            self._tracks[tid].bbox = boxes[i]
+
+    def _update_impl(self, detections: Detections) -> TrackedDetections:
+        tracked = super()._update_impl(detections)
+        # Drop galleries of tracks the base tracker removed this frame.
+        for tid in set(self._appearance) - set(self._tracks):
+            del self._appearance[tid]
+        return tracked
+
+    def _associate(
+        self,
+        track_ids: list[int],
+        dets: Detections,
+        cost_limit: float,
+        *,
+        apply_fuse_score: bool,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Associate with IoU, appearance fusion (high stages), and class gating.
+
+        Mirrors `ByteTrackTracker._associate` but blends an appearance cost into
+        the IoU cost before score fusion. Appearance is applied only on the
+        high-score stages (``apply_fuse_score`` is set) and only when detection
+        embeddings and at least one non-empty gallery are available; the
+        low-score second stage stays IoU-only.
+        """
+        if not track_ids or len(dets) == 0:
+            return (
+                np.empty((0, 2), dtype=np.int64),
+                np.arange(len(track_ids), dtype=np.int64),
+                np.arange(len(dets), dtype=np.int64),
+            )
+        track_boxes = np.stack([self._tracks[tid].bbox for tid in track_ids], axis=0)
+        cost = self._distance(track_boxes, dets.bboxes)
+        if apply_fuse_score and dets.embeddings is not None:
+            appearance_cost = self._appearance_cost(track_ids, dets.embeddings)
+            if appearance_cost is not None:
+                cost = fuse_appearance_cost(
+                    cost,
+                    appearance_cost,
+                    appearance_weight=self._cfg.appearance_weight,
+                    iou_floor=self._cfg.appearance_iou_floor,
+                )
+        cls_mismatch: np.ndarray | None = None
+        if self._cfg.match_class_only:
+            track_classes = np.array([self._tracks[tid].class_id for tid in track_ids])
+            cls_mismatch = track_classes[:, None] != dets.class_ids[None, :]
+        if apply_fuse_score:
+            cost = fuse_score(cost, dets.scores)
+        if cls_mismatch is not None:
+            cost[cls_mismatch] = self._UNMATCHABLE_COST
+        return linear_assignment(cost, cost_limit)
+
+    def _appearance_cost(self, track_ids: list[int], det_embeddings: np.ndarray) -> np.ndarray | None:
+        """Build the ``(T, N)`` appearance cost, or None if no gallery is usable.
+
+        Tracks without a usable gallery get an all-``NaN`` row, which
+        `fuse_appearance_cost` treats as "no appearance information" and falls
+        back to IoU for that track.
+        """
+        n = det_embeddings.shape[0]
+        rows: list[np.ndarray] = []
+        usable = False
+        for tid in track_ids:
+            gallery = self._appearance.get(tid)
+            if gallery is None or gallery.is_empty:
+                rows.append(np.full((n,), np.nan, dtype=np.float32))
+            else:
+                rows.append(gallery.distance(det_embeddings))
+                usable = True
+        if not usable:
+            return None
+        return np.stack(rows, axis=0).astype(np.float32)
+
+    def _apply_hits(
+        self,
+        hits: list[tuple[int, int, int]],
+        dets: Detections,
+        lifecycle: LifecycleConfig,
+    ) -> None:
+        super()._apply_hits(hits, dets, lifecycle)
+        if dets.embeddings is None or not hits:
+            return
+        for tid, di, _ in hits:
+            score = float(dets.scores[di])
+            if score >= self._cfg.high_score_threshold:
+                self._admit(tid, dets.embeddings[di], score)
+
+    def _spawn(self, dets: Detections, det_idx: int, *, src_index: int) -> None:
+        # Coupling to BaseTracker._allocate_id's read-then-increment contract:
+        # it returns the current ``_next_id`` and then increments it, so the id
+        # this spawn assigns is exactly ``_next_id`` read *before* super() runs.
+        # Read it here to key the new track's gallery to the right detection.
+        # (Covered by the multi-spawn-in-one-frame test in test_botsort.py.)
+        new_id = self._next_id
+        super()._spawn(dets, det_idx, src_index=src_index)
+        if dets.embeddings is not None:
+            score = float(dets.scores[det_idx])
+            if score >= self._cfg.high_score_threshold:
+                self._admit(new_id, dets.embeddings[det_idx], score)
+
+    def _admit(self, track_id: int, feature: np.ndarray, score: float) -> None:
+        """Feed a matched detection's descriptor into the track's gallery."""
+        gallery = self._appearance.get(track_id)
+        if gallery is None:
+            gallery = AppearanceGallery(
+                gallery_size=self._cfg.gallery_size,
+                use_ema=self._cfg.use_ema,
+                ema_alpha=self._cfg.ema_alpha,
+                admission_threshold=self._cfg.appearance_threshold,
+            )
+            self._appearance[track_id] = gallery
+        gallery.update(feature, confidence=score)

--- a/libraries/getitrack/src/getitrack/algorithms/botsort.py
+++ b/libraries/getitrack/src/getitrack/algorithms/botsort.py
@@ -2,26 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 """BoT-SORT: ByteTrack association augmented with appearance (ReID).
 
-BoT-SORT reuses ByteTrack's two-stage detection-to-track association and adds an
-appearance stage: each confirmed track keeps a bounded appearance gallery
+Extends ByteTrack's two-stage detection-to-track association with an appearance
+stage. Each confirmed track keeps a bounded appearance gallery
 (`getitrack.reid.gallery.AppearanceGallery`), and the first association
-(confirmed tracks vs high-score detections, which includes recovering LOST
-tracks) fuses a cosine appearance cost with the IoU cost under an IoU proximity
-gate. This lets appearance disambiguate matches and recover identities across
-occlusions where geometry alone would fail, while the gate prevents appearance
-from rescuing non-overlapping boxes. The low-score second stage stays IoU-only,
-matching the reference.
+(confirmed tracks vs high-score detections, including recovering LOST tracks)
+fuses a cosine appearance cost with the IoU cost under an IoU proximity gate.
+The low-score second stage stays IoU-only.
 
-BoT-SORT's second contribution, camera-motion (global motion) compensation, is
-also here: when ``gmc`` is enabled the tracker warps its predicted track states
-by the estimated frame-to-frame camera motion before association, so tracks stay
-aligned under a moving camera. The caller feeds frames to the estimator via
-`BotSortTracker.apply_camera_motion` (kept off the `update` path so ``update``
-stays frame-agnostic).
+When ``gmc`` is enabled the tracker warps its predicted track states by the
+estimated frame-to-frame camera motion before association. The caller feeds
+frames to the estimator via `BotSortTracker.apply_camera_motion`.
 
-Appearance features come from ``Detections.embeddings``. Callers populate them
-directly, or via the ReID provider exposed as `BotSortTracker.reid_provider`
-when ``reid`` is configured (kept separate so ``update`` stays frame-agnostic).
+Appearance features come from ``Detections.embeddings``, populated directly or
+via the ReID provider exposed as `BotSortTracker.reid_provider` when ``reid`` is
+configured.
 
 Reference: Aharon et al., "BoT-SORT: Robust Associations Multi-Pedestrian
 Tracking" (2022).
@@ -51,8 +45,8 @@ if TYPE_CHECKING:
 class BotSortTracker(ByteTrackTracker):
     """BoT-SORT multi-object tracker (ByteTrack + appearance gallery).
 
-    Maintains ByteTrack's Kalman + lifecycle state and, in parallel, one
-    `AppearanceGallery` per track keyed by track id. High-confidence matched
+    Maintains ByteTrack's Kalman and lifecycle state alongside one
+    `AppearanceGallery` per track, keyed by track id. High-confidence matched
     detections feed their descriptor into the gallery; the first association
     fuses the resulting appearance cost with IoU.
     """
@@ -68,12 +62,7 @@ class BotSortTracker(ByteTrackTracker):
 
     @property
     def _cfg(self) -> BotSortConfig:
-        """Return the config under its BoT-SORT type.
-
-        The base tracker stores ``config`` under the wider ``ByteTrackConfig``
-        type; this narrows it so the appearance-specific fields resolve without
-        weakening the base annotation.
-        """
+        """Return ``config`` narrowed to the ``BotSortConfig`` type."""
         return cast("BotSortConfig", self.config)
 
     def reset(self) -> None:
@@ -88,16 +77,13 @@ class BotSortTracker(ByteTrackTracker):
     def reid_provider(self) -> ReIDProvider | None:
         """Lazily-built ReID provider from ``config.reid``, or None if disabled.
 
-        Callers use it to fill ``Detections.embeddings`` before `update`::
+        Fill ``Detections.embeddings`` before `update`::
 
             dets = replace(dets, embeddings=tracker.reid_provider.extract(frame, dets.bboxes))
 
-        Kept off the `update` path so the tracker itself never needs a frame.
-        The backend (torch / OpenVINO / torchreid) is imported only on first
-        access, via `build_reid_provider`.
+        The backend (torch / OpenVINO / torchreid) is imported on first access.
         """
         if self._reid_provider is None and self._cfg.reid.enabled:
-            # Lazy import keeps the ReID backends optional dependencies.
             from getitrack.reid.factory import build_reid_provider
 
             self._reid_provider = build_reid_provider(self._cfg.reid)
@@ -107,7 +93,6 @@ class BotSortTracker(ByteTrackTracker):
     def cmc(self) -> BaseMotionEstimator | None:
         """Lazily-built camera-motion estimator from ``config.gmc``, or None if disabled."""
         if self._cmc is None and self._cfg.gmc.enabled:
-            # Lazy import keeps the GMC estimators off the import path when unused.
             from getitrack.motion.gmc import BaseMotionEstimator
 
             self._cmc = BaseMotionEstimator.from_config(self._cfg.gmc)
@@ -121,7 +106,7 @@ class BotSortTracker(ByteTrackTracker):
             tracker.apply_camera_motion(frame)
             out = tracker.update(dets)
 
-        The staged warp is consumed (and cleared) during the next `update`'s
+        The staged warp is consumed and cleared during the next `update`'s
         prediction step. Returns the ``2x3`` affine, or None when GMC is disabled.
         """
         estimator = self.cmc
@@ -131,10 +116,9 @@ class BotSortTracker(ByteTrackTracker):
         return self._pending_warp
 
     def _predict_all(self) -> None:
-        # Warp the just-predicted track states by the staged camera motion, so
-        # association sees boxes in the current frame. Runs between predict and
-        # associate; the warp is consumed once (a frame without a staged warp
-        # gets no compensation).
+        # Warp the just-predicted track states by the staged camera motion.
+        # The warp is consumed once; a frame without a staged warp gets no
+        # compensation.
         super()._predict_all()
         if self._pending_warp is not None:
             self._apply_cmc(self._pending_warp)
@@ -143,11 +127,9 @@ class BotSortTracker(ByteTrackTracker):
     def _apply_cmc(self, warp: np.ndarray) -> None:
         """Transform every Kalman state (mean and covariance) by the affine ``warp``.
 
-        Follows BoT-SORT: the ``2x2`` linear part is applied blockwise to the
-        8-D state via ``kron(I4, R)`` and to the covariance, and the translation
-        is added to the position. The aspect component is scaled along with it (a
-        harmless approximation for near-unit camera scale, corrected by the next
-        Kalman update); the refreshed boxes feed association.
+        The ``2x2`` linear part is applied blockwise to the 8-D state via
+        ``kron(I4, R)`` and to the covariance; the translation is added to the
+        position. The aspect component is scaled along with the position.
         """
         if not self._kalman_states:
             return
@@ -251,11 +233,9 @@ class BotSortTracker(ByteTrackTracker):
                 self._admit(tid, dets.embeddings[di], score)
 
     def _spawn(self, dets: Detections, det_idx: int, *, src_index: int) -> None:
-        # Coupling to BaseTracker._allocate_id's read-then-increment contract:
-        # it returns the current ``_next_id`` and then increments it, so the id
-        # this spawn assigns is exactly ``_next_id`` read *before* super() runs.
-        # Read it here to key the new track's gallery to the right detection.
-        # (Covered by the multi-spawn-in-one-frame test in test_botsort.py.)
+        # BaseTracker._allocate_id returns the current ``_next_id`` then
+        # increments it, so the id this spawn assigns equals ``_next_id`` read
+        # before super() runs.
         new_id = self._next_id
         super()._spawn(dets, det_idx, src_index=src_index)
         if dets.embeddings is not None:

--- a/libraries/getitrack/src/getitrack/algorithms/botsort.py
+++ b/libraries/getitrack/src/getitrack/algorithms/botsort.py
@@ -127,21 +127,28 @@ class BotSortTracker(ByteTrackTracker):
     def _apply_cmc(self, warp: np.ndarray) -> None:
         """Transform every Kalman state (mean and covariance) by the affine ``warp``.
 
-        The ``2x2`` linear part is applied blockwise to the 8-D state via
-        ``kron(I4, R)`` and to the covariance; the translation is added to the
-        position. The aspect component is scaled along with the position.
+        The ``xyah`` state is mapped by an aspect-preserving Jacobian: position
+        ``(x, y)`` and velocity ``(vx, vy)`` are transformed by the ``2x2`` linear
+        part, height ``h`` and its velocity ``vh`` are scaled by ``sqrt(|det|)``,
+        and the aspect ratio ``a`` (and ``va``) is left unchanged. The translation
+        is added to the position afterwards.
         """
         if not self._kalman_states:
             return
-        linear = warp[:2, :2]
-        translation = warp[:2, 2]
-        block = np.kron(np.eye(4, dtype=np.float32), linear)
+        linear = np.asarray(warp[:2, :2], dtype=np.float64)
+        translation = np.asarray(warp[:2, 2], dtype=np.float64)
+        scale = float(np.sqrt(abs(np.linalg.det(linear))))
+        jacobian = np.eye(8, dtype=np.float64)
+        jacobian[:2, :2] = linear
+        jacobian[3, 3] = scale
+        jacobian[4:6, 4:6] = linear
+        jacobian[7, 7] = scale
         tids = list(self._kalman_states)
         for tid in tids:
             mean, cov = self._kalman_states[tid]
-            mean = block @ mean
+            mean = jacobian @ mean
             mean[:2] += translation
-            cov = block @ cov @ block.T
+            cov = jacobian @ cov @ jacobian.T
             self._kalman_states[tid] = (mean, cov)
         boxes = xyah_to_xyxy(np.stack([self._kalman_states[tid][0][:4] for tid in tids], axis=0)).astype(np.float32)
         for i, tid in enumerate(tids):

--- a/libraries/getitrack/src/getitrack/algorithms/configs/botsort.py
+++ b/libraries/getitrack/src/getitrack/algorithms/configs/botsort.py
@@ -1,0 +1,55 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Configuration model for the BoT-SORT tracker."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import Field
+
+from getitrack.algorithms.configs.bytetrack import ByteTrackConfig
+from getitrack.config import AlgorithmType, GMCConfig, ReIDConfig
+
+
+class BotSortConfig(ByteTrackConfig):
+    """BoT-SORT configuration.
+
+    Extends the ByteTrack parameter set with an appearance (ReID) stage: a
+    bounded per-track gallery, cosine appearance costs fused with IoU under an
+    IoU proximity gate, and an optional confidence-scaled EMA feature.
+    """
+
+    algorithm: Literal[AlgorithmType.BOTSORT] = AlgorithmType.BOTSORT  # pyrefly: ignore[bad-override]
+    """Algorithm identifier; fixed to ``botsort``."""
+
+    appearance_weight: Annotated[float, Field(ge=0.0, le=1.0)] = 0.25
+    """Weight of the appearance term when fusing appearance and IoU costs.
+    0 disables appearance influence; 1 matches on appearance alone (still
+    subject to the IoU proximity gate)."""
+
+    appearance_iou_floor: Annotated[float, Field(ge=0.0, le=1.0)] = 0.5
+    """Minimum IoU a track/detection pair must reach for appearance fusion to
+    apply. Pairs below it are gated out, so appearance cannot rescue
+    non-overlapping boxes."""
+
+    gallery_size: Annotated[int, Field(ge=1)] = 50
+    """Maximum descriptors retained in each track's FIFO appearance gallery."""
+
+    appearance_threshold: Annotated[float, Field(ge=0.0, le=2.0)] = 0.25
+    """Maximum cosine distance for a descriptor to be admitted into a track's
+    gallery. Larger admits more; guards the gallery against pollution."""
+
+    use_ema: bool = True
+    """Also query appearance against a running EMA descriptor, in addition to the
+    FIFO gallery entries."""
+
+    ema_alpha: Annotated[float, Field(gt=0.0, lt=1.0)] = 0.9
+    """EMA retention factor. Higher keeps more appearance history. The update is
+    ``ema = (1 - w) * ema + w * feature`` with ``w = (1 - ema_alpha) * score``."""
+
+    reid: ReIDConfig = Field(default_factory=ReIDConfig)
+    """ReID model enablement and path used to embed detections."""
+
+    gmc: GMCConfig = Field(default_factory=GMCConfig)
+    """Global motion compensation (camera-motion) parameters."""

--- a/libraries/getitrack/src/getitrack/algorithms/configs/botsort.py
+++ b/libraries/getitrack/src/getitrack/algorithms/configs/botsort.py
@@ -30,15 +30,14 @@ class BotSortConfig(ByteTrackConfig):
 
     appearance_iou_floor: Annotated[float, Field(ge=0.0, le=1.0)] = 0.5
     """Minimum IoU a track/detection pair must reach for appearance fusion to
-    apply. Pairs below it are gated out, so appearance cannot rescue
-    non-overlapping boxes."""
+    apply. Pairs below it use the IoU cost alone."""
 
     gallery_size: Annotated[int, Field(ge=1)] = 50
     """Maximum descriptors retained in each track's FIFO appearance gallery."""
 
     appearance_threshold: Annotated[float, Field(ge=0.0, le=2.0)] = 0.25
     """Maximum cosine distance for a descriptor to be admitted into a track's
-    gallery. Larger admits more; guards the gallery against pollution."""
+    gallery. Larger values admit more descriptors."""
 
     use_ema: bool = True
     """Also query appearance against a running EMA descriptor, in addition to the

--- a/libraries/getitrack/src/getitrack/config.py
+++ b/libraries/getitrack/src/getitrack/config.py
@@ -13,6 +13,7 @@ docstrings become schema ``description`` strings via ``use_attribute_docstrings`
 
 from __future__ import annotations
 
+import warnings
 from enum import StrEnum
 from pathlib import Path
 from typing import Annotated, Any
@@ -52,6 +53,26 @@ class DistanceMetric(StrEnum):
     GIOU = "giou"
     DIOU = "diou"
     CIOU = "ciou"
+
+
+class ReIDBackend(StrEnum):
+    """Inference backend used to run the appearance (ReID) model.
+
+    ``torch`` runs the torchreid model natively; ``openvino`` runs an OpenVINO IR,
+    either supplied directly or auto-exported from the torchreid model and cached.
+    """
+
+    OPENVINO = "openvino"
+    TORCH = "torch"
+
+
+class GMCMethod(StrEnum):
+    """Algorithm used to estimate frame-to-frame camera motion (GMC)."""
+
+    SPARSE_OPT_FLOW = "sparse_opt_flow"
+    ECC = "ecc"
+    ORB = "orb"
+    SIFT = "sift"
 
 
 class _StrictModel(BaseModel):
@@ -106,6 +127,89 @@ class InterpolationConfig(_StrictModel):
 
     online_buffer: Annotated[int, Field(ge=0)] = 0
     """Frames of lookahead permitted in online mode. 0 is strictly causal (zero latency)."""
+
+
+class ReIDConfig(_StrictModel):
+    """Appearance-model (ReID) parameters shared by appearance-aware trackers.
+
+    A ReID model is sourced either from torchreid (set ``model_name``) or as a
+    prebuilt OpenVINO IR (set ``model_path`` to a ``.xml`` with ``backend`` left
+    at ``openvino``). With ``model_name`` set, ``backend`` selects how it runs:
+    ``torch`` natively, or ``openvino`` via an IR auto-exported and cached from
+    the torchreid model. Kept in the shared config module so BoT-SORT and future
+    appearance trackers (Deep OC-SORT, StrongSORT) reuse the same section.
+    """
+
+    enabled: bool = False
+    """Enable appearance embedding via a ReID model. When false, callers may
+    still supply ``Detections.embeddings`` directly."""
+
+    backend: ReIDBackend = ReIDBackend.OPENVINO
+    """Inference backend for the ReID model (``openvino`` or ``torch``)."""
+
+    model_name: str | None = None
+    """torchreid architecture name (e.g. ``osnet_x1_0``). When set, the model is
+    built with torchreid; the ``torch`` backend runs it natively and the
+    ``openvino`` backend auto-exports it to a cached IR."""
+
+    model_path: Path | None = None
+    """Model weights location. With ``model_name`` set, an optional torchreid
+    ``.pth.tar`` checkpoint (torchreid downloads ImageNet-pretrained weights when
+    omitted). Without ``model_name``, a prebuilt OpenVINO IR ``.xml`` to run
+    directly."""
+
+    device: str = "CPU"
+    """Device the model runs on. OpenVINO device string (e.g. ``CPU``, ``GPU``)
+    for the OpenVINO backend; mapped to ``cpu``/``cuda`` for the torch backend."""
+
+    input_size: tuple[int, int] = (256, 128)
+    """ReID model input ``(height, width)`` in pixels (OSNet default 256x128)."""
+
+    cache_dir: Path | None = None
+    """Directory for IRs auto-exported from a torchreid model on the openvino
+    backend. Defaults to ``~/.cache/getitrack/reid`` when omitted."""
+
+    @model_validator(mode="after")
+    def _warn_enabled_without_model(self) -> ReIDConfig:
+        """Warn when ReID is enabled but no model source is configured.
+
+        Supplying ``Detections.embeddings`` directly is valid, so this is a
+        warning rather than an error; it catches the common misconfiguration
+        where a user enables ReID yet the tracker silently falls back to IoU-only
+        for want of a model.
+        """
+        if self.enabled and self.model_name is None and self.model_path is None:
+            warnings.warn(
+                "ReIDConfig.enabled is True but neither model_name nor model_path "
+                "is set; no ReID model will be built. Supply Detections.embeddings "
+                "directly, or set model_name (torchreid) or model_path (IR) to "
+                "embed detections automatically.",
+                UserWarning,
+                stacklevel=2,
+            )
+        return self
+
+
+class GMCConfig(_StrictModel):
+    """Global motion compensation (camera-motion) parameters.
+
+    When enabled, an appearance-aware tracker estimates the affine camera motion
+    between consecutive frames and warps its predicted track states by it before
+    association, so tracks stay aligned under a moving camera (BoT-SORT's GMC).
+    Kept in the shared config module so BoT-SORT and future appearance trackers
+    (Deep OC-SORT, StrongSORT) reuse the same section.
+    """
+
+    enabled: bool = False
+    """Enable camera-motion compensation. The caller must feed frames to the
+    tracker's estimator (e.g. ``tracker.apply_camera_motion(frame)``) each frame."""
+
+    method: GMCMethod = GMCMethod.SPARSE_OPT_FLOW
+    """Motion-estimation algorithm (BoT-SORT defaults to sparse optical flow)."""
+
+    downscale: Annotated[int, Field(ge=1)] = 2
+    """Integer factor the frame is downscaled by before estimation, trading
+    accuracy for speed. 1 disables downscaling."""
 
 
 class TrackerConfig(_StrictModel):

--- a/libraries/getitrack/src/getitrack/config.py
+++ b/libraries/getitrack/src/getitrack/config.py
@@ -161,7 +161,7 @@ class ReIDConfig(_StrictModel):
     """Device the model runs on. OpenVINO device string (e.g. ``CPU``, ``GPU``)
     for the OpenVINO backend; mapped to ``cpu``/``cuda`` for the torch backend."""
 
-    input_size: tuple[int, int] = (256, 128)
+    input_size: tuple[Annotated[int, Field(gt=0)], Annotated[int, Field(gt=0)]] = (256, 128)
     """ReID model input ``(height, width)`` in pixels (OSNet default 256x128)."""
 
     cache_dir: Path | None = None

--- a/libraries/getitrack/src/getitrack/config.py
+++ b/libraries/getitrack/src/getitrack/config.py
@@ -136,8 +136,7 @@ class ReIDConfig(_StrictModel):
     prebuilt OpenVINO IR (set ``model_path`` to a ``.xml`` with ``backend`` left
     at ``openvino``). With ``model_name`` set, ``backend`` selects how it runs:
     ``torch`` natively, or ``openvino`` via an IR auto-exported and cached from
-    the torchreid model. Kept in the shared config module so BoT-SORT and future
-    appearance trackers (Deep OC-SORT, StrongSORT) reuse the same section.
+    the torchreid model.
     """
 
     enabled: bool = False
@@ -171,13 +170,7 @@ class ReIDConfig(_StrictModel):
 
     @model_validator(mode="after")
     def _warn_enabled_without_model(self) -> ReIDConfig:
-        """Warn when ReID is enabled but no model source is configured.
-
-        Supplying ``Detections.embeddings`` directly is valid, so this is a
-        warning rather than an error; it catches the common misconfiguration
-        where a user enables ReID yet the tracker silently falls back to IoU-only
-        for want of a model.
-        """
+        """Warn when ReID is enabled but no model source is configured."""
         if self.enabled and self.model_name is None and self.model_path is None:
             warnings.warn(
                 "ReIDConfig.enabled is True but neither model_name nor model_path "
@@ -195,9 +188,7 @@ class GMCConfig(_StrictModel):
 
     When enabled, an appearance-aware tracker estimates the affine camera motion
     between consecutive frames and warps its predicted track states by it before
-    association, so tracks stay aligned under a moving camera (BoT-SORT's GMC).
-    Kept in the shared config module so BoT-SORT and future appearance trackers
-    (Deep OC-SORT, StrongSORT) reuse the same section.
+    association (BoT-SORT's GMC).
     """
 
     enabled: bool = False
@@ -208,8 +199,8 @@ class GMCConfig(_StrictModel):
     """Motion-estimation algorithm (BoT-SORT defaults to sparse optical flow)."""
 
     downscale: Annotated[int, Field(ge=1)] = 2
-    """Integer factor the frame is downscaled by before estimation, trading
-    accuracy for speed. 1 disables downscaling."""
+    """Integer factor the frame is downscaled by before estimation. 1 disables
+    downscaling."""
 
 
 class TrackerConfig(_StrictModel):

--- a/libraries/getitrack/src/getitrack/matching/__init__.py
+++ b/libraries/getitrack/src/getitrack/matching/__init__.py
@@ -1,7 +1,12 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-"""Detection-to-track association: IoU-family distance metrics and assignment."""
+"""Detection-to-track association: distance metrics, appearance, and assignment."""
 
+from getitrack.matching.appearance import (
+    cosine_distance,
+    fuse_appearance_cost,
+    l2_normalize,
+)
 from getitrack.matching.assignment import fuse_score, linear_assignment
 from getitrack.matching.distance import (
     BaseDistanceMetric,
@@ -18,7 +23,10 @@ __all__ = [
     "DIoUDistance",
     "GIoUDistance",
     "IoUDistance",
+    "cosine_distance",
+    "fuse_appearance_cost",
     "fuse_score",
     "iou_matrix",
+    "l2_normalize",
     "linear_assignment",
 ]

--- a/libraries/getitrack/src/getitrack/matching/appearance.py
+++ b/libraries/getitrack/src/getitrack/matching/appearance.py
@@ -1,0 +1,104 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Appearance (ReID) cost computation and IoU-gated fusion.
+
+These helpers are tracker-agnostic: they operate on plain numpy feature
+matrices and cost matrices so any appearance-aware tracker (BoT-SORT, Deep
+OC-SORT, StrongSORT) can reuse them.
+
+Features are assumed L2-normalised row vectors; `cosine_distance` renormalises
+defensively, so an unnormalised input still yields a valid cosine distance.
+`fuse_appearance_cost` blends an IoU cost with an appearance cost and gates the
+result by an IoU floor, so appearance can never rescue a pair whose boxes do
+not overlap enough.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+_EPS = 1e-12
+
+
+def l2_normalize(features: np.ndarray) -> np.ndarray:
+    """Return ``features`` scaled to unit L2 norm along the last axis.
+
+    Args:
+        features: ``(..., D)`` float array. A ``(D,)`` vector or an ``(N, D)``
+            batch are both accepted.
+
+    Returns:
+        A float32 array of the same shape with each row rescaled to unit norm.
+        Zero rows are left at zero (division is floored by a small epsilon).
+    """
+    arr = np.asarray(features, dtype=np.float32)
+    norms = np.linalg.norm(arr, axis=-1, keepdims=True)
+    return (arr / np.maximum(norms, _EPS)).astype(np.float32)
+
+
+def cosine_distance(features_a: np.ndarray, features_b: np.ndarray) -> np.ndarray:
+    """Compute pairwise cosine distance between two feature sets.
+
+    Cosine distance is ``1 - cosine_similarity``. For L2-normalised inputs this
+    lands in ``[0, 2]``: ``~0`` for identical direction, ``~1`` for orthogonal
+    vectors, and ``~2`` for opposite vectors. The result is clipped to
+    ``[0, 2]`` to absorb floating-point overshoot.
+
+    Args:
+        features_a: ``(M, D)`` float array of query features.
+        features_b: ``(N, D)`` float array of gallery features.
+
+    Returns:
+        ``(M, N)`` float32 cosine-distance matrix.
+    """
+    m, n = features_a.shape[0], features_b.shape[0]
+    if m == 0 or n == 0:
+        return np.zeros((m, n), dtype=np.float32)
+    a = l2_normalize(features_a)
+    b = l2_normalize(features_b)
+    similarity = a @ b.T
+    return np.clip(1.0 - similarity, 0.0, 2.0).astype(np.float32)
+
+
+def fuse_appearance_cost(
+    iou_cost: np.ndarray,
+    appearance_cost: np.ndarray,
+    *,
+    appearance_weight: float,
+    iou_floor: float,
+) -> np.ndarray:
+    """Blend an IoU cost with an appearance cost, gated by IoU proximity.
+
+    The appearance term is applied only where it is trustworthy: the pair's IoU
+    (``1 - iou_cost``) is at or above ``iou_floor`` **and** the appearance cost
+    is present (not ``NaN``). There the fused cost is the convex combination
+    ``(1 - appearance_weight) * iou_cost + appearance_weight * appearance_cost``,
+    which lowers the cost when appearance agrees and raises it when appearance
+    disagrees, letting appearance disambiguate competing matches.
+
+    Everywhere else, the cell falls back to the **plain** ``iou_cost``. The gate
+    only ever *removes the appearance contribution*; it never writes an
+    unmatchable sentinel. This preserves a key invariant for every appearance
+    tracker built on this layer (BoT-SORT, Deep OC-SORT, StrongSORT): appearance
+    can only help. A pair that IoU alone would match is never made unmatchable by
+    appearance, so an appearance tracker is never stricter on geometry than its
+    IoU-only baseline (e.g. a same-identity track reappearing at moderate overlap
+    below the floor is still recovered on IoU).
+
+    Args:
+        iou_cost: ``(T, N)`` IoU cost matrix (``1 - IoU``).
+        appearance_cost: ``(T, N)`` appearance cost matrix, optionally holding
+            ``NaN`` for tracks without gallery features.
+        appearance_weight: Weight in ``[0, 1]`` given to the appearance term.
+        iou_floor: Minimum IoU a pair must reach for appearance to be fused in.
+
+    Returns:
+        ``(T, N)`` float32 fused cost matrix.
+    """
+    if iou_cost.size == 0:
+        return iou_cost.astype(np.float32, copy=False)
+    weight = float(appearance_weight)
+    blended = (1.0 - weight) * iou_cost + weight * appearance_cost
+    iou = 1.0 - iou_cost
+    use_appearance = (iou >= iou_floor) & ~np.isnan(appearance_cost)
+    return np.where(use_appearance, blended, iou_cost).astype(np.float32)

--- a/libraries/getitrack/src/getitrack/matching/appearance.py
+++ b/libraries/getitrack/src/getitrack/matching/appearance.py
@@ -2,15 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 """Appearance (ReID) cost computation and IoU-gated fusion.
 
-Operate on plain numpy feature and cost matrices. Features are assumed
-L2-normalised row vectors; `cosine_distance` renormalises defensively.
-`fuse_appearance_cost` blends an IoU cost with an appearance cost and gates the
-result by an IoU floor.
+Operate on plain numpy feature and cost matrices. `cosine_distance` returns the
+pairwise cosine-distance matrix; `fuse_appearance_cost` blends an IoU cost with an
+appearance cost and gates the result by an IoU floor.
 """
 
 from __future__ import annotations
 
 import numpy as np
+from scipy.spatial.distance import cdist
 
 _EPS = 1e-12
 
@@ -49,10 +49,7 @@ def cosine_distance(features_a: np.ndarray, features_b: np.ndarray) -> np.ndarra
     m, n = features_a.shape[0], features_b.shape[0]
     if m == 0 or n == 0:
         return np.zeros((m, n), dtype=np.float32)
-    a = l2_normalize(features_a)
-    b = l2_normalize(features_b)
-    similarity = a @ b.T
-    return np.clip(1.0 - similarity, 0.0, 2.0).astype(np.float32)
+    return np.clip(cdist(features_a, features_b, metric="cosine"), 0.0, 2.0).astype(np.float32)
 
 
 def fuse_appearance_cost(

--- a/libraries/getitrack/src/getitrack/matching/appearance.py
+++ b/libraries/getitrack/src/getitrack/matching/appearance.py
@@ -2,15 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Appearance (ReID) cost computation and IoU-gated fusion.
 
-These helpers are tracker-agnostic: they operate on plain numpy feature
-matrices and cost matrices so any appearance-aware tracker (BoT-SORT, Deep
-OC-SORT, StrongSORT) can reuse them.
-
-Features are assumed L2-normalised row vectors; `cosine_distance` renormalises
-defensively, so an unnormalised input still yields a valid cosine distance.
+Operate on plain numpy feature and cost matrices. Features are assumed
+L2-normalised row vectors; `cosine_distance` renormalises defensively.
 `fuse_appearance_cost` blends an IoU cost with an appearance cost and gates the
-result by an IoU floor, so appearance can never rescue a pair whose boxes do
-not overlap enough.
+result by an IoU floor.
 """
 
 from __future__ import annotations
@@ -69,21 +64,12 @@ def fuse_appearance_cost(
 ) -> np.ndarray:
     """Blend an IoU cost with an appearance cost, gated by IoU proximity.
 
-    The appearance term is applied only where it is trustworthy: the pair's IoU
-    (``1 - iou_cost``) is at or above ``iou_floor`` **and** the appearance cost
-    is present (not ``NaN``). There the fused cost is the convex combination
-    ``(1 - appearance_weight) * iou_cost + appearance_weight * appearance_cost``,
-    which lowers the cost when appearance agrees and raises it when appearance
-    disagrees, letting appearance disambiguate competing matches.
-
-    Everywhere else, the cell falls back to the **plain** ``iou_cost``. The gate
-    only ever *removes the appearance contribution*; it never writes an
-    unmatchable sentinel. This preserves a key invariant for every appearance
-    tracker built on this layer (BoT-SORT, Deep OC-SORT, StrongSORT): appearance
-    can only help. A pair that IoU alone would match is never made unmatchable by
-    appearance, so an appearance tracker is never stricter on geometry than its
-    IoU-only baseline (e.g. a same-identity track reappearing at moderate overlap
-    below the floor is still recovered on IoU).
+    The appearance term is applied only where the pair's IoU (``1 - iou_cost``)
+    is at or above ``iou_floor`` and the appearance cost is present (not
+    ``NaN``). There the fused cost is the convex combination
+    ``(1 - appearance_weight) * iou_cost + appearance_weight * appearance_cost``.
+    Every other cell falls back to the plain ``iou_cost``; the gate never writes
+    an unmatchable sentinel.
 
     Args:
         iou_cost: ``(T, N)`` IoU cost matrix (``1 - IoU``).

--- a/libraries/getitrack/src/getitrack/matching/appearance.py
+++ b/libraries/getitrack/src/getitrack/matching/appearance.py
@@ -65,8 +65,10 @@ def fuse_appearance_cost(
     is at or above ``iou_floor`` and the appearance cost is present (not
     ``NaN``). There the fused cost is the convex combination
     ``(1 - appearance_weight) * iou_cost + appearance_weight * appearance_cost``.
-    Every other cell falls back to the plain ``iou_cost``; the gate never writes
-    an unmatchable sentinel.
+    Every other cell falls back to the plain ``iou_cost``, so appearance never
+    rescues a below-floor (low-overlap) pair. Above the floor a disagreeing
+    appearance raises the fused cost and can reject a pair that IoU alone would
+    match; the gate itself never writes an unmatchable sentinel.
 
     Args:
         iou_cost: ``(T, N)`` IoU cost matrix (``1 - IoU``).

--- a/libraries/getitrack/src/getitrack/motion/gmc/__init__.py
+++ b/libraries/getitrack/src/getitrack/motion/gmc/__init__.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Global motion compensation estimators.
+
+Importing the package registers every estimator with `BaseMotionEstimator`, so
+`BaseMotionEstimator.from_config` can build any of them by `GMCMethod`.
+"""
+
+from getitrack.motion.gmc.base import BaseMotionEstimator
+from getitrack.motion.gmc.ecc import ECCEstimator
+from getitrack.motion.gmc.features import FeatureMatchingEstimator
+from getitrack.motion.gmc.orb import ORBEstimator
+from getitrack.motion.gmc.sift import SIFTEstimator
+from getitrack.motion.gmc.sparse_optflow import SparseOptFlowEstimator
+
+__all__ = [
+    "BaseMotionEstimator",
+    "ECCEstimator",
+    "FeatureMatchingEstimator",
+    "ORBEstimator",
+    "SIFTEstimator",
+    "SparseOptFlowEstimator",
+]

--- a/libraries/getitrack/src/getitrack/motion/gmc/base.py
+++ b/libraries/getitrack/src/getitrack/motion/gmc/base.py
@@ -72,19 +72,25 @@ class BaseMotionEstimator(ABC):
         there is no previous frame to compare against.
         """
         gray = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2GRAY)
+        scale_x = scale_y = 1.0
         if self._downscale > 1:
             height, width = gray.shape[:2]
-            gray = cv2.resize(gray, (width // self._downscale, height // self._downscale))
+            # Clamp to at least one pixel so a large downscale on a small frame
+            # never produces a zero resize dimension.
+            resized_width = max(1, width // self._downscale)
+            resized_height = max(1, height // self._downscale)
+            scale_x = width / resized_width
+            scale_y = height / resized_height
+            gray = cv2.resize(gray, (resized_width, resized_height))
         if self._prev_gray is None:
             self._prev_gray = gray
             return _IDENTITY.copy()
         warp = self._estimate(self._prev_gray, gray)
         self._prev_gray = gray
-        if self._downscale > 1:
-            # Rotation/scale is downscale-invariant; only translation must be
-            # rescaled back to full-resolution pixels.
-            warp[0, 2] *= self._downscale
-            warp[1, 2] *= self._downscale
+        # Rotation/scale is downscale-invariant; only translation must be rescaled
+        # back to full-resolution pixels, using the actual per-axis resize ratios.
+        warp[0, 2] *= scale_x
+        warp[1, 2] *= scale_y
         return warp
 
     @abstractmethod

--- a/libraries/getitrack/src/getitrack/motion/gmc/base.py
+++ b/libraries/getitrack/src/getitrack/motion/gmc/base.py
@@ -1,0 +1,92 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Global motion compensation (GMC): frame-to-frame camera-motion estimation.
+
+`BaseMotionEstimator` owns the machinery shared by every method: grayscale
+conversion, optional downscaling, previous-frame caching, and rescaling the
+estimated translation back to full resolution. Subclasses implement only
+`_estimate`, the affine fit between two grayscale frames, and register
+themselves under a `GMCMethod` via the subclass hook so `from_config` can build
+them by name.
+
+The estimate is a ``2x3`` partial-affine (similarity) matrix mapping the previous
+frame onto the current one, in the convention consumed by BoT-SORT's state warp.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, ClassVar
+
+import cv2
+import numpy as np
+
+if TYPE_CHECKING:
+    from getitrack.config import GMCConfig, GMCMethod
+
+_IDENTITY = np.eye(2, 3, dtype=np.float32)
+
+
+class BaseMotionEstimator(ABC):
+    """Estimate the affine camera motion between consecutive frames.
+
+    Concrete estimators set the ``method`` ClassVar and implement `_estimate`.
+    Instances are stateful: each `estimate` call caches the frame for the next
+    call, so a fresh estimator (or `reset`) is needed per sequence.
+    """
+
+    method: ClassVar[GMCMethod]
+    _REGISTRY: ClassVar[dict[GMCMethod, type[BaseMotionEstimator]]] = {}
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+        # Register only leaf estimators that set a concrete ``method``; abstract
+        # intermediates (e.g. the shared feature-matching base) define none.
+        method = cls.__dict__.get("method")
+        if method is not None:
+            BaseMotionEstimator._REGISTRY[method] = cls
+
+    def __init__(self, *, downscale: int = 2) -> None:
+        """Initialise with the frame downscale factor (>= 1)."""
+        self._downscale = max(1, int(downscale))
+        self._prev_gray: np.ndarray | None = None
+
+    @classmethod
+    def from_config(cls, config: GMCConfig) -> BaseMotionEstimator:
+        """Build the estimator selected by ``config.method``."""
+        estimator_cls = cls._REGISTRY.get(config.method)
+        if estimator_cls is None:
+            known = sorted(m.value for m in cls._REGISTRY)
+            msg = f"no GMC estimator registered for method {config.method!r}; known: {known}"
+            raise ValueError(msg)
+        return estimator_cls(downscale=config.downscale)
+
+    def reset(self) -> None:
+        """Forget the cached previous frame, so the next estimate is identity."""
+        self._prev_gray = None
+
+    def estimate(self, frame_bgr: np.ndarray) -> np.ndarray:
+        """Return the ``2x3`` affine mapping the previous frame onto this one.
+
+        The first call (or the first after `reset`) returns the identity, since
+        there is no previous frame to compare against.
+        """
+        gray = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2GRAY)
+        if self._downscale > 1:
+            height, width = gray.shape[:2]
+            gray = cv2.resize(gray, (width // self._downscale, height // self._downscale))
+        if self._prev_gray is None:
+            self._prev_gray = gray
+            return _IDENTITY.copy()
+        warp = self._estimate(self._prev_gray, gray)
+        self._prev_gray = gray
+        if self._downscale > 1:
+            # Rotation/scale is downscale-invariant; only translation must be
+            # rescaled back to full-resolution pixels.
+            warp[0, 2] *= self._downscale
+            warp[1, 2] *= self._downscale
+        return warp
+
+    @abstractmethod
+    def _estimate(self, prev_gray: np.ndarray, curr_gray: np.ndarray) -> np.ndarray:
+        """Fit the ``2x3`` affine from ``prev_gray`` to ``curr_gray`` (downscaled)."""

--- a/libraries/getitrack/src/getitrack/motion/gmc/ecc.py
+++ b/libraries/getitrack/src/getitrack/motion/gmc/ecc.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""ECC (Enhanced Correlation Coefficient) camera-motion estimator.
+
+Estimates a Euclidean (rotation + translation) warp by directly maximising the
+image correlation, as used by StrongSORT. Denser and more robust than feature
+matching on low-texture frames, but slower; it can fail to converge, in which
+case the estimate falls back to identity.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import cv2
+import numpy as np
+
+from getitrack.config import GMCMethod
+from getitrack.motion.gmc.base import BaseMotionEstimator
+
+_IDENTITY = np.eye(2, 3, dtype=np.float32)
+_MAX_ITERATIONS = 100
+_TERMINATION_EPS = 1e-6
+
+
+class ECCEstimator(BaseMotionEstimator):
+    """Fit a Euclidean warp by maximising the enhanced correlation coefficient."""
+
+    method: ClassVar[GMCMethod] = GMCMethod.ECC
+
+    def _estimate(self, prev_gray: np.ndarray, curr_gray: np.ndarray) -> np.ndarray:
+        warp = np.eye(2, 3, dtype=np.float32)
+        criteria = (
+            cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT,
+            _MAX_ITERATIONS,
+            _TERMINATION_EPS,
+        )
+        try:
+            _, warp = cv2.findTransformECC(prev_gray, curr_gray, warp, cv2.MOTION_EUCLIDEAN, criteria, None)
+        except cv2.error:
+            return _IDENTITY.copy()
+        return warp.astype(np.float32)

--- a/libraries/getitrack/src/getitrack/motion/gmc/ecc.py
+++ b/libraries/getitrack/src/getitrack/motion/gmc/ecc.py
@@ -2,10 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """ECC (Enhanced Correlation Coefficient) camera-motion estimator.
 
-Estimates a Euclidean (rotation + translation) warp by directly maximising the
-image correlation, as used by StrongSORT. Denser and more robust than feature
-matching on low-texture frames, but slower; it can fail to converge, in which
-case the estimate falls back to identity.
+Estimates a Euclidean (rotation + translation) warp by maximising the image
+correlation. Falls back to identity when the optimisation fails to converge.
 """
 
 from __future__ import annotations

--- a/libraries/getitrack/src/getitrack/motion/gmc/features.py
+++ b/libraries/getitrack/src/getitrack/motion/gmc/features.py
@@ -44,7 +44,7 @@ class FeatureMatchingEstimator(BaseMotionEstimator):
         """Return the ``(detector, extractor, matcher)`` OpenCV objects for this method."""
 
     def _border_mask(self, gray: np.ndarray) -> np.ndarray:
-        """A mask that excludes a small border, where keypoints are least reliable."""
+        """Return a mask that excludes a small border around each edge."""
         height, width = gray.shape[:2]
         mask = np.zeros_like(gray)
         y0, y1 = int(self._BORDER_FRACTION * height), int((1 - self._BORDER_FRACTION) * height)
@@ -85,9 +85,9 @@ class FeatureMatchingEstimator(BaseMotionEstimator):
         if len(matches) < self._MIN_MATCHES:
             return _IDENTITY.copy()
 
-        # Keep displacements close to the mean (abs distance, unlike the reference
-        # which only filters positive deviations); the epsilon admits a pure,
-        # noise-free translation, where the standard deviation is zero.
+        # Keep displacements within _INLIER_STD standard deviations of the mean
+        # (absolute distance). The epsilon admits a pure translation, where the
+        # standard deviation is zero.
         deltas = np.array(displacements)
         inliers = np.abs(deltas - deltas.mean(axis=0)) < self._INLIER_STD * deltas.std(axis=0) + 1e-6
         prev_pts = np.array(

--- a/libraries/getitrack/src/getitrack/motion/gmc/features.py
+++ b/libraries/getitrack/src/getitrack/motion/gmc/features.py
@@ -1,0 +1,104 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Shared feature-matching camera-motion pipeline for ORB and SIFT.
+
+`FeatureMatchingEstimator` holds the pipeline both descriptor-based methods
+share: detect keypoints inside a border-cropped mask, describe them, match with
+a ratio test, drop spatial outliers, and fit a RANSAC partial affine. Concrete
+methods (ORB, SIFT) only supply the OpenCV detector, extractor, and matcher via
+`_build_cv`. Mirrors Ultralytics' ``apply_features`` (border mask only; detection
+regions are not excluded, matching its behaviour when no detections are passed).
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING
+
+import cv2
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+from getitrack.motion.gmc.base import BaseMotionEstimator
+
+_IDENTITY = np.eye(2, 3, dtype=np.float32)
+
+
+class FeatureMatchingEstimator(BaseMotionEstimator):
+    """Estimate camera motion by matching descriptors between consecutive frames."""
+
+    _LOWE_RATIO = 0.9  # a match is kept when its distance is below this fraction of the runner-up's.
+    _MAX_SPATIAL_FRACTION = 0.25  # reject matches displaced by more than this fraction of the frame.
+    _INLIER_STD = 2.5  # keep displacements within this many standard deviations of the mean.
+    _MIN_MATCHES = 4  # estimateAffinePartial2D needs at least this many correspondences.
+    _BORDER_FRACTION = 0.02  # ignore keypoints within this fraction of each edge.
+
+    def __init__(self, *, downscale: int = 2) -> None:
+        super().__init__(downscale=downscale)
+        self._detector, self._extractor, self._matcher = self._build_cv()
+
+    @abstractmethod
+    def _build_cv(self) -> tuple[cv2.Feature2D, cv2.Feature2D, cv2.DescriptorMatcher]:
+        """Return the ``(detector, extractor, matcher)`` OpenCV objects for this method."""
+
+    def _border_mask(self, gray: np.ndarray) -> np.ndarray:
+        """A mask that excludes a small border, where keypoints are least reliable."""
+        height, width = gray.shape[:2]
+        mask = np.zeros_like(gray)
+        y0, y1 = int(self._BORDER_FRACTION * height), int((1 - self._BORDER_FRACTION) * height)
+        x0, x1 = int(self._BORDER_FRACTION * width), int((1 - self._BORDER_FRACTION) * width)
+        mask[y0:y1, x0:x1] = 255
+        return mask
+
+    def _describe(self, gray: np.ndarray, mask: np.ndarray) -> tuple[Sequence[cv2.KeyPoint], np.ndarray | None]:
+        """Detect and describe keypoints in ``gray`` within ``mask``."""
+        keypoints = self._detector.detect(gray, mask)
+        keypoints, descriptors = self._extractor.compute(gray, keypoints)
+        return keypoints, descriptors
+
+    def _estimate(self, prev_gray: np.ndarray, curr_gray: np.ndarray) -> np.ndarray:
+        mask = self._border_mask(curr_gray)
+        prev_kp, prev_desc = self._describe(prev_gray, mask)
+        curr_kp, curr_desc = self._describe(curr_gray, mask)
+        too_few = len(prev_kp) < self._MIN_MATCHES or len(curr_kp) < self._MIN_MATCHES
+        if prev_desc is None or curr_desc is None or too_few:
+            return _IDENTITY.copy()
+
+        height, width = curr_gray.shape[:2]
+        max_spatial = self._MAX_SPATIAL_FRACTION * np.array([width, height])
+        matches: list[cv2.DMatch] = []
+        displacements: list[tuple[float, float]] = []
+        for pair in self._matcher.knnMatch(prev_desc, curr_desc, 2):
+            if len(pair) < 2:
+                continue
+            match, runner_up = pair
+            if match.distance >= self._LOWE_RATIO * runner_up.distance:
+                continue
+            prev_pt = prev_kp[match.queryIdx].pt
+            curr_pt = curr_kp[match.trainIdx].pt
+            delta = (prev_pt[0] - curr_pt[0], prev_pt[1] - curr_pt[1])
+            if abs(delta[0]) < max_spatial[0] and abs(delta[1]) < max_spatial[1]:
+                matches.append(match)
+                displacements.append(delta)
+        if len(matches) < self._MIN_MATCHES:
+            return _IDENTITY.copy()
+
+        # Keep displacements close to the mean (abs distance, unlike the reference
+        # which only filters positive deviations); the epsilon admits a pure,
+        # noise-free translation, where the standard deviation is zero.
+        deltas = np.array(displacements)
+        inliers = np.abs(deltas - deltas.mean(axis=0)) < self._INLIER_STD * deltas.std(axis=0) + 1e-6
+        prev_pts = np.array(
+            [prev_kp[m.queryIdx].pt for i, m in enumerate(matches) if inliers[i, 0] and inliers[i, 1]], dtype=np.float32
+        )
+        curr_pts = np.array(
+            [curr_kp[m.trainIdx].pt for i, m in enumerate(matches) if inliers[i, 0] and inliers[i, 1]], dtype=np.float32
+        )
+        if len(prev_pts) < self._MIN_MATCHES:
+            return _IDENTITY.copy()
+        warp, _ = cv2.estimateAffinePartial2D(prev_pts, curr_pts, method=cv2.RANSAC)
+        if warp is None:
+            return _IDENTITY.copy()
+        return warp.astype(np.float32)

--- a/libraries/getitrack/src/getitrack/motion/gmc/orb.py
+++ b/libraries/getitrack/src/getitrack/motion/gmc/orb.py
@@ -15,9 +15,7 @@ from getitrack.motion.gmc.features import FeatureMatchingEstimator
 class ORBEstimator(FeatureMatchingEstimator):
     """Detect FAST corners, describe them with ORB, and match with Hamming distance.
 
-    The fastest of the descriptor-based methods; a lightweight alternative to
-    sparse optical flow that re-detects features each frame rather than tracking
-    them.
+    Re-detects features each frame rather than tracking them.
     """
 
     method: ClassVar[GMCMethod] = GMCMethod.ORB

--- a/libraries/getitrack/src/getitrack/motion/gmc/orb.py
+++ b/libraries/getitrack/src/getitrack/motion/gmc/orb.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""ORB feature-based camera-motion estimator (FAST corners + ORB descriptors)."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import cv2
+
+from getitrack.config import GMCMethod
+from getitrack.motion.gmc.features import FeatureMatchingEstimator
+
+
+class ORBEstimator(FeatureMatchingEstimator):
+    """Detect FAST corners, describe them with ORB, and match with Hamming distance.
+
+    The fastest of the descriptor-based methods; a lightweight alternative to
+    sparse optical flow that re-detects features each frame rather than tracking
+    them.
+    """
+
+    method: ClassVar[GMCMethod] = GMCMethod.ORB
+
+    def _build_cv(self) -> tuple[cv2.Feature2D, cv2.Feature2D, cv2.DescriptorMatcher]:
+        return cv2.FastFeatureDetector.create(20), cv2.ORB.create(), cv2.BFMatcher(cv2.NORM_HAMMING)

--- a/libraries/getitrack/src/getitrack/motion/gmc/sift.py
+++ b/libraries/getitrack/src/getitrack/motion/gmc/sift.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""SIFT feature-based camera-motion estimator (scale-invariant descriptors)."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import cv2
+
+from getitrack.config import GMCMethod
+from getitrack.motion.gmc.features import FeatureMatchingEstimator
+
+
+class SIFTEstimator(FeatureMatchingEstimator):
+    """Detect and describe keypoints with SIFT, matched by L2 distance.
+
+    The most robust of the descriptor-based methods on textured, low-motion
+    footage, at the cost of being the slowest. SIFT is patent-free since 2020 and
+    ships in the main OpenCV module.
+    """
+
+    method: ClassVar[GMCMethod] = GMCMethod.SIFT
+
+    def _build_cv(self) -> tuple[cv2.Feature2D, cv2.Feature2D, cv2.DescriptorMatcher]:
+        sift = cv2.SIFT.create(nOctaveLayers=3, contrastThreshold=0.02, edgeThreshold=20)
+        return sift, sift, cv2.BFMatcher(cv2.NORM_L2)

--- a/libraries/getitrack/src/getitrack/motion/gmc/sift.py
+++ b/libraries/getitrack/src/getitrack/motion/gmc/sift.py
@@ -13,12 +13,7 @@ from getitrack.motion.gmc.features import FeatureMatchingEstimator
 
 
 class SIFTEstimator(FeatureMatchingEstimator):
-    """Detect and describe keypoints with SIFT, matched by L2 distance.
-
-    The most robust of the descriptor-based methods on textured, low-motion
-    footage, at the cost of being the slowest. SIFT is patent-free since 2020 and
-    ships in the main OpenCV module.
-    """
+    """Detect and describe keypoints with SIFT, matched by L2 distance."""
 
     method: ClassVar[GMCMethod] = GMCMethod.SIFT
 

--- a/libraries/getitrack/src/getitrack/motion/gmc/sparse_optflow.py
+++ b/libraries/getitrack/src/getitrack/motion/gmc/sparse_optflow.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Sparse optical-flow camera-motion estimator (BoT-SORT's default GMC)."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import cv2
+import numpy as np
+
+from getitrack.config import GMCMethod
+from getitrack.motion.gmc.base import BaseMotionEstimator
+
+_IDENTITY = np.eye(2, 3, dtype=np.float32)
+_MIN_MATCHES = 4  # estimateAffinePartial2D needs at least this many correspondences.
+
+
+class SparseOptFlowEstimator(BaseMotionEstimator):
+    """Track Shi-Tomasi corners with Lucas-Kanade flow, then fit a partial affine.
+
+    Corners detected in the previous frame are followed into the current one with
+    pyramidal optical flow; the surviving matches feed a RANSAC partial-affine
+    fit. Falls back to identity when too few corners survive to fit reliably.
+    """
+
+    method: ClassVar[GMCMethod] = GMCMethod.SPARSE_OPT_FLOW
+
+    def _estimate(self, prev_gray: np.ndarray, curr_gray: np.ndarray) -> np.ndarray:
+        prev_points = cv2.goodFeaturesToTrack(prev_gray, maxCorners=1000, qualityLevel=0.01, minDistance=1, blockSize=3)
+        if prev_points is None or len(prev_points) < _MIN_MATCHES:
+            return _IDENTITY.copy()
+        # nextPts must be passed as None so cv2 allocates it; the stub wrongly types it as required.
+        curr_points, status, _ = cv2.calcOpticalFlowPyrLK(  # pyrefly: ignore[no-matching-overload]
+            prev_gray, curr_gray, prev_points, None
+        )
+        if curr_points is None or status is None:
+            return _IDENTITY.copy()
+        tracked = status.ravel() == 1
+        prev_matched = prev_points[tracked]
+        curr_matched = curr_points[tracked]
+        if len(prev_matched) < _MIN_MATCHES:
+            return _IDENTITY.copy()
+        warp, _ = cv2.estimateAffinePartial2D(prev_matched, curr_matched, method=cv2.RANSAC)
+        if warp is None:
+            return _IDENTITY.copy()
+        return warp.astype(np.float32)

--- a/libraries/getitrack/src/getitrack/reid/__init__.py
+++ b/libraries/getitrack/src/getitrack/reid/__init__.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Appearance / ReID layer: feature providers and per-track appearance memory.
+
+This package is tracker-agnostic. `ReIDProvider` (with OpenVINO and torch
+implementations) turns boxes into descriptors; `build_reid_provider` picks one
+from a `ReIDConfig`; `AppearanceGallery` holds a bounded per-track appearance
+memory. Appearance-aware trackers (BoT-SORT and, later, Deep OC-SORT /
+StrongSORT) compose these with the cosine/fusion helpers in
+`getitrack.matching.appearance`.
+
+The provider implementations import their backend (openvino / torch / torchreid)
+lazily, so this package stays importable without those extras installed.
+"""
+
+from getitrack.reid.base import ReIDProvider
+from getitrack.reid.export import export_torchreid_to_openvino
+from getitrack.reid.factory import build_reid_provider
+from getitrack.reid.gallery import AppearanceGallery
+from getitrack.reid.openvino_provider import OpenVINOReIDProvider
+from getitrack.reid.torchreid_provider import TorchReIDProvider
+
+__all__ = [
+    "AppearanceGallery",
+    "OpenVINOReIDProvider",
+    "ReIDProvider",
+    "TorchReIDProvider",
+    "build_reid_provider",
+    "export_torchreid_to_openvino",
+]

--- a/libraries/getitrack/src/getitrack/reid/__init__.py
+++ b/libraries/getitrack/src/getitrack/reid/__init__.py
@@ -2,15 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 """Appearance / ReID layer: feature providers and per-track appearance memory.
 
-This package is tracker-agnostic. `ReIDProvider` (with OpenVINO and torch
-implementations) turns boxes into descriptors; `build_reid_provider` picks one
-from a `ReIDConfig`; `AppearanceGallery` holds a bounded per-track appearance
-memory. Appearance-aware trackers (BoT-SORT and, later, Deep OC-SORT /
-StrongSORT) compose these with the cosine/fusion helpers in
-`getitrack.matching.appearance`.
-
-The provider implementations import their backend (openvino / torch / torchreid)
-lazily, so this package stays importable without those extras installed.
+`ReIDProvider` (with OpenVINO and torch implementations) turns boxes into
+descriptors; `build_reid_provider` picks one from a `ReIDConfig`;
+`AppearanceGallery` holds a bounded per-track appearance memory. Provider
+implementations import their backend (openvino / torch / torchreid) lazily.
 """
 
 from getitrack.reid.base import ReIDProvider

--- a/libraries/getitrack/src/getitrack/reid/_torchreid_compat.py
+++ b/libraries/getitrack/src/getitrack/reid/_torchreid_compat.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Compatibility shim for importing torchreid without its training-only deps.
+
+torchreid 0.2.5 eagerly imports ``torch.utils.tensorboard`` at package load (for
+its training engine), which in turn requires the heavy ``tensorboard`` package.
+The tracking library only ever runs ReID inference, so this stubs the module when
+the real one is absent, letting torchreid import without ``tensorboard`` installed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+
+
+def ensure_torchreid_importable() -> None:
+    """Install a stub ``torch.utils.tensorboard`` when the real module is missing.
+
+    A no-op when ``tensorboard`` is installed (the real module is used) or when a
+    stub is already registered. Must be called before importing torchreid.
+    """
+    name = "torch.utils.tensorboard"
+    if name in sys.modules or importlib.util.find_spec("tensorboard") is not None:
+        return
+    importlib.import_module("torch.utils")  # ensure the parent package is initialised
+    stub = types.ModuleType(name)
+    # torchreid's engine imports SummaryWriter but never instantiates it for
+    # inference; a placeholder is enough to satisfy the import.
+    stub.__dict__["SummaryWriter"] = object
+    sys.modules[name] = stub

--- a/libraries/getitrack/src/getitrack/reid/base.py
+++ b/libraries/getitrack/src/getitrack/reid/base.py
@@ -4,11 +4,10 @@
 
 A `ReIDProvider` turns image crops (one per bounding box) into fixed-length
 appearance descriptors. Concrete providers wrap a specific inference backend
-(e.g. OpenVINO IR) but share the contract defined here so trackers stay
-backend-agnostic.
+(e.g. OpenVINO IR) and share the contract defined here.
 
-The provider is deliberately stateless with respect to tracks: it only knows
-how to embed boxes. Per-track appearance memory lives in
+The provider is stateless with respect to tracks; it only embeds boxes.
+Per-track appearance memory lives in
 `getitrack.reid.gallery.AppearanceGallery`.
 """
 

--- a/libraries/getitrack/src/getitrack/reid/base.py
+++ b/libraries/getitrack/src/getitrack/reid/base.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Abstract ReID feature-provider interface.
+
+A `ReIDProvider` turns image crops (one per bounding box) into fixed-length
+appearance descriptors. Concrete providers wrap a specific inference backend
+(e.g. OpenVINO IR) but share the contract defined here so trackers stay
+backend-agnostic.
+
+The provider is deliberately stateless with respect to tracks: it only knows
+how to embed boxes. Per-track appearance memory lives in
+`getitrack.reid.gallery.AppearanceGallery`.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
+
+
+class ReIDProvider(ABC):
+    """Abstract appearance-feature extractor.
+
+    Implementations embed the image region under each bounding box into a
+    descriptor vector. Extraction is lazy: only the boxes handed to `extract`
+    are cropped and inferred, never the whole frame.
+    """
+
+    @abstractmethod
+    def extract(self, frame_bgr: np.ndarray, boxes: np.ndarray) -> np.ndarray:
+        """Embed each box's image region into an appearance descriptor.
+
+        Args:
+            frame_bgr: ``(H, W, 3)`` uint8 image in BGR channel order (the
+                OpenCV convention), the frame the boxes were detected in.
+            boxes: ``(N, 4)`` float array of ``xyxy`` boxes in absolute pixel
+                coordinates of ``frame_bgr``.
+
+        Returns:
+            ``(N, D)`` float32 array of L2-normalised descriptors, row-aligned
+            with ``boxes``. For an empty ``boxes`` input the result is
+            ``(0, D)`` (``D`` may be ``0`` before the feature size is known).
+        """

--- a/libraries/getitrack/src/getitrack/reid/crops.py
+++ b/libraries/getitrack/src/getitrack/reid/crops.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Bounding-box crop extraction shared by ReID providers.
+
+Both the OpenVINO and torch providers embed the image region under each box, so
+the clamping rule (keep every crop inside the frame and at least one pixel wide)
+lives here once rather than in each provider.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def crop_boxes(frame_bgr: np.ndarray, boxes: np.ndarray) -> list[np.ndarray]:
+    """Extract the clamped image crop under each ``xyxy`` box.
+
+    Coordinates are floored/ceiled to integer pixels and clamped so the crop
+    stays within the frame and is never empty (a degenerate or out-of-bounds box
+    yields a 1-pixel crop rather than an error).
+
+    Args:
+        frame_bgr: ``(H, W, 3)`` image the boxes were detected in.
+        boxes: ``(N, 4)`` ``xyxy`` boxes in absolute pixel coordinates.
+
+    Returns:
+        A list of ``N`` crops (views into ``frame_bgr``), one per box, in the
+        same channel order as ``frame_bgr`` and of varying size.
+    """
+    frame_h, frame_w = frame_bgr.shape[:2]
+    crops: list[np.ndarray] = []
+    for x1, y1, x2, y2 in boxes:
+        xi1 = int(np.clip(np.floor(x1), 0, frame_w - 1))
+        yi1 = int(np.clip(np.floor(y1), 0, frame_h - 1))
+        xi2 = int(np.clip(np.ceil(x2), xi1 + 1, frame_w))
+        yi2 = int(np.clip(np.ceil(y2), yi1 + 1, frame_h))
+        crops.append(frame_bgr[yi1:yi2, xi1:xi2])
+    return crops

--- a/libraries/getitrack/src/getitrack/reid/crops.py
+++ b/libraries/getitrack/src/getitrack/reid/crops.py
@@ -1,11 +1,6 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-"""Bounding-box crop extraction shared by ReID providers.
-
-Both the OpenVINO and torch providers embed the image region under each box, so
-the clamping rule (keep every crop inside the frame and at least one pixel wide)
-lives here once rather than in each provider.
-"""
+"""Bounding-box crop extraction shared by ReID providers."""
 
 from __future__ import annotations
 

--- a/libraries/getitrack/src/getitrack/reid/export.py
+++ b/libraries/getitrack/src/getitrack/reid/export.py
@@ -17,14 +17,26 @@ def _default_cache_dir() -> Path:
     return Path.home() / ".cache" / "getitrack" / "reid"
 
 
+def _weights_fingerprint(weights_path: str | Path) -> str:
+    """Return an 8-char digest that changes when the checkpoint changes.
+
+    Combines the resolved path with the file size and modification time so that
+    replacing a checkpoint in place yields a new cache key. Falls back to the
+    path alone when the file cannot be stat-ed (e.g. it does not exist yet).
+    """
+    resolved = Path(weights_path).resolve()
+    try:
+        stat = resolved.stat()
+        fingerprint = f"{resolved}:{stat.st_size}:{stat.st_mtime_ns}"
+    except OSError:
+        fingerprint = str(resolved)
+    return hashlib.sha256(fingerprint.encode()).hexdigest()[:8]
+
+
 def _cache_stem(model_name: str, input_size: tuple[int, int], weights_path: str | Path | None) -> str:
     """Build a cache filename stem unique to the model, input size, and weights."""
     height, width = input_size
-    if weights_path is None:
-        tag = "pretrained"
-    else:
-        digest = hashlib.sha256(str(Path(weights_path).resolve()).encode()).hexdigest()[:8]
-        tag = f"{Path(weights_path).stem}_{digest}"
+    tag = "pretrained" if weights_path is None else f"{Path(weights_path).stem}_{_weights_fingerprint(weights_path)}"
     return f"{model_name}_{height}x{width}_{tag}"
 
 

--- a/libraries/getitrack/src/getitrack/reid/export.py
+++ b/libraries/getitrack/src/getitrack/reid/export.py
@@ -2,9 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Export a torchreid model to an OpenVINO IR for the OpenVINO ReID backend.
 
-This bridges torchreid's model zoo to `OpenVINOReIDProvider`: it builds the
-torchreid ``nn.Module`` (downloading or loading its weights) and converts it to
-an IR once, caching the result so repeated runs skip the conversion.
+Builds the torchreid ``nn.Module`` (downloading or loading its weights) and
+converts it to an IR, caching the result. Repeated runs reuse the cached IR.
 """
 
 from __future__ import annotations
@@ -58,7 +57,7 @@ def export_torchreid_to_openvino(
     if xml_path.exists():
         return xml_path
 
-    # Lazy imports keep torch/torchreid/openvino optional for the wider package.
+    # Import torch/torchreid/openvino lazily.
     import openvino as ov
     import torch
     from torchreid.reid.utils import FeatureExtractor

--- a/libraries/getitrack/src/getitrack/reid/export.py
+++ b/libraries/getitrack/src/getitrack/reid/export.py
@@ -69,9 +69,13 @@ def export_torchreid_to_openvino(
     if xml_path.exists():
         return xml_path
 
-    # Import torch/torchreid/openvino lazily.
+    # Import torch/torchreid/openvino lazily, stubbing torchreid's tensorboard import.
     import openvino as ov
     import torch
+
+    from getitrack.reid._torchreid_compat import ensure_torchreid_importable
+
+    ensure_torchreid_importable()
     from torchreid.reid.utils import FeatureExtractor
 
     height, width = input_size

--- a/libraries/getitrack/src/getitrack/reid/export.py
+++ b/libraries/getitrack/src/getitrack/reid/export.py
@@ -1,0 +1,77 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Export a torchreid model to an OpenVINO IR for the OpenVINO ReID backend.
+
+This bridges torchreid's model zoo to `OpenVINOReIDProvider`: it builds the
+torchreid ``nn.Module`` (downloading or loading its weights) and converts it to
+an IR once, caching the result so repeated runs skip the conversion.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+def _default_cache_dir() -> Path:
+    """Return the default cache directory for exported ReID IRs."""
+    return Path.home() / ".cache" / "getitrack" / "reid"
+
+
+def _cache_stem(model_name: str, input_size: tuple[int, int], weights_path: str | Path | None) -> str:
+    """Build a cache filename stem unique to the model, input size, and weights."""
+    height, width = input_size
+    if weights_path is None:
+        tag = "pretrained"
+    else:
+        digest = hashlib.sha256(str(Path(weights_path).resolve()).encode()).hexdigest()[:8]
+        tag = f"{Path(weights_path).stem}_{digest}"
+    return f"{model_name}_{height}x{width}_{tag}"
+
+
+def export_torchreid_to_openvino(
+    model_name: str,
+    input_size: tuple[int, int],
+    *,
+    weights_path: str | Path | None = None,
+    cache_dir: str | Path | None = None,
+) -> Path:
+    """Export a torchreid model to an OpenVINO IR, returning the cached ``.xml``.
+
+    The model is built on CPU and converted to a dynamic-batch IR. When the IR
+    already exists in the cache it is returned without re-exporting.
+
+    Args:
+        model_name: torchreid architecture name (e.g. ``osnet_x1_0``).
+        input_size: Model input ``(height, width)`` in pixels.
+        weights_path: Optional ``.pth.tar`` checkpoint; torchreid downloads
+            ImageNet-pretrained weights when omitted.
+        cache_dir: Directory for the exported IR; defaults to
+            ``~/.cache/getitrack/reid``.
+
+    Returns:
+        Path to the exported IR ``.xml`` (its ``.bin`` sits alongside).
+    """
+    cache = Path(cache_dir) if cache_dir is not None else _default_cache_dir()
+    cache.mkdir(parents=True, exist_ok=True)
+    xml_path = cache / f"{_cache_stem(model_name, input_size, weights_path)}.xml"
+    if xml_path.exists():
+        return xml_path
+
+    # Lazy imports keep torch/torchreid/openvino optional for the wider package.
+    import openvino as ov
+    import torch
+    from torchreid.reid.utils import FeatureExtractor
+
+    height, width = input_size
+    extractor = FeatureExtractor(
+        model_name=model_name,
+        model_path=str(weights_path) if weights_path is not None else "",
+        image_size=input_size,
+        device="cpu",
+        verbose=False,
+    )
+    model = extractor.model.eval()
+    ov_model = ov.convert_model(model, example_input=torch.zeros(1, 3, height, width))
+    ov.save_model(ov_model, str(xml_path))
+    return xml_path

--- a/libraries/getitrack/src/getitrack/reid/factory.py
+++ b/libraries/getitrack/src/getitrack/reid/factory.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Resolve a `ReIDConfig` into a concrete `ReIDProvider`.
+
+Keeps backend selection (torch vs OpenVINO, torchreid model vs prebuilt IR) in
+one place so trackers only depend on the `ReIDProvider` contract. Backend-specific
+imports stay lazy, so choosing one backend never requires the other's stack.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from getitrack.config import ReIDBackend
+
+if TYPE_CHECKING:
+    from getitrack.config import ReIDConfig
+    from getitrack.reid.base import ReIDProvider
+
+
+def _torch_device(device: str) -> str:
+    """Map a config device string to a torch device (``CPU``->``cpu``, ``GPU``->``cuda``)."""
+    lowered = device.lower()
+    if lowered.startswith(("cpu", "cuda")):
+        return lowered
+    return "cuda" if lowered == "gpu" else lowered
+
+
+def build_reid_provider(config: ReIDConfig) -> ReIDProvider | None:
+    """Build the ReID provider selected by ``config``, or None when unavailable.
+
+    Returns None when ReID is disabled or no model source is configured (the
+    caller then supplies ``Detections.embeddings`` directly). The torch backend
+    runs a torchreid model natively; the OpenVINO backend runs a prebuilt IR, or
+    auto-exports and caches one from the torchreid model when ``model_name`` is
+    set.
+    """
+    if not config.enabled:
+        return None
+
+    if config.backend is ReIDBackend.TORCH:
+        if config.model_name is None:
+            msg = "ReID torch backend requires model_name (a torchreid architecture)."
+            raise ValueError(msg)
+        from getitrack.reid.torchreid_provider import TorchReIDProvider
+
+        return TorchReIDProvider(
+            config.model_name,
+            weights_path=config.model_path,
+            device=_torch_device(config.device),
+            input_size=config.input_size,
+        )
+
+    from getitrack.reid.openvino_provider import OpenVINOReIDProvider
+
+    if config.model_name is not None:
+        from getitrack.reid.export import export_torchreid_to_openvino
+
+        xml_path = export_torchreid_to_openvino(
+            config.model_name,
+            config.input_size,
+            weights_path=config.model_path,
+            cache_dir=config.cache_dir,
+        )
+        return OpenVINOReIDProvider(xml_path, input_size=config.input_size, device=config.device)
+
+    if config.model_path is not None:
+        return OpenVINOReIDProvider(config.model_path, input_size=config.input_size, device=config.device)
+
+    return None

--- a/libraries/getitrack/src/getitrack/reid/factory.py
+++ b/libraries/getitrack/src/getitrack/reid/factory.py
@@ -2,9 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """Resolve a `ReIDConfig` into a concrete `ReIDProvider`.
 
-Keeps backend selection (torch vs OpenVINO, torchreid model vs prebuilt IR) in
-one place so trackers only depend on the `ReIDProvider` contract. Backend-specific
-imports stay lazy, so choosing one backend never requires the other's stack.
+Selects the backend (torch vs OpenVINO, torchreid model vs prebuilt IR).
+Backend-specific imports stay lazy.
 """
 
 from __future__ import annotations

--- a/libraries/getitrack/src/getitrack/reid/gallery.py
+++ b/libraries/getitrack/src/getitrack/reid/gallery.py
@@ -2,19 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 """Bounded per-track appearance memory (gallery + EMA).
 
-An `AppearanceGallery` holds the appearance history of a single track. It keeps
-two complementary representations:
+An `AppearanceGallery` holds the appearance history of a single track in two
+representations:
 
 - a fixed-capacity FIFO gallery of recent descriptors, and
-- an exponential-moving-average (EMA) descriptor, optionally confidence-scaled,
-  as used by StrongSORT / BoT-SORT.
+- an exponential-moving-average (EMA) descriptor, optionally confidence-scaled.
 
-A cosine admission gate rejects descriptors that are too dissimilar from the
-track's current representation, guarding the memory against pollution from a
-wrong association or a badly-cropped box.
-
-The class is tracker-agnostic: a tracker keeps one `AppearanceGallery` per track
-id, feeds it the matched detection's descriptor via `update`, and queries the
+A cosine admission gate rejects descriptors too dissimilar from the track's
+current representation. A tracker keeps one `AppearanceGallery` per track id,
+feeds it the matched detection's descriptor via `update`, and queries the
 appearance distance of candidate detections via `distance`.
 """
 
@@ -30,10 +26,10 @@ from getitrack.matching.appearance import cosine_distance, l2_normalize
 class AppearanceGallery:
     """Fixed-capacity appearance memory for one track.
 
-    The FIFO gallery is always maintained and always queried, so ``gallery_size``
-    affects matching in both modes. When ``use_ema`` is set, the running EMA
-    descriptor is added as one extra representative alongside the FIFO entries,
-    and `distance` reports the minimum cosine distance over that combined set.
+    The FIFO gallery is always maintained and queried. When ``use_ema`` is set,
+    the running EMA descriptor is queried as one extra representative alongside
+    the FIFO entries, and `distance` reports the minimum cosine distance over the
+    combined set.
 
     Attributes:
         gallery_size: Maximum number of descriptors retained in the FIFO
@@ -76,8 +72,7 @@ class AppearanceGallery:
 
         Args:
             feature: ``(D,)`` appearance descriptor of the matched detection.
-            confidence: Detection score in ``[0, 1]`` scaling the EMA step, so
-                low-confidence detections perturb the running feature less.
+            confidence: Detection score in ``[0, 1]`` scaling the EMA step.
 
         Returns:
             True if the descriptor was admitted, False if the admission gate
@@ -120,8 +115,7 @@ class AppearanceGallery:
     def _representatives(self) -> np.ndarray | None:
         """Return the descriptor set queried against, or None when empty.
 
-        Always the FIFO gallery entries, plus the EMA descriptor when
-        ``use_ema`` is set, so ``gallery_size`` is never inert.
+        The FIFO gallery entries, plus the EMA descriptor when ``use_ema`` is set.
         """
         reps = list(self._gallery)
         if self.use_ema and self._ema is not None:

--- a/libraries/getitrack/src/getitrack/reid/gallery.py
+++ b/libraries/getitrack/src/getitrack/reid/gallery.py
@@ -1,0 +1,131 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Bounded per-track appearance memory (gallery + EMA).
+
+An `AppearanceGallery` holds the appearance history of a single track. It keeps
+two complementary representations:
+
+- a fixed-capacity FIFO gallery of recent descriptors, and
+- an exponential-moving-average (EMA) descriptor, optionally confidence-scaled,
+  as used by StrongSORT / BoT-SORT.
+
+A cosine admission gate rejects descriptors that are too dissimilar from the
+track's current representation, guarding the memory against pollution from a
+wrong association or a badly-cropped box.
+
+The class is tracker-agnostic: a tracker keeps one `AppearanceGallery` per track
+id, feeds it the matched detection's descriptor via `update`, and queries the
+appearance distance of candidate detections via `distance`.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+import numpy as np
+
+from getitrack.matching.appearance import cosine_distance, l2_normalize
+
+
+class AppearanceGallery:
+    """Fixed-capacity appearance memory for one track.
+
+    The FIFO gallery is always maintained and always queried, so ``gallery_size``
+    affects matching in both modes. When ``use_ema`` is set, the running EMA
+    descriptor is added as one extra representative alongside the FIFO entries,
+    and `distance` reports the minimum cosine distance over that combined set.
+
+    Attributes:
+        gallery_size: Maximum number of descriptors retained in the FIFO
+            gallery. The oldest descriptor is evicted once the cap is reached.
+        use_ema: When true, the running EMA descriptor is queried in addition to
+            the FIFO gallery entries.
+        ema_alpha: EMA retention factor in ``(0, 1)``. Higher values keep more
+            history. The update is ``ema = (1 - w) * ema + w * feature`` with
+            ``w = (1 - ema_alpha) * confidence``.
+        admission_threshold: Maximum cosine distance a new descriptor may have
+            from the current representation to be admitted. Descriptors above it
+            are rejected. Set high (>= 2.0) to admit everything.
+    """
+
+    def __init__(
+        self,
+        *,
+        gallery_size: int,
+        use_ema: bool,
+        ema_alpha: float,
+        admission_threshold: float,
+    ) -> None:
+        self.gallery_size = gallery_size
+        self.use_ema = use_ema
+        self.ema_alpha = ema_alpha
+        self.admission_threshold = admission_threshold
+        self._gallery: deque[np.ndarray] = deque(maxlen=gallery_size)
+        self._ema: np.ndarray | None = None
+
+    @property
+    def is_empty(self) -> bool:
+        """True until the first descriptor has been admitted."""
+        return self._ema is None and len(self._gallery) == 0
+
+    def __len__(self) -> int:
+        return len(self._gallery)
+
+    def update(self, feature: np.ndarray, *, confidence: float = 1.0) -> bool:
+        """Admit a descriptor into the memory, subject to the admission gate.
+
+        Args:
+            feature: ``(D,)`` appearance descriptor of the matched detection.
+            confidence: Detection score in ``[0, 1]`` scaling the EMA step, so
+                low-confidence detections perturb the running feature less.
+
+        Returns:
+            True if the descriptor was admitted, False if the admission gate
+            rejected it as too dissimilar from the current representation.
+        """
+        feat = l2_normalize(np.asarray(feature, dtype=np.float32).reshape(-1))
+        representatives = self._representatives()
+        if representatives is not None and representatives.shape[0] > 0:
+            gate_distance = float(cosine_distance(feat[None, :], representatives).min())
+            if gate_distance > self.admission_threshold:
+                return False
+        if self.use_ema:
+            if self._ema is None:
+                self._ema = feat
+            else:
+                weight = (1.0 - self.ema_alpha) * float(confidence)
+                self._ema = l2_normalize((1.0 - weight) * self._ema + weight * feat)
+        self._gallery.append(feat)
+        return True
+
+    def distance(self, features: np.ndarray) -> np.ndarray:
+        """Return each candidate's appearance distance to this track.
+
+        Args:
+            features: ``(N, D)`` candidate detection descriptors.
+
+        Returns:
+            ``(N,)`` float32 cosine distances: the minimum distance over the
+            FIFO gallery entries (and, when ``use_ema`` is set, the EMA
+            descriptor). An empty memory yields all ``NaN`` (no appearance
+            information available).
+        """
+        candidates = np.asarray(features, dtype=np.float32)
+        representatives = self._representatives()
+        if representatives is None or representatives.shape[0] == 0:
+            return np.full((candidates.shape[0],), np.nan, dtype=np.float32)
+        distances = cosine_distance(candidates, representatives)
+        return distances.min(axis=1).astype(np.float32)
+
+    def _representatives(self) -> np.ndarray | None:
+        """Return the descriptor set queried against, or None when empty.
+
+        Always the FIFO gallery entries, plus the EMA descriptor when
+        ``use_ema`` is set, so ``gallery_size`` is never inert.
+        """
+        reps = list(self._gallery)
+        if self.use_ema and self._ema is not None:
+            reps.append(self._ema)
+        if not reps:
+            return None
+        return np.stack(reps, axis=0)

--- a/libraries/getitrack/src/getitrack/reid/openvino_provider.py
+++ b/libraries/getitrack/src/getitrack/reid/openvino_provider.py
@@ -1,0 +1,128 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""OpenVINO-IR appearance-feature provider.
+
+`OpenVINOReIDProvider` embeds bounding-box crops with a ReID model compiled from
+an OpenVINO IR (``.xml`` + ``.bin``). It crops each box, resizes to the model
+input, applies ImageNet normalisation, batches the crops through a single infer
+call, and L2-normalises the descriptors.
+
+No weights are bundled. Supply any IR that takes an ``(N, 3, H, W)`` NCHW batch
+and returns ``(N, D)`` descriptors (set ``input_size`` to match); OSNet exported
+from ``torchreid`` is one common choice.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
+
+import cv2
+import numpy as np
+
+from getitrack.matching.appearance import l2_normalize
+from getitrack.reid.base import ReIDProvider
+from getitrack.reid.crops import crop_boxes
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+# ImageNet normalisation constants (RGB), the standard ReID preprocessing.
+_IMAGENET_MEAN = (0.485, 0.456, 0.406)
+_IMAGENET_STD = (0.229, 0.224, 0.225)
+
+
+@runtime_checkable
+class InferResult(Protocol):
+    """Minimal view of an OpenVINO inference result (index-addressable outputs)."""
+
+    def __getitem__(self, index: int) -> np.ndarray:
+        """Return the output tensor at ``index``."""
+
+
+class CompiledModel(Protocol):
+    """Minimal view of a compiled OpenVINO model: callable on an input batch."""
+
+    def __call__(self, inputs: np.ndarray) -> InferResult:
+        """Run inference on ``inputs`` and return the index-addressable outputs."""
+
+
+class OpenVINOReIDProvider(ReIDProvider):
+    """ReID feature provider backed by a compiled OpenVINO IR model.
+
+    The OpenVINO runtime is imported lazily inside the constructor, so importing
+    this module (and the wider ``getitrack`` package) does not require
+    ``openvino`` to be installed.
+    """
+
+    def __init__(
+        self,
+        model_path: str | Path | None = None,
+        *,
+        input_size: tuple[int, int] = (256, 128),
+        device: str = "CPU",
+        mean: Sequence[float] = _IMAGENET_MEAN,
+        std: Sequence[float] = _IMAGENET_STD,
+        compiled_model: CompiledModel | None = None,
+    ) -> None:
+        """Initialise the provider.
+
+        Args:
+            model_path: Path to the OpenVINO IR ``.xml``. Ignored when
+                ``compiled_model`` is supplied; required otherwise.
+            input_size: Model input ``(height, width)`` in pixels.
+            device: OpenVINO device to compile for (e.g. ``"CPU"``, ``"GPU"``).
+            mean: Per-channel RGB mean used for normalisation.
+            std: Per-channel RGB standard deviation used for normalisation.
+            compiled_model: Pre-compiled model to use directly, bypassing the
+                file load. Primarily an injection point for testing.
+
+        Raises:
+            ValueError: If neither ``model_path`` nor ``compiled_model`` is given.
+        """
+        self._input_size = input_size
+        self._mean = np.asarray(mean, dtype=np.float32).reshape(1, 1, 3)
+        self._std = np.asarray(std, dtype=np.float32).reshape(1, 1, 3)
+        self._output_dim: int | None = None
+        if compiled_model is not None:
+            self._compiled: CompiledModel = compiled_model
+            return
+        if model_path is None:
+            msg = "either model_path or compiled_model must be provided"
+            raise ValueError(msg)
+        # Lazy import keeps openvino an optional dependency; the module (and the
+        # wider getitrack package) stays importable without it installed.
+        import openvino as ov
+
+        core = ov.Core()
+        model = core.read_model(model_path)
+        height, width = input_size
+        # Force a dynamic batch dimension so a single infer call embeds all boxes,
+        # regardless of the batch size the IR was exported with.
+        model.reshape([-1, 3, height, width])
+        # The compiled model satisfies the CompiledModel protocol at runtime; the
+        # cast bridges openvino's broader ``__call__`` signature to it.
+        self._compiled = cast("CompiledModel", core.compile_model(model, device))
+
+    def extract(self, frame_bgr: np.ndarray, boxes: np.ndarray) -> np.ndarray:
+        """Embed each box crop into an L2-normalised descriptor (see `ReIDProvider.extract`)."""
+        box_array = np.asarray(boxes, dtype=np.float32).reshape(-1, 4)
+        if box_array.shape[0] == 0:
+            return np.empty((0, self._output_dim or 0), dtype=np.float32)
+        batch = self._preprocess(frame_bgr, box_array)
+        result = self._compiled(batch)
+        features = np.asarray(result[0], dtype=np.float32)
+        features = features.reshape(features.shape[0], -1)
+        self._output_dim = int(features.shape[1])
+        return l2_normalize(features)
+
+    def _preprocess(self, frame_bgr: np.ndarray, boxes: np.ndarray) -> np.ndarray:
+        """Crop, resize, and normalise each box into an ``(N, 3, H, W)`` batch."""
+        height, width = self._input_size
+        batch = np.empty((boxes.shape[0], 3, height, width), dtype=np.float32)
+        for i, crop in enumerate(crop_boxes(frame_bgr, boxes)):
+            resized = cv2.resize(crop, (width, height), interpolation=cv2.INTER_LINEAR)
+            rgb = resized[:, :, ::-1].astype(np.float32) / 255.0
+            normalised = (rgb - self._mean) / self._std
+            batch[i] = normalised.transpose(2, 0, 1)
+        return batch

--- a/libraries/getitrack/src/getitrack/reid/openvino_provider.py
+++ b/libraries/getitrack/src/getitrack/reid/openvino_provider.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
-# ImageNet normalisation constants (RGB), the standard ReID preprocessing.
+# ImageNet normalisation constants (RGB).
 _IMAGENET_MEAN = (0.485, 0.456, 0.406)
 _IMAGENET_STD = (0.229, 0.224, 0.225)
 
@@ -50,9 +50,7 @@ class CompiledModel(Protocol):
 class OpenVINOReIDProvider(ReIDProvider):
     """ReID feature provider backed by a compiled OpenVINO IR model.
 
-    The OpenVINO runtime is imported lazily inside the constructor, so importing
-    this module (and the wider ``getitrack`` package) does not require
-    ``openvino`` to be installed.
+    The OpenVINO runtime is imported lazily in the constructor.
     """
 
     def __init__(
@@ -90,18 +88,15 @@ class OpenVINOReIDProvider(ReIDProvider):
         if model_path is None:
             msg = "either model_path or compiled_model must be provided"
             raise ValueError(msg)
-        # Lazy import keeps openvino an optional dependency; the module (and the
-        # wider getitrack package) stays importable without it installed.
+        # Import openvino lazily.
         import openvino as ov
 
         core = ov.Core()
         model = core.read_model(model_path)
         height, width = input_size
-        # Force a dynamic batch dimension so a single infer call embeds all boxes,
-        # regardless of the batch size the IR was exported with.
+        # Force a dynamic batch dimension so one infer call embeds all boxes.
         model.reshape([-1, 3, height, width])
-        # The compiled model satisfies the CompiledModel protocol at runtime; the
-        # cast bridges openvino's broader ``__call__`` signature to it.
+        # Cast openvino's broader ``__call__`` signature to the CompiledModel protocol.
         self._compiled = cast("CompiledModel", core.compile_model(model, device))
 
     def extract(self, frame_bgr: np.ndarray, boxes: np.ndarray) -> np.ndarray:

--- a/libraries/getitrack/src/getitrack/reid/torchreid_provider.py
+++ b/libraries/getitrack/src/getitrack/reid/torchreid_provider.py
@@ -43,7 +43,7 @@ class Descriptors(Protocol):
 class FeatureExtractorLike(Protocol):
     """Minimal view of torchreid's ``FeatureExtractor``: callable on a crop list."""
 
-    def __call__(self, images: list[np.ndarray]) -> Descriptors:
+    def __call__(self, images: list[np.ndarray], /) -> Descriptors:
         """Embed each ``(H, W, 3)`` RGB crop into a ``(N, D)`` descriptor batch."""
 
 
@@ -77,7 +77,10 @@ class TorchReIDProvider(ReIDProvider):
         if extractor is not None:
             self._extractor: FeatureExtractorLike = extractor
             return
-        # Import torchreid lazily.
+        # Import torchreid lazily, stubbing its training-only tensorboard import.
+        from getitrack.reid._torchreid_compat import ensure_torchreid_importable
+
+        ensure_torchreid_importable()
         from torchreid.reid.utils import FeatureExtractor
 
         self._extractor = FeatureExtractor(

--- a/libraries/getitrack/src/getitrack/reid/torchreid_provider.py
+++ b/libraries/getitrack/src/getitrack/reid/torchreid_provider.py
@@ -4,9 +4,8 @@
 
 `TorchReIDProvider` wraps torchreid's ``FeatureExtractor`` to embed box crops
 with any torchreid model-zoo architecture (e.g. OSNet). torchreid handles the
-resize and ImageNet normalisation internally, so the provider only crops the
-boxes, converts BGR to RGB, and L2-normalises the returned descriptors to honour
-the `ReIDProvider` contract.
+resize and ImageNet normalisation internally; the provider crops the boxes,
+converts BGR to RGB, and L2-normalises the returned descriptors.
 
 No weights are bundled: torchreid downloads ImageNet-pretrained weights for the
 chosen ``model_name`` on first use, or loads a ``.pth.tar`` checkpoint when one
@@ -51,9 +50,7 @@ class FeatureExtractorLike(Protocol):
 class TorchReIDProvider(ReIDProvider):
     """ReID feature provider backed by a native torchreid model.
 
-    torchreid is imported lazily in the constructor, so importing this module
-    (and the wider ``getitrack`` package) does not require torch/torchreid to be
-    installed.
+    torchreid is imported lazily in the constructor.
     """
 
     def __init__(
@@ -80,8 +77,7 @@ class TorchReIDProvider(ReIDProvider):
         if extractor is not None:
             self._extractor: FeatureExtractorLike = extractor
             return
-        # Lazy import keeps torchreid an optional dependency; the module (and the
-        # wider getitrack package) stays importable without it installed.
+        # Import torchreid lazily.
         from torchreid.reid.utils import FeatureExtractor
 
         self._extractor = FeatureExtractor(

--- a/libraries/getitrack/src/getitrack/reid/torchreid_provider.py
+++ b/libraries/getitrack/src/getitrack/reid/torchreid_provider.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""torchreid appearance-feature provider (native PyTorch backend).
+
+`TorchReIDProvider` wraps torchreid's ``FeatureExtractor`` to embed box crops
+with any torchreid model-zoo architecture (e.g. OSNet). torchreid handles the
+resize and ImageNet normalisation internally, so the provider only crops the
+boxes, converts BGR to RGB, and L2-normalises the returned descriptors to honour
+the `ReIDProvider` contract.
+
+No weights are bundled: torchreid downloads ImageNet-pretrained weights for the
+chosen ``model_name`` on first use, or loads a ``.pth.tar`` checkpoint when one
+is supplied.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+import numpy as np
+
+from getitrack.matching.appearance import l2_normalize
+from getitrack.reid.base import ReIDProvider
+from getitrack.reid.crops import crop_boxes
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@runtime_checkable
+class Descriptors(Protocol):
+    """Minimal view of a torch tensor: detachable and convertible to numpy."""
+
+    def detach(self) -> Descriptors:
+        """Return a version detached from the autograd graph."""
+
+    def cpu(self) -> Descriptors:
+        """Return a version resident on host memory."""
+
+    def numpy(self) -> np.ndarray:
+        """Return the underlying array."""
+
+
+class FeatureExtractorLike(Protocol):
+    """Minimal view of torchreid's ``FeatureExtractor``: callable on a crop list."""
+
+    def __call__(self, images: list[np.ndarray]) -> Descriptors:
+        """Embed each ``(H, W, 3)`` RGB crop into a ``(N, D)`` descriptor batch."""
+
+
+class TorchReIDProvider(ReIDProvider):
+    """ReID feature provider backed by a native torchreid model.
+
+    torchreid is imported lazily in the constructor, so importing this module
+    (and the wider ``getitrack`` package) does not require torch/torchreid to be
+    installed.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        *,
+        weights_path: str | Path | None = None,
+        device: str = "cpu",
+        input_size: tuple[int, int] = (256, 128),
+        extractor: FeatureExtractorLike | None = None,
+    ) -> None:
+        """Initialise the provider.
+
+        Args:
+            model_name: torchreid architecture name (e.g. ``osnet_x1_0``).
+            weights_path: Optional ``.pth.tar`` checkpoint; torchreid downloads
+                ImageNet-pretrained weights when omitted.
+            device: torch device to run on (``cpu`` or ``cuda``).
+            input_size: Model input ``(height, width)`` in pixels.
+            extractor: Pre-built feature extractor to use directly, bypassing the
+                torchreid load. Primarily an injection point for testing.
+        """
+        self._output_dim: int | None = None
+        if extractor is not None:
+            self._extractor: FeatureExtractorLike = extractor
+            return
+        # Lazy import keeps torchreid an optional dependency; the module (and the
+        # wider getitrack package) stays importable without it installed.
+        from torchreid.reid.utils import FeatureExtractor
+
+        self._extractor = FeatureExtractor(
+            model_name=model_name,
+            model_path=str(weights_path) if weights_path is not None else "",
+            image_size=input_size,
+            device=device,
+            verbose=False,
+        )
+
+    def extract(self, frame_bgr: np.ndarray, boxes: np.ndarray) -> np.ndarray:
+        """Embed each box crop into an L2-normalised descriptor (see `ReIDProvider.extract`)."""
+        box_array = np.asarray(boxes, dtype=np.float32).reshape(-1, 4)
+        if box_array.shape[0] == 0:
+            return np.empty((0, self._output_dim or 0), dtype=np.float32)
+        # torchreid's numpy path builds a PIL image per crop and assumes RGB, so
+        # flip BGR and make contiguous (PIL rejects the negative-stride view).
+        crops_rgb = [np.ascontiguousarray(crop[:, :, ::-1]) for crop in crop_boxes(frame_bgr, box_array)]
+        features = np.asarray(self._extractor(crops_rgb).detach().cpu().numpy(), dtype=np.float32)
+        self._output_dim = int(features.shape[1])
+        return l2_normalize(features)

--- a/libraries/getitrack/tests/unit/test_appearance.py
+++ b/libraries/getitrack/tests/unit/test_appearance.py
@@ -1,0 +1,109 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the appearance cost helpers (cosine distance + IoU-gated fusion)."""
+
+import numpy as np
+import pytest
+
+from getitrack.matching.appearance import (
+    cosine_distance,
+    fuse_appearance_cost,
+    l2_normalize,
+)
+
+
+class TestCosineDistance:
+    def test_identical_features_are_near_zero(self):
+        a = np.array([[1.0, 2.0, 3.0]], dtype=np.float32)
+        dist = cosine_distance(a, a.copy())
+        assert dist[0, 0] == pytest.approx(0.0, abs=1e-5)
+
+    def test_orthogonal_features_are_near_one(self):
+        a = np.array([[1.0, 0.0]], dtype=np.float32)
+        b = np.array([[0.0, 1.0]], dtype=np.float32)
+        assert cosine_distance(a, b)[0, 0] == pytest.approx(1.0, abs=1e-5)
+
+    def test_opposite_features_are_near_two(self):
+        a = np.array([[1.0, 0.0]], dtype=np.float32)
+        b = np.array([[-1.0, 0.0]], dtype=np.float32)
+        assert cosine_distance(a, b)[0, 0] == pytest.approx(2.0, abs=1e-5)
+
+    def test_unnormalised_input_still_yields_cosine(self):
+        # Scaling a vector must not change its cosine distance.
+        a = np.array([[3.0, 4.0]], dtype=np.float32)
+        b = np.array([[6.0, 8.0]], dtype=np.float32)
+        assert cosine_distance(a, b)[0, 0] == pytest.approx(0.0, abs=1e-5)
+
+    def test_shape_and_dtype(self):
+        a = np.random.default_rng(0).random((4, 8)).astype(np.float32)
+        b = np.random.default_rng(1).random((3, 8)).astype(np.float32)
+        dist = cosine_distance(a, b)
+        assert dist.shape == (4, 3)
+        assert dist.dtype == np.float32
+
+    def test_empty_inputs(self):
+        empty = np.empty((0, 8), dtype=np.float32)
+        boxes = np.zeros((2, 8), dtype=np.float32)
+        assert cosine_distance(empty, boxes).shape == (0, 2)
+        assert cosine_distance(boxes, empty).shape == (2, 0)
+
+
+class TestL2Normalize:
+    def test_rows_become_unit_norm(self):
+        x = np.array([[3.0, 4.0], [0.0, 2.0]], dtype=np.float32)
+        norms = np.linalg.norm(l2_normalize(x), axis=1)
+        assert np.allclose(norms, 1.0, atol=1e-5)
+
+    def test_zero_row_stays_zero(self):
+        x = np.zeros((1, 4), dtype=np.float32)
+        assert np.allclose(l2_normalize(x), 0.0)
+
+
+class TestFuseAppearanceCost:
+    def test_convex_blend(self):
+        iou_cost = np.array([[0.2]], dtype=np.float32)
+        app_cost = np.array([[0.8]], dtype=np.float32)
+        fused = fuse_appearance_cost(iou_cost, app_cost, appearance_weight=0.25, iou_floor=0.0)
+        # 0.75 * 0.2 + 0.25 * 0.8 = 0.35
+        assert fused[0, 0] == pytest.approx(0.35, abs=1e-6)
+
+    def test_below_floor_pairs_fall_back_to_plain_iou(self):
+        # IoU = 1 - iou_cost. Row 0 overlaps (IoU 0.8 >= floor), row 1 barely
+        # (IoU 0.1 < floor). Appearance must never make a below-floor pair
+        # unmatchable: it falls back to the plain iou_cost, not a sentinel.
+        iou_cost = np.array([[0.2], [0.9]], dtype=np.float32)
+        app_cost = np.array([[0.0], [0.0]], dtype=np.float32)
+        fused = fuse_appearance_cost(iou_cost, app_cost, appearance_weight=0.9, iou_floor=0.5)
+        # Above the floor, appearance lowers the cost.
+        assert fused[0, 0] < iou_cost[0, 0]
+        # Below the floor, appearance is dropped: the pair keeps its IoU cost and
+        # stays exactly as matchable as it is under IoU alone (not gated out).
+        assert fused[1, 0] == pytest.approx(iou_cost[1, 0])
+
+    def test_never_stricter_than_iou_for_below_floor_reappearance(self):
+        # A same-identity reappearance at moderate overlap (IoU 0.36, below a 0.5
+        # floor) with a perfect appearance match keeps its plain IoU cost, so it
+        # remains matchable exactly where the IoU-only baseline would match it.
+        iou_cost = np.array([[0.64]], dtype=np.float32)
+        app_cost = np.array([[0.0]], dtype=np.float32)
+        fused = fuse_appearance_cost(iou_cost, app_cost, appearance_weight=0.9, iou_floor=0.5)
+        assert fused[0, 0] == pytest.approx(0.64)
+
+    def test_disagreeing_appearance_raises_cost_above_floor(self):
+        # A high-overlap pair whose appearance disagrees is penalised, letting
+        # appearance discriminate competing matches.
+        iou_cost = np.array([[0.1]], dtype=np.float32)
+        app_cost = np.array([[1.0]], dtype=np.float32)
+        fused = fuse_appearance_cost(iou_cost, app_cost, appearance_weight=0.5, iou_floor=0.5)
+        assert fused[0, 0] > iou_cost[0, 0]
+
+    def test_nan_appearance_falls_back_to_iou(self):
+        iou_cost = np.array([[0.3]], dtype=np.float32)
+        app_cost = np.array([[np.nan]], dtype=np.float32)
+        fused = fuse_appearance_cost(iou_cost, app_cost, appearance_weight=0.5, iou_floor=0.0)
+        assert fused[0, 0] == pytest.approx(0.3, abs=1e-6)
+
+    def test_empty_matrix_passthrough(self):
+        empty = np.empty((0, 0), dtype=np.float32)
+        fused = fuse_appearance_cost(empty, empty, appearance_weight=0.5, iou_floor=0.5)
+        assert fused.shape == (0, 0)

--- a/libraries/getitrack/tests/unit/test_botsort.py
+++ b/libraries/getitrack/tests/unit/test_botsort.py
@@ -1,0 +1,283 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit + integration tests for the BoT-SORT tracker and its config."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import getitrack.algorithms  # noqa: F401  -> registers BoT-SORT
+from getitrack.algorithms import BotSortTracker, ByteTrackTracker
+from getitrack.algorithms.configs.botsort import BotSortConfig
+from getitrack.algorithms.configs.bytetrack import ByteTrackConfig
+from getitrack.config import AlgorithmType, LifecycleConfig, TrackerConfig
+from getitrack.core.base import BaseTracker
+from getitrack.core.detection import Detections
+from getitrack.core.registry import resolve_tracker_config
+
+_E_A = np.array([1.0, 0.0], dtype=np.float32)
+_E_B = np.array([0.0, 1.0], dtype=np.float32)
+
+
+def _dets(
+    boxes: list[list[float]],
+    scores: list[float],
+    frame_id: int,
+    embeddings: list[np.ndarray] | None = None,
+) -> Detections:
+    n = len(boxes)
+    emb: np.ndarray | None = None
+    if embeddings is not None:
+        emb = np.asarray(embeddings, dtype=np.float32).reshape(n, -1) if n else np.empty((0, 2), dtype=np.float32)
+    return Detections(
+        bboxes=np.asarray(boxes, dtype=np.float32).reshape(n, 4),
+        scores=np.asarray(scores, dtype=np.float32),
+        class_ids=np.zeros(n, dtype=np.int64),
+        frame_id=frame_id,
+        embeddings=emb,
+    )
+
+
+class TestConfigRegistry:
+    def test_from_config_dispatches_to_botsort(self):
+        tracker = BaseTracker.from_config(BotSortConfig())
+        assert isinstance(tracker, BotSortTracker)
+
+    def test_resolve_dispatches_on_algorithm_key(self):
+        resolved = resolve_tracker_config({"algorithm": "botsort", "appearance_weight": 0.4})
+        assert isinstance(resolved, BotSortConfig)
+        assert resolved.appearance_weight == pytest.approx(0.4)
+
+    def test_algorithm_is_pinned(self):
+        assert BotSortConfig().algorithm == AlgorithmType.BOTSORT
+
+    def test_yaml_round_trip(self, tmp_path):
+        cfg = BotSortConfig(
+            appearance_weight=0.5,
+            gallery_size=17,
+            appearance_threshold=0.3,
+            use_ema=False,
+            lifecycle=LifecycleConfig(max_age=42),
+        )
+        path = tmp_path / "botsort.yaml"
+        cfg.to_yaml(path)
+        assert TrackerConfig.from_yaml(path) == cfg
+
+    def test_reid_section_defaults(self):
+        cfg = BotSortConfig()
+        assert cfg.reid.enabled is False
+        assert cfg.reid.model_path is None
+        assert cfg.reid.input_size == (256, 128)
+
+    def test_extends_bytetrack_parameters(self):
+        # BoT-SORT inherits the ByteTrack knobs (e.g. the high/low split).
+        assert BotSortConfig().high_score_threshold == pytest.approx(0.5)
+
+
+class TestReidProviderProperty:
+    def test_provider_is_none_when_reid_disabled(self):
+        assert BotSortTracker(BotSortConfig()).reid_provider is None
+
+
+class TestAppearanceRecovery:
+    """Appearance recovers an identity across an occlusion that IoU alone drops."""
+
+    @staticmethod
+    def _run(tracker: BaseTracker) -> int:
+        # Frame 0: object A at a box, with appearance e_A -> track id 1.
+        tracker.update(_dets([[50, 50, 90, 90]], [0.9], frame_id=0, embeddings=[_E_A]))
+        # Frame 1: A occluded (no detection) -> track goes LOST.
+        tracker.update(_dets([], [], frame_id=1, embeddings=[]))
+        # Frame 2: a distractor (e_B) sits exactly on A's coasted box (IoU 1.0),
+        # while the true A (e_A) reappears slightly displaced (IoU ~0.68). Both
+        # overlap above the DEFAULT appearance_iou_floor (0.5), so appearance
+        # applies to both and must disambiguate them.
+        out = tracker.update(
+            _dets(
+                [[50, 50, 90, 90], [46, 46, 86, 86]],
+                [0.9, 0.9],
+                frame_id=2,
+                embeddings=[_E_B, _E_A],
+            ),
+        )
+        # The true-A detection is input row 1; return the id it received.
+        assert out.det_indices is not None
+        det_indices = out.det_indices.tolist()
+        row = det_indices.index(1)
+        return int(out.track_ids[row])
+
+    def test_bytetrack_iou_only_loses_the_identity(self):
+        # IoU-only association latches id 1 onto the higher-overlap distractor,
+        # so the real A gets a fresh id.
+        cfg = ByteTrackConfig(lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1, max_age=5))
+        assert self._run(ByteTrackTracker(cfg)) != 1
+
+    def test_botsort_appearance_recovers_the_identity_under_default_floor(self):
+        # Default appearance_iou_floor (0.5); only appearance_weight is raised for
+        # a robust margin. Appearance discriminates the distractor from true A.
+        cfg = BotSortConfig(
+            lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1, max_age=5),
+            appearance_weight=0.5,
+        )
+        assert cfg.appearance_iou_floor == pytest.approx(0.5)
+        assert self._run(BotSortTracker(cfg)) == 1
+
+
+class TestModerateOverlapRecovery:
+    """A below-floor same-identity reappearance is still recovered on IoU.
+
+    This is the regression guard for the fusion fix: the old sentinel-gate made
+    BoT-SORT stricter than ByteTrack and dropped this match; the fall-back-to-IoU
+    semantics recover it under the DEFAULT config.
+    """
+
+    @staticmethod
+    def _run(tracker: BaseTracker) -> list[int]:
+        tracker.update(_dets([[50, 50, 90, 90]], [0.9], frame_id=0, embeddings=[_E_A]))
+        tracker.update(_dets([], [], frame_id=1, embeddings=[]))
+        # Reappears at IoU ~0.32 (below the default 0.5 floor) with the SAME e_A.
+        out = tracker.update(_dets([[62, 62, 102, 102]], [0.9], frame_id=2, embeddings=[_E_A]))
+        return out.track_ids.tolist()
+
+    def test_botsort_recovers_below_floor_reappearance_under_default_config(self):
+        cfg = BotSortConfig(lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1, max_age=5))
+        # Default floor; no appearance sidestep. The id is preserved, not re-spawned.
+        assert self._run(BotSortTracker(cfg)) == [1]
+
+    def test_matches_the_bytetrack_baseline(self):
+        cfg = ByteTrackConfig(lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1, max_age=5))
+        assert self._run(ByteTrackTracker(cfg)) == [1]
+
+
+class TestGalleryLifecycle:
+    def test_gallery_created_on_spawn_and_dropped_on_removal(self):
+        cfg = BotSortConfig(lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1, max_age=1))
+        tracker = BotSortTracker(cfg)
+        tracker.update(_dets([[10, 10, 50, 50]], [0.9], frame_id=0, embeddings=[_E_A]))
+        assert set(tracker._appearance) == {1}
+        # Three empty frames age the track out: ACTIVE -> LOST -> LOST -> REMOVED.
+        for f in range(1, 4):
+            tracker.update(_dets([], [], frame_id=f, embeddings=[]))
+        assert tracker._appearance == {}
+
+    def test_reset_clears_galleries(self):
+        cfg = BotSortConfig(lifecycle=LifecycleConfig(min_hits=1))
+        tracker = BotSortTracker(cfg)
+        tracker.update(_dets([[10, 10, 50, 50]], [0.9], frame_id=0, embeddings=[_E_A]))
+        tracker.reset()
+        assert tracker._appearance == {}
+
+    def test_low_score_hits_do_not_pollute_gallery(self):
+        # A low-score detection recovers the track but must not enter the gallery.
+        cfg = BotSortConfig(lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1), high_score_threshold=0.5)
+        tracker = BotSortTracker(cfg)
+        tracker.update(_dets([[10, 10, 50, 50]], [0.9], frame_id=0, embeddings=[_E_A]))
+        tracker.update(_dets([[12, 12, 52, 52]], [0.3], frame_id=1, embeddings=[_E_B]))
+        # Only the initial high-score e_A descriptor was admitted.
+        assert len(tracker._appearance[1]) == 1
+
+
+class TestMultiSpawn:
+    def test_each_gallery_is_keyed_to_the_right_detection(self):
+        # Two objects spawn in the same (first) frame; each track's gallery must
+        # hold its own detection's descriptor, verifying the _next_id peek in
+        # _spawn keys galleries correctly.
+        cfg = BotSortConfig(lifecycle=LifecycleConfig(min_hits=1))
+        tracker = BotSortTracker(cfg)
+        out = tracker.update(
+            _dets(
+                [[0, 0, 20, 20], [200, 200, 240, 240]],
+                [0.9, 0.9],
+                frame_id=0,
+                embeddings=[_E_A, _E_B],
+            ),
+        )
+        # Row 0 (e_A) -> id 1, row 1 (e_B) -> id 2.
+        assert out.track_ids.tolist() == [1, 2]
+        # Track 1's gallery matches e_A and rejects e_B, and vice-versa.
+        assert float(tracker._appearance[1].distance(_E_A[None, :])[0]) == pytest.approx(0.0, abs=1e-5)
+        assert float(tracker._appearance[1].distance(_E_B[None, :])[0]) == pytest.approx(1.0, abs=1e-5)
+        assert float(tracker._appearance[2].distance(_E_B[None, :])[0]) == pytest.approx(0.0, abs=1e-5)
+        assert float(tracker._appearance[2].distance(_E_A[None, :])[0]) == pytest.approx(1.0, abs=1e-5)
+
+
+class TestReidConfigWarning:
+    def test_enabled_without_model_source_warns(self):
+        from getitrack.config import ReIDConfig
+
+        with pytest.warns(UserWarning, match="neither model_name nor model_path"):
+            ReIDConfig(enabled=True)
+
+    def test_botsort_config_with_enabled_reid_and_no_source_warns(self):
+        from getitrack.config import ReIDConfig
+
+        with pytest.warns(UserWarning, match="neither model_name nor model_path"):
+            BotSortConfig(reid=ReIDConfig(enabled=True))
+
+    def test_no_warning_when_model_name_set(self):
+        import warnings
+
+        from getitrack.config import ReIDConfig
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            ReIDConfig(enabled=True, model_name="osnet_x1_0")
+
+    def test_no_warning_when_disabled(self):
+        import warnings
+
+        from getitrack.config import ReIDConfig
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            ReIDConfig(enabled=False)
+
+
+class TestNoEmbeddings:
+    def test_botsort_falls_back_to_iou_without_embeddings(self):
+        # With no embeddings supplied, BoT-SORT behaves like ByteTrack.
+        cfg = BotSortConfig(lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1))
+        tracker = BotSortTracker(cfg)
+        tracker.update(_dets([[10, 10, 50, 50]], [0.9], frame_id=0))
+        out = tracker.update(_dets([[12, 12, 52, 52]], [0.9], frame_id=1))
+        assert out.track_ids.tolist() == [1]
+
+
+class TestCameraMotion:
+    @staticmethod
+    def _seeded_tracker() -> BotSortTracker:
+        from getitrack.config import GMCConfig
+
+        cfg = BotSortConfig(gmc=GMCConfig(enabled=True), lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1))
+        tracker = BotSortTracker(cfg)
+        tracker.update(_dets([[50, 50, 90, 90]], [0.9], frame_id=0))
+        return tracker
+
+    def test_cmc_is_none_when_gmc_disabled(self):
+        tracker = BotSortTracker(BotSortConfig())
+        assert tracker.cmc is None
+        assert tracker.apply_camera_motion(np.zeros((20, 20, 3), dtype=np.uint8)) is None
+
+    def test_cmc_built_when_enabled(self):
+        from getitrack.config import GMCConfig
+        from getitrack.motion.gmc import SparseOptFlowEstimator
+
+        tracker = BotSortTracker(BotSortConfig(gmc=GMCConfig(enabled=True)))
+        assert isinstance(tracker.cmc, SparseOptFlowEstimator)
+
+    def test_apply_cmc_translates_predicted_boxes(self):
+        tracker = self._seeded_tracker()
+        before = tracker._tracks[1].bbox.copy()
+        tracker._apply_cmc(np.array([[1, 0, 10], [0, 1, 5]], dtype=np.float32))
+        after = tracker._tracks[1].bbox
+        assert after == pytest.approx(before + np.array([10, 5, 10, 5]), abs=1e-3)
+
+    def test_predict_all_consumes_pending_warp(self):
+        tracker = self._seeded_tracker()
+        left_before = float(tracker._tracks[1].bbox[0])
+        tracker._pending_warp = np.array([[1, 0, 12], [0, 1, 0]], dtype=np.float32)
+        tracker._predict_all()
+        assert tracker._pending_warp is None
+        # The staged +12 x shift moved the predicted box to the right.
+        assert float(tracker._tracks[1].bbox[0]) > left_before + 8

--- a/libraries/getitrack/tests/unit/test_botsort.py
+++ b/libraries/getitrack/tests/unit/test_botsort.py
@@ -245,12 +245,12 @@ class TestNoEmbeddings:
 
 class TestCameraMotion:
     @staticmethod
-    def _seeded_tracker() -> BotSortTracker:
+    def _seeded_tracker(box: list[float] | None = None) -> BotSortTracker:
         from getitrack.config import GMCConfig
 
         cfg = BotSortConfig(gmc=GMCConfig(enabled=True), lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1))
         tracker = BotSortTracker(cfg)
-        tracker.update(_dets([[50, 50, 90, 90]], [0.9], frame_id=0))
+        tracker.update(_dets([box or [50, 50, 90, 90]], [0.9], frame_id=0))
         return tracker
 
     def test_cmc_is_none_when_gmc_disabled(self):
@@ -271,6 +271,34 @@ class TestCameraMotion:
         tracker._apply_cmc(np.array([[1, 0, 10], [0, 1, 5]], dtype=np.float32))
         after = tracker._tracks[1].bbox
         assert after == pytest.approx(before + np.array([10, 5, 10, 5]), abs=1e-3)
+
+    def test_apply_cmc_scale_preserves_aspect_ratio(self):
+        # A uniform zoom must scale width and height equally, leaving the aspect
+        # ratio unchanged; the old kron(I4, R) transform scaled width by s**2.
+        tracker = self._seeded_tracker([50, 50, 90, 130])  # w=40, h=80, aspect 0.5
+        before = tracker._tracks[1].bbox.copy()
+        w0, h0 = before[2] - before[0], before[3] - before[1]
+        tracker._apply_cmc(np.array([[2, 0, 0], [0, 2, 0]], dtype=np.float32))
+        after = tracker._tracks[1].bbox
+        w1, h1 = after[2] - after[0], after[3] - after[1]
+        assert h1 == pytest.approx(2 * h0, rel=1e-2)
+        assert w1 == pytest.approx(2 * w0, rel=1e-2)
+        assert (w1 / h1) == pytest.approx(w0 / h0, rel=1e-2)
+
+    def test_apply_cmc_rotation_keeps_height_and_aspect(self):
+        # A pure rotation (det == 1) must leave height and aspect ratio intact
+        # and never drive them negative; only position rotates.
+        tracker = self._seeded_tracker([50, 50, 90, 130])
+        before = tracker._tracks[1].bbox.copy()
+        w0, h0 = before[2] - before[0], before[3] - before[1]
+        theta = np.deg2rad(10)
+        cos, sin = np.cos(theta), np.sin(theta)
+        tracker._apply_cmc(np.array([[cos, -sin, 0], [sin, cos, 0]], dtype=np.float32))
+        after = tracker._tracks[1].bbox
+        w1, h1 = after[2] - after[0], after[3] - after[1]
+        assert w1 > 0
+        assert h1 == pytest.approx(h0, rel=1e-3)
+        assert (w1 / h1) == pytest.approx(w0 / h0, rel=1e-3)
 
     def test_predict_all_consumes_pending_warp(self):
         tracker = self._seeded_tracker()

--- a/libraries/getitrack/tests/unit/test_botsort.py
+++ b/libraries/getitrack/tests/unit/test_botsort.py
@@ -127,9 +127,8 @@ class TestAppearanceRecovery:
 class TestModerateOverlapRecovery:
     """A below-floor same-identity reappearance is still recovered on IoU.
 
-    This is the regression guard for the fusion fix: the old sentinel-gate made
-    BoT-SORT stricter than ByteTrack and dropped this match; the fall-back-to-IoU
-    semantics recover it under the DEFAULT config.
+    Pairs below the appearance floor fall back to the IoU cost, so the id is
+    preserved under the default config.
     """
 
     @staticmethod

--- a/libraries/getitrack/tests/unit/test_config.py
+++ b/libraries/getitrack/tests/unit/test_config.py
@@ -12,6 +12,7 @@ from getitrack.config import (
     InterpolationMethod,
     LifecycleConfig,
     MotionConfig,
+    ReIDConfig,
     TrackerConfig,
 )
 
@@ -60,6 +61,16 @@ class TestBaseConfig:
         # A subclass pins ``algorithm``; a different value must be rejected.
         with pytest.raises(ValidationError, match="pins algorithm"):
             _DemoConfig(algorithm=AlgorithmType.OCSORT)
+
+
+class TestReIDConfig:
+    def test_accepts_positive_input_size(self):
+        assert ReIDConfig(input_size=(128, 64)).input_size == (128, 64)
+
+    @pytest.mark.parametrize("bad", [(0, 128), (256, 0), (-1, 128), (256, -1)])
+    def test_rejects_non_positive_input_size(self, bad):
+        with pytest.raises(ValidationError, match="input_size"):
+            ReIDConfig(input_size=bad)
 
 
 class TestYAML:

--- a/libraries/getitrack/tests/unit/test_gallery.py
+++ b/libraries/getitrack/tests/unit/test_gallery.py
@@ -1,0 +1,99 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the bounded per-track appearance gallery and EMA."""
+
+import numpy as np
+import pytest
+
+from getitrack.reid.gallery import AppearanceGallery
+
+
+def _gallery(**overrides) -> AppearanceGallery:
+    params = {"gallery_size": 3, "use_ema": False, "ema_alpha": 0.9, "admission_threshold": 10.0}
+    params.update(overrides)
+    return AppearanceGallery(**params)
+
+
+class TestBoundedFIFO:
+    def test_gallery_is_bounded_and_fifo(self):
+        gallery = _gallery(gallery_size=3, use_ema=False)
+        feats = [np.array([np.cos(t), np.sin(t)], dtype=np.float32) for t in np.linspace(0.0, 1.0, 5)]
+        for f in feats:
+            gallery.update(f)
+        # Capacity is respected: only the last 3 descriptors are retained.
+        assert len(gallery) == 3
+        # The two most-recently-added features are near-zero distance; the
+        # evicted earliest one is farther, confirming FIFO eviction order.
+        assert float(gallery.distance(feats[4][None, :])[0]) == pytest.approx(0.0, abs=1e-5)
+        assert float(gallery.distance(feats[2][None, :])[0]) == pytest.approx(0.0, abs=1e-5)
+        assert float(gallery.distance(feats[0][None, :])[0]) > 1e-3
+
+    def test_empty_gallery_reports_nan_distance(self):
+        gallery = _gallery()
+        assert gallery.is_empty
+        dist = gallery.distance(np.array([[1.0, 0.0]], dtype=np.float32))
+        assert np.isnan(dist[0])
+
+
+class TestAdmissionGate:
+    def test_dissimilar_feature_is_rejected(self):
+        gallery = _gallery(gallery_size=5, use_ema=False, admission_threshold=0.2)
+        assert gallery.update(np.array([1.0, 0.0], dtype=np.float32)) is True
+        # Orthogonal (distance ~1.0) exceeds the 0.2 gate and is rejected.
+        assert gallery.update(np.array([0.0, 1.0], dtype=np.float32)) is False
+        assert len(gallery) == 1
+
+
+class TestEMA:
+    def test_ema_update_math(self):
+        gallery = _gallery(use_ema=True, ema_alpha=0.9, admission_threshold=2.0)
+        gallery.update(np.array([1.0, 0.0], dtype=np.float32), confidence=1.0)
+        gallery.update(np.array([0.0, 1.0], dtype=np.float32), confidence=1.0)
+        # w = (1 - 0.9) * 1.0 = 0.1 -> raw = 0.9*[1,0] + 0.1*[0,1] = [0.9, 0.1], then L2-normalised.
+        expected = np.array([0.9, 0.1], dtype=np.float32)
+        expected /= np.linalg.norm(expected)
+        # distance to the (unnormalised) raw direction is ~0 since cosine ignores scale.
+        assert float(gallery.distance(expected[None, :])[0]) == pytest.approx(0.0, abs=1e-5)
+
+    def test_confidence_scales_ema_step(self):
+        gallery = _gallery(use_ema=True, ema_alpha=0.9, admission_threshold=2.0)
+        gallery.update(np.array([1.0, 0.0], dtype=np.float32), confidence=1.0)
+        gallery.update(np.array([0.0, 1.0], dtype=np.float32), confidence=0.5)
+        # w = (1 - 0.9) * 0.5 = 0.05 -> raw = 0.95*[1,0] + 0.05*[0,1] = [0.95, 0.05].
+        expected = np.array([0.95, 0.05], dtype=np.float32)
+        assert float(gallery.distance(expected[None, :])[0]) == pytest.approx(0.0, abs=1e-5)
+
+    def test_ema_mode_matches_the_running_feature(self):
+        gallery = _gallery(use_ema=True, ema_alpha=0.5, admission_threshold=2.0)
+        gallery.update(np.array([1.0, 0.0], dtype=np.float32))
+        assert float(gallery.distance(np.array([[1.0, 0.0]], dtype=np.float32))[0]) == pytest.approx(0.0, abs=1e-5)
+
+
+class TestGallerySizeEffect:
+    """`gallery_size` must actually change matching, in both modes."""
+
+    def test_smaller_gallery_forgets_older_features(self):
+        # use_ema=False: only the FIFO is queried, so eviction is directly visible.
+        feats = [
+            np.array([1.0, 0.0], dtype=np.float32),
+            np.array([0.0, 1.0], dtype=np.float32),
+            np.array([-1.0, 0.0], dtype=np.float32),
+        ]
+        big = _gallery(gallery_size=3, use_ema=False, admission_threshold=10.0)
+        small = _gallery(gallery_size=1, use_ema=False, admission_threshold=10.0)
+        for f in feats:
+            big.update(f)
+            small.update(f)
+        # The size-3 gallery still recognises the earliest feature; the size-1
+        # gallery has evicted everything but the most recent one.
+        assert float(big.distance(feats[0][None, :])[0]) == pytest.approx(0.0, abs=1e-5)
+        assert float(small.distance(feats[0][None, :])[0]) > 0.1
+
+    def test_fifo_is_queried_in_ema_mode_too(self):
+        # In EMA mode the FIFO entries are also representatives, so a raw feature
+        # still in the gallery is matchable even when the EMA has drifted away.
+        gallery = _gallery(gallery_size=5, use_ema=True, ema_alpha=0.9, admission_threshold=2.0)
+        gallery.update(np.array([1.0, 0.0], dtype=np.float32))
+        gallery.update(np.array([0.0, 1.0], dtype=np.float32))
+        # The EMA is dominated by [1, 0], but [0, 1] is retained in the FIFO.
+        assert float(gallery.distance(np.array([[0.0, 1.0]], dtype=np.float32))[0]) == pytest.approx(0.0, abs=1e-5)

--- a/libraries/getitrack/tests/unit/test_gmc.py
+++ b/libraries/getitrack/tests/unit/test_gmc.py
@@ -31,10 +31,10 @@ def _textured(height: int = 200, width: int = 200) -> np.ndarray:
 
 
 def _rich_scene(size: int = 240) -> np.ndarray:
-    """A scene of varied-size, varied-intensity rectangles: distinctive sharp corners.
+    """A scene of varied-size, varied-intensity rectangles with distinct corners.
 
-    Unlike uniform shapes, the distinct grey levels give descriptor-based methods
-    (ORB/SIFT) unambiguous matches that survive the ratio test.
+    The distinct grey levels give descriptor-based methods (ORB/SIFT) unambiguous
+    matches that survive the ratio test.
     """
     rng = np.random.default_rng(3)
     frame = np.full((size, size, 3), 40, dtype=np.uint8)

--- a/libraries/getitrack/tests/unit/test_gmc.py
+++ b/libraries/getitrack/tests/unit/test_gmc.py
@@ -93,6 +93,14 @@ class TestTranslationRecovery:
         # full-resolution pixels, so it should still recover ~8 not ~4.
         assert warp[0, 2] == pytest.approx(8.0, abs=2.5)
 
+    def test_large_downscale_on_small_frame_does_not_crash(self):
+        # A downscale larger than the frame would floor a resize dimension to
+        # zero (and OpenCV would raise) without the clamp; estimate must run.
+        estimator = SparseOptFlowEstimator(downscale=32)
+        assert np.array_equal(estimator.estimate(_textured(height=20, width=20)), _IDENTITY)
+        warp = estimator.estimate(_textured(height=20, width=20))
+        assert warp.shape == (2, 3)
+
 
 class TestECC:
     def test_returns_affine_shape(self):

--- a/libraries/getitrack/tests/unit/test_gmc.py
+++ b/libraries/getitrack/tests/unit/test_gmc.py
@@ -1,0 +1,128 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the global motion compensation (camera-motion) estimators."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from getitrack.config import GMCConfig, GMCMethod
+from getitrack.motion.gmc import (
+    BaseMotionEstimator,
+    ECCEstimator,
+    ORBEstimator,
+    SIFTEstimator,
+    SparseOptFlowEstimator,
+)
+
+_IDENTITY = np.eye(2, 3, dtype=np.float32)
+
+
+def _textured(height: int = 200, width: int = 200) -> np.ndarray:
+    """A corner-rich frame: bright squares scattered on a dark background."""
+    rng = np.random.default_rng(0)
+    frame = np.zeros((height, width, 3), dtype=np.uint8)
+    for _ in range(80):
+        y = int(rng.integers(6, height - 8))
+        x = int(rng.integers(6, width - 8))
+        frame[y : y + 4, x : x + 4] = 255
+    return frame
+
+
+def _rich_scene(size: int = 240) -> np.ndarray:
+    """A scene of varied-size, varied-intensity rectangles: distinctive sharp corners.
+
+    Unlike uniform shapes, the distinct grey levels give descriptor-based methods
+    (ORB/SIFT) unambiguous matches that survive the ratio test.
+    """
+    rng = np.random.default_rng(3)
+    frame = np.full((size, size, 3), 40, dtype=np.uint8)
+    for _ in range(70):
+        x, y = int(rng.integers(10, size - 30)), int(rng.integers(10, size - 30))
+        w, h = int(rng.integers(6, 26)), int(rng.integers(6, 26))
+        frame[y : y + h, x : x + w] = int(rng.integers(80, 256))
+    return frame
+
+
+class TestFromConfig:
+    def test_dispatches_by_method(self):
+        cases = [
+            (GMCMethod.SPARSE_OPT_FLOW, SparseOptFlowEstimator),
+            (GMCMethod.ECC, ECCEstimator),
+            (GMCMethod.ORB, ORBEstimator),
+            (GMCMethod.SIFT, SIFTEstimator),
+        ]
+        for method, expected in cases:
+            assert isinstance(BaseMotionEstimator.from_config(GMCConfig(method=method)), expected)
+
+    def test_passes_downscale(self):
+        estimator = BaseMotionEstimator.from_config(GMCConfig(downscale=4))
+        assert estimator._downscale == 4
+
+
+class TestFirstFrameAndReset:
+    def test_first_frame_is_identity(self):
+        estimator = SparseOptFlowEstimator(downscale=1)
+        assert np.array_equal(estimator.estimate(_textured()), _IDENTITY)
+
+    def test_reset_returns_to_identity(self):
+        estimator = SparseOptFlowEstimator(downscale=1)
+        estimator.estimate(_textured())
+        estimator.reset()
+        assert np.array_equal(estimator.estimate(_textured()), _IDENTITY)
+
+
+class TestTranslationRecovery:
+    def test_sparse_optflow_recovers_shift(self):
+        estimator = SparseOptFlowEstimator(downscale=1)
+        base = _textured()
+        shifted = np.roll(base, shift=7, axis=1)  # content moves +7 in x
+        estimator.estimate(base)
+        warp = estimator.estimate(shifted)
+        assert warp[0, 2] == pytest.approx(7.0, abs=2.0)
+        assert warp[1, 2] == pytest.approx(0.0, abs=2.0)
+
+    def test_downscale_rescales_translation(self):
+        estimator = SparseOptFlowEstimator(downscale=2)
+        base = _textured()
+        shifted = np.roll(base, shift=8, axis=1)
+        estimator.estimate(base)
+        warp = estimator.estimate(shifted)
+        # Estimation runs at half resolution; the returned translation is in
+        # full-resolution pixels, so it should still recover ~8 not ~4.
+        assert warp[0, 2] == pytest.approx(8.0, abs=2.5)
+
+
+class TestECC:
+    def test_returns_affine_shape(self):
+        estimator = ECCEstimator(downscale=1)
+        estimator.estimate(_textured())
+        warp = estimator.estimate(np.roll(_textured(), shift=4, axis=1))
+        assert warp.shape == (2, 3)
+        assert warp.dtype == np.float32
+        assert np.all(np.isfinite(warp))
+
+
+class TestFeatureMethods:
+    @pytest.mark.parametrize("estimator_cls", [ORBEstimator, SIFTEstimator])
+    def test_first_frame_is_identity(self, estimator_cls):
+        estimator = estimator_cls(downscale=1)
+        assert np.array_equal(estimator.estimate(_rich_scene()), _IDENTITY)
+
+    @pytest.mark.parametrize("estimator_cls", [ORBEstimator, SIFTEstimator])
+    def test_recovers_translation(self, estimator_cls):
+        estimator = estimator_cls(downscale=1)
+        base = _rich_scene()
+        shifted = np.roll(base, shift=7, axis=1)
+        estimator.estimate(base)
+        warp = estimator.estimate(shifted)
+        assert warp[0, 2] == pytest.approx(7.0, abs=2.0)
+        assert warp[1, 2] == pytest.approx(0.0, abs=2.0)
+
+    def test_low_texture_frame_falls_back_to_identity(self):
+        # A blank frame yields no keypoints; the estimate must not raise.
+        estimator = ORBEstimator(downscale=1)
+        blank = np.zeros((120, 120, 3), dtype=np.uint8)
+        estimator.estimate(blank)
+        assert np.array_equal(estimator.estimate(blank), _IDENTITY)

--- a/libraries/getitrack/tests/unit/test_reid_export.py
+++ b/libraries/getitrack/tests/unit/test_reid_export.py
@@ -9,6 +9,7 @@ pre-created IR) and never trigger the heavy imports.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from getitrack.reid.export import _cache_stem, _default_cache_dir, export_torchreid_to_openvino
@@ -29,6 +30,22 @@ class TestCacheStem:
 
     def test_encodes_size(self):
         assert "256x128" in _cache_stem("osnet_x1_0", (256, 128), None)
+
+    def test_in_place_weights_update_changes_stem(self, tmp_path):
+        # Replacing a checkpoint in place must invalidate the cache key, so the
+        # stem must reflect the file contents, not just its path.
+        weights = tmp_path / "model.pth.tar"
+        weights.write_bytes(b"first checkpoint")
+        first = _cache_stem("osnet_x1_0", (256, 128), weights)
+        # Rewrite in place with different contents and a later mtime.
+        weights.write_bytes(b"second checkpoint, larger payload")
+        os.utime(weights, ns=(2_000_000_000_000, 2_000_000_000_000))
+        second = _cache_stem("osnet_x1_0", (256, 128), weights)
+        assert first != second
+
+    def test_missing_weights_file_falls_back_to_path(self):
+        # A non-existent checkpoint still produces a stable, path-based stem.
+        assert _cache_stem("osnet_x1_0", (256, 128), "missing.pth.tar")
 
 
 class TestCacheHit:

--- a/libraries/getitrack/tests/unit/test_reid_export.py
+++ b/libraries/getitrack/tests/unit/test_reid_export.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the torchreid-to-OpenVINO export bridge.
+
+Only the cache and filename logic is exercised; the actual conversion needs
+torch/torchreid/openvino, so these tests stay on the cache-hit path (a
+pre-created IR) and never trigger the heavy imports.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from getitrack.reid.export import _cache_stem, _default_cache_dir, export_torchreid_to_openvino
+
+
+class TestCacheStem:
+    def test_distinguishes_model_size_and_weights(self):
+        stems = {
+            _cache_stem("osnet_x1_0", (256, 128), None),
+            _cache_stem("osnet_ain_x1_0", (256, 128), None),
+            _cache_stem("osnet_x1_0", (128, 64), None),
+            _cache_stem("osnet_x1_0", (256, 128), "weights.pth.tar"),
+        }
+        assert len(stems) == 4
+
+    def test_pretrained_tag_when_no_weights(self):
+        assert _cache_stem("osnet_x1_0", (256, 128), None).endswith("pretrained")
+
+    def test_encodes_size(self):
+        assert "256x128" in _cache_stem("osnet_x1_0", (256, 128), None)
+
+
+class TestCacheHit:
+    def test_returns_existing_ir_without_export(self, tmp_path):
+        # Pre-create the cached IR so the heavy conversion path is never entered.
+        xml = tmp_path / f"{_cache_stem('osnet_x1_0', (256, 128), None)}.xml"
+        xml.write_text("<net/>")
+        out = export_torchreid_to_openvino("osnet_x1_0", (256, 128), cache_dir=tmp_path)
+        assert out == xml
+
+
+class TestDefaultCacheDir:
+    def test_under_home_cache(self):
+        assert _default_cache_dir() == Path.home() / ".cache" / "getitrack" / "reid"

--- a/libraries/getitrack/tests/unit/test_reid_factory.py
+++ b/libraries/getitrack/tests/unit/test_reid_factory.py
@@ -1,0 +1,95 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for `build_reid_provider` backend dispatch.
+
+The provider classes and the export bridge are monkeypatched, so dispatch is
+verified without torch/torchreid/openvino installed: the tests assert which
+backend is chosen and with what arguments.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pytest
+
+from getitrack.config import ReIDBackend, ReIDConfig
+from getitrack.reid.factory import _torch_device, build_reid_provider
+
+
+class TestDispatch:
+    def test_disabled_returns_none(self):
+        assert build_reid_provider(ReIDConfig(enabled=False)) is None
+
+    def test_enabled_without_source_returns_none(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            cfg = ReIDConfig(enabled=True)
+        assert build_reid_provider(cfg) is None
+
+    def test_torch_requires_model_name(self):
+        cfg = ReIDConfig(enabled=True, backend=ReIDBackend.TORCH, model_path=Path("weights.pth.tar"))
+        with pytest.raises(ValueError, match="requires model_name"):
+            build_reid_provider(cfg)
+
+    def test_torch_dispatch(self, monkeypatch):
+        captured: dict[str, object] = {}
+
+        def fake_torch(model_name, *, weights_path, device, input_size) -> str:
+            captured.update(model_name=model_name, weights_path=weights_path, device=device, input_size=input_size)
+            return "TORCH_PROVIDER"
+
+        monkeypatch.setattr("getitrack.reid.torchreid_provider.TorchReIDProvider", fake_torch)
+        cfg = ReIDConfig(
+            enabled=True, backend=ReIDBackend.TORCH, model_name="osnet_x1_0", device="CPU", input_size=(128, 64)
+        )
+        assert build_reid_provider(cfg) == "TORCH_PROVIDER"
+        assert captured["model_name"] == "osnet_x1_0"
+        assert captured["device"] == "cpu"
+        assert captured["input_size"] == (128, 64)
+
+    def test_openvino_export_dispatch(self, monkeypatch, tmp_path):
+        export_calls: dict[str, object] = {}
+        ov_calls: dict[str, object] = {}
+        exported = tmp_path / "exported.xml"
+
+        def fake_export(model_name, input_size, *, weights_path, cache_dir) -> Path:
+            export_calls.update(
+                model_name=model_name, input_size=input_size, weights_path=weights_path, cache_dir=cache_dir
+            )
+            return exported
+
+        def fake_ov(model_path, *, input_size, device) -> str:
+            ov_calls.update(model_path=model_path, input_size=input_size, device=device)
+            return "OV_PROVIDER"
+
+        monkeypatch.setattr("getitrack.reid.export.export_torchreid_to_openvino", fake_export)
+        monkeypatch.setattr("getitrack.reid.openvino_provider.OpenVINOReIDProvider", fake_ov)
+        cfg = ReIDConfig(enabled=True, backend=ReIDBackend.OPENVINO, model_name="osnet_x1_0", device="CPU")
+        assert build_reid_provider(cfg) == "OV_PROVIDER"
+        assert export_calls["model_name"] == "osnet_x1_0"
+        assert ov_calls["model_path"] == exported
+        assert ov_calls["device"] == "CPU"
+
+    def test_openvino_prebuilt_ir_dispatch(self, monkeypatch, tmp_path):
+        ov_calls: dict[str, object] = {}
+
+        def fake_ov(model_path, *, input_size, device) -> str:
+            ov_calls.update(model_path=model_path, input_size=input_size, device=device)
+            return "OV_PROVIDER"
+
+        monkeypatch.setattr("getitrack.reid.openvino_provider.OpenVINOReIDProvider", fake_ov)
+        ir = tmp_path / "model.xml"
+        cfg = ReIDConfig(enabled=True, backend=ReIDBackend.OPENVINO, model_path=ir)
+        assert build_reid_provider(cfg) == "OV_PROVIDER"
+        assert ov_calls["model_path"] == ir
+
+
+class TestTorchDevice:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [("CPU", "cpu"), ("cpu", "cpu"), ("GPU", "cuda"), ("gpu", "cuda"), ("cuda", "cuda"), ("cuda:1", "cuda:1")],
+    )
+    def test_mapping(self, value, expected):
+        assert _torch_device(value) == expected

--- a/libraries/getitrack/tests/unit/test_reid_provider.py
+++ b/libraries/getitrack/tests/unit/test_reid_provider.py
@@ -1,0 +1,125 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the ReID feature-provider layer.
+
+The abstract contract and fusion wiring are checked with a lightweight mock so
+they run without any inference backend. The OpenVINO provider is exercised
+against a tiny CNN exported to IR at test time, so no pretrained weights are
+required; it is skipped when ``torch``/``openvino`` are unavailable.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from getitrack.matching.appearance import l2_normalize
+from getitrack.reid.base import ReIDProvider
+
+
+class _MockReIDProvider(ReIDProvider):
+    """Deterministic provider: embeds each box by its geometry, then normalises."""
+
+    def __init__(self, dim: int = 8) -> None:
+        self._dim = dim
+        self._rng = np.random.default_rng(0)
+
+    def extract(self, frame_bgr: np.ndarray, boxes: np.ndarray) -> np.ndarray:
+        box_array = np.asarray(boxes, dtype=np.float32).reshape(-1, 4)
+        if box_array.shape[0] == 0:
+            return np.empty((0, self._dim), dtype=np.float32)
+        raw = self._rng.random((box_array.shape[0], self._dim)).astype(np.float32)
+        return l2_normalize(raw)
+
+
+class TestAbstractContract:
+    def test_cannot_instantiate_abstract_base(self):
+        with pytest.raises(TypeError):
+            ReIDProvider()  # type: ignore[abstract]  # pyrefly: ignore[bad-instantiation]
+
+    def test_mock_returns_normalised_features(self):
+        provider = _MockReIDProvider(dim=8)
+        frame = np.zeros((100, 100, 3), dtype=np.uint8)
+        boxes = np.array([[0, 0, 10, 10], [20, 20, 40, 40]], dtype=np.float32)
+        feats = provider.extract(frame, boxes)
+        assert feats.shape == (2, 8)
+        assert feats.dtype == np.float32
+        assert np.allclose(np.linalg.norm(feats, axis=1), 1.0, atol=1e-5)
+
+    def test_mock_handles_empty_boxes(self):
+        provider = _MockReIDProvider(dim=8)
+        frame = np.zeros((10, 10, 3), dtype=np.uint8)
+        feats = provider.extract(frame, np.empty((0, 4), dtype=np.float32))
+        assert feats.shape == (0, 8)
+
+
+class TestOpenVINOProvider:
+    @staticmethod
+    def _export_tiny_ir(tmp_path, height: int, width: int, out_dim: int) -> str:
+        torch = pytest.importorskip("torch")
+        ov = pytest.importorskip("openvino")
+        from torch import nn
+
+        class _TinyReID(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.conv = nn.Conv2d(3, 8, kernel_size=3, padding=1)
+                self.pool = nn.AdaptiveAvgPool2d(1)
+                self.fc = nn.Linear(8, out_dim)
+
+            def forward(self, x: torch.Tensor) -> torch.Tensor:
+                x = torch.relu(self.conv(x))
+                x = self.pool(x).flatten(1)
+                return self.fc(x)
+
+        model = _TinyReID().eval()
+        ov_model = ov.convert_model(model, example_input=torch.zeros(1, 3, height, width))
+        xml_path = tmp_path / "tiny_reid.xml"
+        ov.save_model(ov_model, str(xml_path))
+        return str(xml_path)
+
+    def test_extract_shape_dtype_and_normalisation(self, tmp_path):
+        pytest.importorskip("torch")
+        pytest.importorskip("openvino")
+        from getitrack.reid.openvino_provider import OpenVINOReIDProvider
+
+        height, width, out_dim = 64, 32, 16
+        xml_path = self._export_tiny_ir(tmp_path, height, width, out_dim)
+        provider = OpenVINOReIDProvider(xml_path, input_size=(height, width))
+        rng = np.random.default_rng(1)
+        frame = (rng.random((120, 200, 3)) * 255).astype(np.uint8)
+        boxes = np.array([[10, 10, 60, 90], [100, 20, 180, 110]], dtype=np.float32)
+        feats = provider.extract(frame, boxes)
+        assert feats.shape == (2, out_dim)
+        assert feats.dtype == np.float32
+        assert np.allclose(np.linalg.norm(feats, axis=1), 1.0, atol=1e-4)
+
+    def test_degenerate_box_does_not_crash(self, tmp_path):
+        pytest.importorskip("torch")
+        pytest.importorskip("openvino")
+        from getitrack.reid.openvino_provider import OpenVINOReIDProvider
+
+        xml_path = self._export_tiny_ir(tmp_path, 64, 32, 16)
+        provider = OpenVINOReIDProvider(xml_path, input_size=(64, 32))
+        frame = np.zeros((50, 50, 3), dtype=np.uint8)
+        # Zero-area and out-of-bounds boxes are clamped, not rejected.
+        boxes = np.array([[10, 10, 10, 10], [-5, -5, 3, 3]], dtype=np.float32)
+        feats = provider.extract(frame, boxes)
+        assert feats.shape == (2, 16)
+
+    def test_empty_boxes_before_first_infer(self, tmp_path):
+        pytest.importorskip("torch")
+        pytest.importorskip("openvino")
+        from getitrack.reid.openvino_provider import OpenVINOReIDProvider
+
+        xml_path = self._export_tiny_ir(tmp_path, 64, 32, 16)
+        provider = OpenVINOReIDProvider(xml_path, input_size=(64, 32))
+        feats = provider.extract(np.zeros((10, 10, 3), dtype=np.uint8), np.empty((0, 4), dtype=np.float32))
+        # Feature width is unknown before the first inference, so it is 0.
+        assert feats.shape == (0, 0)
+
+    def test_requires_a_source(self):
+        from getitrack.reid.openvino_provider import OpenVINOReIDProvider
+
+        with pytest.raises(ValueError, match="model_path or compiled_model"):
+            OpenVINOReIDProvider()

--- a/libraries/getitrack/tests/unit/test_torchreid_compat.py
+++ b/libraries/getitrack/tests/unit/test_torchreid_compat.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the torchreid tensorboard-import compatibility shim."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+
+from getitrack.reid._torchreid_compat import ensure_torchreid_importable
+
+_NAME = "torch.utils.tensorboard"
+
+
+class TestEnsureTorchreidImportable:
+    def test_installs_stub_when_tensorboard_absent(self, monkeypatch):
+        monkeypatch.delitem(sys.modules, _NAME, raising=False)
+        real = importlib.util.find_spec
+        monkeypatch.setattr(importlib.util, "find_spec", lambda n: None if n == "tensorboard" else real(n))
+
+        ensure_torchreid_importable()
+
+        assert _NAME in sys.modules
+        from torch.utils.tensorboard import SummaryWriter  # resolves via the stub
+
+        assert SummaryWriter is object
+
+    def test_noop_when_tensorboard_available(self, monkeypatch):
+        monkeypatch.delitem(sys.modules, _NAME, raising=False)
+        real = importlib.util.find_spec
+        monkeypatch.setattr(importlib.util, "find_spec", lambda n: object() if n == "tensorboard" else real(n))
+
+        ensure_torchreid_importable()
+
+        # No stub is registered; the real torch.utils.tensorboard would be used.
+        assert _NAME not in sys.modules
+
+    def test_noop_when_already_registered(self, monkeypatch):
+        sentinel = types.ModuleType(_NAME)
+        monkeypatch.setitem(sys.modules, _NAME, sentinel)
+
+        ensure_torchreid_importable()
+
+        assert sys.modules[_NAME] is sentinel

--- a/libraries/getitrack/tests/unit/test_torchreid_provider.py
+++ b/libraries/getitrack/tests/unit/test_torchreid_provider.py
@@ -1,0 +1,101 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the torchreid ReID provider.
+
+The provider is exercised through an injected fake extractor, so the tests run
+without torch/torchreid installed. The fake mimics torchreid's contract: called
+with a list of ``(H, W, 3)`` RGB crops, it returns a tensor-like object whose
+``detach().cpu().numpy()`` yields the descriptors.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from getitrack.reid.torchreid_provider import TorchReIDProvider
+
+
+class _FakeTensor:
+    """Numpy-backed stand-in for a torch tensor (detach/cpu/numpy chain)."""
+
+    def __init__(self, array: np.ndarray) -> None:
+        self._array = array
+
+    def detach(self) -> _FakeTensor:
+        return self
+
+    def cpu(self) -> _FakeTensor:
+        return self
+
+    def numpy(self) -> np.ndarray:
+        return self._array
+
+
+class _FakeExtractor:
+    """Records the crops it was called with and returns one row per crop."""
+
+    def __init__(self, dim: int = 16) -> None:
+        self.dim = dim
+        self.last_crops: list[np.ndarray] | None = None
+
+    def __call__(self, images: list[np.ndarray]) -> _FakeTensor:
+        self.last_crops = images
+        rows = np.stack([np.full(self.dim, i + 1, dtype=np.float32) for i in range(len(images))])
+        return _FakeTensor(rows)
+
+
+def _provider(dim: int = 16) -> tuple[TorchReIDProvider, _FakeExtractor]:
+    extractor = _FakeExtractor(dim=dim)
+    return TorchReIDProvider("osnet_x1_0", extractor=extractor), extractor
+
+
+class TestExtract:
+    def test_shape_dtype_and_normalisation(self):
+        provider, _ = _provider(dim=16)
+        frame = np.zeros((120, 200, 3), dtype=np.uint8)
+        boxes = np.array([[10, 10, 60, 90], [100, 20, 180, 110]], dtype=np.float32)
+        feats = provider.extract(frame, boxes)
+        assert feats.shape == (2, 16)
+        assert feats.dtype == np.float32
+        assert np.allclose(np.linalg.norm(feats, axis=1), 1.0, atol=1e-5)
+
+    def test_one_crop_per_box(self):
+        provider, extractor = _provider()
+        frame = np.zeros((100, 100, 3), dtype=np.uint8)
+        provider.extract(frame, np.array([[0, 0, 10, 10], [20, 20, 40, 40], [5, 5, 15, 15]], dtype=np.float32))
+        assert extractor.last_crops is not None
+        assert len(extractor.last_crops) == 3
+
+    def test_crops_are_rgb_contiguous(self):
+        provider, extractor = _provider()
+        # Distinct per-channel values in BGR: B=10, G=20, R=200.
+        frame = np.zeros((50, 50, 3), dtype=np.uint8)
+        frame[:, :, 0], frame[:, :, 1], frame[:, :, 2] = 10, 20, 200
+        provider.extract(frame, np.array([[0, 0, 20, 20]], dtype=np.float32))
+        assert extractor.last_crops is not None
+        crop = extractor.last_crops[0]
+        assert crop.flags["C_CONTIGUOUS"]
+        # After BGR->RGB the first channel is R (200), the last is B (10).
+        assert crop[0, 0, 0] == 200
+        assert crop[0, 0, 2] == 10
+
+    def test_empty_boxes_before_first_infer(self):
+        provider, _ = _provider(dim=16)
+        feats = provider.extract(np.zeros((10, 10, 3), dtype=np.uint8), np.empty((0, 4), dtype=np.float32))
+        # Feature width is unknown before the first inference, so it is 0.
+        assert feats.shape == (0, 0)
+
+    def test_empty_boxes_after_first_infer_uses_known_dim(self):
+        provider, _ = _provider(dim=16)
+        provider.extract(np.zeros((60, 60, 3), dtype=np.uint8), np.array([[0, 0, 30, 30]], dtype=np.float32))
+        feats = provider.extract(np.zeros((10, 10, 3), dtype=np.uint8), np.empty((0, 4), dtype=np.float32))
+        assert feats.shape == (0, 16)
+
+    def test_degenerate_box_does_not_crash(self):
+        provider, extractor = _provider()
+        frame = np.zeros((50, 50, 3), dtype=np.uint8)
+        # Zero-area and out-of-bounds boxes are clamped to a 1-pixel crop.
+        feats = provider.extract(frame, np.array([[10, 10, 10, 10], [-5, -5, 3, 3]], dtype=np.float32))
+        assert feats.shape == (2, 16)
+        assert extractor.last_crops is not None
+        assert all(crop.size > 0 for crop in extractor.last_crops)

--- a/libraries/getitrack/uv.lock
+++ b/libraries/getitrack/uv.lock
@@ -25,6 +25,101 @@ wheels = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "13.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/6b/457ca12dad3ee9bfcc9a545cfd6b64b359ba49de40f776f6e028e678f262/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5879712accf6e14bb01aa5e67440eb84998b8d104b509cc7a6dc0b8f656a474", size = 6053539, upload-time = "2026-05-29T23:11:43.19Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7a/c5e3c34a409b148f5c0f5a4ea374158f95d488862c1dffedf9aa5c639df9/cuda_bindings-13.3.1-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:04436a9364059c84b8f9636f359eccda1cf814341f5b670c71d80d2f79dbc708", size = 6674166, upload-time = "2026-05-29T23:11:45.478Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/81/bff68ce829999c1e4209c761bbf903b1c06ec570416ddb25020864ad5907/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ab2f74ed65bfef4163ba07a8db16f1085e0729291db12a2423aff84ee8278b8", size = 6013639, upload-time = "2026-05-29T23:12:03.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd4c814d311ec08c981f6dded1dbe7d4b371067ee4f6c14cccec4bde9590f80", size = 6534419, upload-time = "2026-05-29T23:12:05.633Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/83b1f563925b290f2d11a01a77a84013ba56052fe3653a5bef3ccfbb43d6/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3c772dfff49681541d59630c90f858e173ac926b9c593a2b7123f2a1043cc76", size = 5809771, upload-time = "2026-05-29T23:12:10.422Z" },
+    { url = "https://files.pythonhosted.org/packages/12/20/e79b4bfe98f075195afb6343d41c498f9dbd2d161d7021d4d28bceb83581/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36febb7c1079d68a981dbbd8d5a67235b399802b82075c9388624719607e52b9", size = 6358584, upload-time = "2026-05-29T23:12:12.767Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/01/a7171c5e2e8755597bd8f1c1eb228a0876f502afdf25f936061f5dbe2880/cuda_pathfinder-1.7.0-py3-none-any.whl", hash = "sha256:e9d67e950f3d5992b854dfd25917c3719d0c21d3057b11abe86ba6feec526138", size = 63091, upload-time = "2026-08-24T04:13:56.054Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.3.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/c7/a79086a62c98befcdb8349656c6f114e2db3b8b2422f6e25c97a7f2a9a3c/cuda_toolkit-13.0.3.0-py2.py3-none-any.whl", hash = "sha256:d693caaa261214ddd7dbb60d68e71cbed884e68c2be7509778f3051da0b91c3f", size = 2512, upload-time = "2026-04-14T00:50:08.173Z" },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cusolver = [
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.32.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/30/03b03951873a1a0ffc7e8ca0e10c15597b59e8d0e39260704cd2ea087bc4/filelock-3.32.4.tar.gz", hash = "sha256:2bde2e4cf732e0153406d8a7bc80620ecf5e621fe0d25e41143c4e3b4733ff30", size = 222126, upload-time = "2026-08-23T17:37:55.363Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/a4/9b63d595d748e3aff8812b65eacc1a2c4bd90b7c2012e08e72373b4835eb/filelock-3.32.4-py3-none-any.whl", hash = "sha256:22e58ca3b1ae3b98993b762d7338367ae64fe50252bf78d59da3bfebcdf1cedd", size = 99864, upload-time = "2026-08-23T17:37:53.913Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88", size = 317040, upload-time = "2026-07-28T16:34:51.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279", size = 206583, upload-time = "2026-07-28T16:34:49.538Z" },
+]
+
+[[package]]
 name = "getitrack"
 source = { editable = "." }
 dependencies = [
@@ -34,6 +129,14 @@ dependencies = [
     { name = "pyyaml" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+
+[package.optional-dependencies]
+reid = [
+    { name = "openvino" },
+    { name = "torch" },
+    { name = "torchreid" },
+    { name = "torchvision" },
 ]
 
 [package.dev-dependencies]
@@ -51,10 +154,15 @@ lint = [
 requires-dist = [
     { name = "numpy", specifier = "~=2.0" },
     { name = "opencv-python-headless", specifier = "~=4.11" },
+    { name = "openvino", marker = "extra == 'reid'", specifier = ">=2024.0" },
     { name = "pydantic", specifier = "~=2.7" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "scipy", specifier = "~=1.13" },
+    { name = "torch", marker = "extra == 'reid'", specifier = ">=2.0" },
+    { name = "torchreid", marker = "extra == 'reid'", specifier = ">=0.2.5" },
+    { name = "torchvision", marker = "extra == 'reid'", specifier = ">=0.15" },
 ]
+provides-extras = ["reid"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -74,6 +182,110 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
@@ -156,6 +368,158 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cublas"
+version = "13.1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.20.0.48"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
+]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.0.0.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+]
+
+[[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.29.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink"
+version = "13.3.33"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/ee/580ca6f29dcab0221db8706badca1bbbb084f1975c4d4e83329c3a7e31f0/nvidia_nvjitlink-13.3.33-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:26a6de7fb4c8fdaa7703d3dad720d6d427ddfea5c48a528fd97c11733ad830e5", size = 40742423, upload-time = "2026-05-26T16:54:51.613Z" },
+    { url = "https://files.pythonhosted.org/packages/69/30/45414e35ff2eee7db3da037e5707037ccf9d2b5218ffbdb055ea4d5aa98a/nvidia_nvjitlink-13.3.33-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ce48b37dfeb3cb1eae4cf85adacb47d7a6539ea2272870c9a3628ce275c2037e", size = 39168635, upload-time = "2026-05-26T16:54:13.906Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+]
+
+[[package]]
 name = "opencv-python-headless"
 version = "4.13.0.92"
 source = { registry = "https://pypi.org/simple" }
@@ -174,12 +538,116 @@ wheels = [
 ]
 
 [[package]]
+name = "openvino"
+version = "2026.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "openvino-telemetry" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/25/8236b2d5ab10805d3603ec50bb1dbd7d4d6fad9bf1531c98c031f5202cb2/openvino-2026.3.0-22451-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6b883cda2ac9dc366881f4c62f039f880c2e6d5e3254a6621d0ba338561ed445", size = 31568962, upload-time = "2026-08-04T09:06:07.734Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/8e/b162407883ad51958d481c2af29d59e694caf4d8216b0c409c59294fd1aa/openvino-2026.3.0-22451-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:93e111164ccfd5c801edcfc3437683210837463bf57a2bd0518b940598664c2c", size = 57472600, upload-time = "2026-08-04T09:06:11.568Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/5b/6cb9709ced1c2f0a89886e70980278363b1240b50ece7cecf9021342761e/openvino-2026.3.0-22451-cp311-cp311-manylinux_2_35_aarch64.whl", hash = "sha256:e13cfe5fad386d615caa55592dc48be31099506eafea2cdb6dda06f2455bd248", size = 28768848, upload-time = "2026-08-04T09:06:14.926Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f8/4970bc51a626c07c4d09a2c9395c13e99dfadca05b2c037fd612927f913a/openvino-2026.3.0-22451-cp311-cp311-win_amd64.whl", hash = "sha256:7b688e38cc129cc268253c17d29a70d57e6e3ef8fb477a211294d1506440da15", size = 75789537, upload-time = "2026-08-04T09:06:19.658Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/aa/80fff09a5559800b79f73e3f56ec1597c80dabdca95b7cce7d07a7615ca8/openvino-2026.3.0-22451-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e9a19dce2390bec6d9fa61de94cdc9d78c64bc6bcab799d53948ff0bf2a534b", size = 31609465, upload-time = "2026-08-04T09:06:23.306Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/3c/e5eb8b5e52877251d2e98e91781b265588e10cc2ddf82265285ef808f20f/openvino-2026.3.0-22451-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a6887adfddf18837e6ed8230c837702d878db83b50b96c5759f8484be495f696", size = 57480757, upload-time = "2026-08-04T09:06:27.245Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8b/a726bd2e1e671d1d3aa06def11c24f8c6dbffb076b5d1d29635ffdd69fb7/openvino-2026.3.0-22451-cp312-cp312-manylinux_2_35_aarch64.whl", hash = "sha256:70cd11e4b14bde48842b611630dc5b141fbfc235ff863640e08463b86a7816de", size = 28760034, upload-time = "2026-08-04T09:06:30.551Z" },
+    { url = "https://files.pythonhosted.org/packages/59/c0/0321a5bc8179b589a6f9fe401d72ec9e95912cdf62dec3a2e7b6f9f4d807/openvino-2026.3.0-22451-cp312-cp312-win_amd64.whl", hash = "sha256:865d2e7e947e544d67117cf79dc160241584ce2138dd5a878e91053ba4f50bf0", size = 75797293, upload-time = "2026-08-04T09:06:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dd/371187173998ca980b7a53a29cf48fede4310cedd77e27a64e334b048ea2/openvino-2026.3.0-22451-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5e1d3dc569cc1a81f4fd004ecbfdbdda0b07996af1bf87228b9f186e8497bac1", size = 31609578, upload-time = "2026-08-04T09:06:39.908Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d3/69e7083339f32621359f0bce2be3a7454db3c9a71fa7492f0a0941c00037/openvino-2026.3.0-22451-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:b7d09f20f009b9167a863f615a2b27400ce025bda8086cc72a2eb6ac3bf1d2af", size = 57480757, upload-time = "2026-08-04T09:06:44.336Z" },
+    { url = "https://files.pythonhosted.org/packages/80/61/19ac3641dcfcaee5bf9ada945579b3ab69701750e5270346633c56fdf876/openvino-2026.3.0-22451-cp313-cp313-manylinux_2_35_aarch64.whl", hash = "sha256:0b071a4e2f731ab29bb9a08bab804c326cc4893283274c352ca56fccafa44749", size = 28760034, upload-time = "2026-08-04T09:06:47.326Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f8/f71508784562a3d427f52f59d74a6364d559e6e82bb112cab5d6a6a677bb/openvino-2026.3.0-22451-cp313-cp313-win_amd64.whl", hash = "sha256:1c41f2d1072d600c260741b350aaf4a09d53f821a9a8fc8989bdc79a46b50a2c", size = 75797507, upload-time = "2026-08-04T09:06:51.858Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/94/c7ca8d625dff92fd90bc58a508d578c286973ea9b5789b1ad7a808aaee02/openvino-2026.3.0-22451-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:30234fafbec63f9306587511132024729d0f5f7e68d900c5df37efdf759b1384", size = 31585580, upload-time = "2026-08-04T09:06:55.376Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/97/fdace942843da232ea06a5a67cc3a70d292873657dc933408fdb9bb796a8/openvino-2026.3.0-22451-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:81a64aebd1a80da93bc9413b3ba9c93846c7cac57161cd4d7b287b354d77ad19", size = 57482441, upload-time = "2026-08-04T09:06:59.277Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6d/e2c7693ebfc6b5833b0065fc52359b0f63e5004f8e49c31375be4b13445e/openvino-2026.3.0-22451-cp314-cp314-manylinux_2_35_aarch64.whl", hash = "sha256:875bb9df4bc694a86541c8598f60a6c797a29d20daf493681db9506eee6fe04f", size = 28767134, upload-time = "2026-08-04T09:07:02.289Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cb/ed637225c7373d9a4267e7fa7252c1f3767fbc9853a906d78068a279b73a/openvino-2026.3.0-22451-cp314-cp314-win_amd64.whl", hash = "sha256:07a8c1cb32e3f7942aab4a0c48404b591e63c89813906c7bc5b001f94bed447c", size = 75798958, upload-time = "2026-08-04T09:07:07.28Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/89565eb119e20fa901305e7da20713a0f6f5aec809ddac1ef669c2785f66/openvino-2026.3.0-22451-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bfce31f1f9267e2c5189b6f4a55aa747917cfe39a2e874839974ff9b7247ff4", size = 31817931, upload-time = "2026-08-04T09:07:11.045Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3c/40c0bbd5c57fc0b5c0c41f9e6f0ec722f231ff25c37d20240d2baf446409/openvino-2026.3.0-22451-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:65f34103c28107e830e1fb70cb9c62afdb31cfde4f8b6056c942761796b1d4fe", size = 57526976, upload-time = "2026-08-04T09:07:15.131Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/33/b8c8fdf461a595b6d4f817224c5edd217494ed0013227513ce4804d3dbf4/openvino-2026.3.0-22451-cp314-cp314t-manylinux_2_35_aarch64.whl", hash = "sha256:d1ee0ecb6abfbe30b723ed6d97d7d55bc5b80b6a3fb8149fd4c97f4c45ef7e4f", size = 25899258, upload-time = "2026-08-04T09:07:18.216Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ca/927354fa957dd0e8c8f53401dcd1239c4cd50d95a26ff5da3bc4b502f4dc/openvino-2026.3.0-22451-cp314-cp314t-win_amd64.whl", hash = "sha256:17581c5acbdaf9bf503cd21d5ad852df7e547073ad7a529661b19f40ab3c8db6", size = 75963071, upload-time = "2026-08-04T09:07:24.796Z" },
+]
+
+[[package]]
+name = "openvino-telemetry"
+version = "2025.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/8a/89d82f1a9d913fb266c2e6dc2f6030935db24b7152963a8db6c4f039787f/openvino_telemetry-2025.2.0.tar.gz", hash = "sha256:8bf8127218e51e99547bf38b8fb85a8b31c9bf96e6f3a82eb0b3b6a34155977c", size = 18894, upload-time = "2025-07-07T10:29:51.159Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ac/5ab0ca0aa269ad3c73f7bfc3801b10e5f56f75a31bf68c1ae8bd51cf70a4/openvino_telemetry-2025.2.0-py3-none-any.whl", hash = "sha256:bcb667e83a44f202ecf4cfa49281715c6d7e21499daec04ff853b7f964833599", size = 25227, upload-time = "2025-07-07T10:29:50.189Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/c8/0a78b0e02d7ac54bc03e5321c9220da52f0c2ea83b21f7c40e7f3169c502/pillow-12.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:00808c5e14ef63ac5161091d242999076604ff74b883423a11e5d7bbb38bf756", size = 5392415, upload-time = "2026-07-01T11:53:47.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/5b/a02d30018abd97ced9f5a6c63d28597694a00d066516b9c1c6de45859fc9/pillow-12.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:37d6d0a00072fd2948eb22bce7e1475f34569d90c87c59f7a2ec59541b77f7a6", size = 4785266, upload-time = "2026-07-01T11:53:49.079Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/98/766667a4be768150a202836acd9fad19c06824ca86c4286d3cf6b274964e/pillow-12.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bcb46e2f9feff8d06323983bd83ed00c201fdcab3d74973e7072a889b3979fcd", size = 6263814, upload-time = "2026-07-01T11:53:51.32Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/2d/ede717bc1144f63886c21fd349bb95860b0d1a21149ff16f2bb362b612b6/pillow-12.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23d27a3e0307ec2244cc51e7287b919aa68d097504ebe19df4e76a98a3eea5bd", size = 6934408, upload-time = "2026-07-01T11:53:53.487Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/48/9c58b685e69d49c31af6c8eb9012055fab7e665785165c84796e2c73ce72/pillow-12.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4f883547d4b7f0495ebe7056b0cc2aea76094e7a4abc8e933540f3271df27d9c", size = 6337160, upload-time = "2026-07-01T11:53:55.457Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/fa/dc2a5c0ba6df93f67c31d34b808b7ce440b40cdbf96f0b81cde1d1e6fa93/pillow-12.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:236ff70b9312fb68943c703aa842ca6a758abfa45ac187a5e7c1452e96ef72b5", size = 7045172, upload-time = "2026-07-01T11:53:57.736Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a5/444817a4d4c4c2417df00513086ca196f388d8f9ef40c2e4ccd1ad1af54b/pillow-12.3.0-cp311-cp311-win32.whl", hash = "sha256:10e41f0fbf1eec8cfd234b8fe17a4caac7c9d0db4c204d3c173a8f9f6ef3232b", size = 6472232, upload-time = "2026-07-01T11:53:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c6/4bad1b18d132a50b27e1365e1ab163616f7a5bb56d330f66f9d1d9d4f9d4/pillow-12.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:8e95e1385e4998ae9694eeaa4730ba5457ff61185b3a55e2e7bea0880aef452a", size = 7233653, upload-time = "2026-07-01T11:54:02.066Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/16/00f91ab7760dc842f5aad55217e80fc4a7067a0604535249bc8a2d6d9870/pillow-12.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:ebaea975e03d3141d9d3a507df75c9b3ec90fa9d2ffd07567b3a978d9d790b26", size = 2568195, upload-time = "2026-07-01T11:54:04.622Z" },
+    { url = "https://files.pythonhosted.org/packages/37/bf/fb3ebff8ddcb76aac5a01389251bbbb9519922a9b520d8247c1ca864a25d/pillow-12.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ba09209fbe443b4acccebe845d8a138b89a8f4fbaeedd44953490b5315d5e965", size = 5345969, upload-time = "2026-07-01T11:54:06.397Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/66/9a386a92561f402389a4fc70c18838bf6d35eb5eb5c6850b4b2dc64f5048/pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7", size = 4780323, upload-time = "2026-07-01T11:54:09.351Z" },
+    { url = "https://files.pythonhosted.org/packages/25/27/ac8f99618ffd3dde21db0f4d4b1d2ab00c0880595bfd17df103f7f39fd0c/pillow-12.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9c7f76c0673154f044e9d78c8655fb4213f6ca31a836df48b40fe5d187717b9", size = 6266838, upload-time = "2026-07-01T11:54:11.71Z" },
+    { url = "https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91", size = 6940830, upload-time = "2026-07-01T11:54:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/51/8b08617af3ad95e33ce6d7dd2c99ed6c8298f7fb131636303956be022e25/pillow-12.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e491916b378fba47242221bb9ead245211b70d504f495d105d17b14a24b4907c", size = 6344383, upload-time = "2026-07-01T11:54:15.756Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/cf78ac9780bb93c28328f408973845a309d4d145041665f734572ced1b52/pillow-12.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0dd2064cbc55aaec028ef5fbb60fa47bb6c3e7918e07ff17935284b227a9d2df", size = 7052934, upload-time = "2026-07-01T11:54:17.721Z" },
+    { url = "https://files.pythonhosted.org/packages/20/20/25e0f4dc178a6bc0696793720055519a0de89e7661dae886992decbd2f81/pillow-12.3.0-cp312-cp312-win32.whl", hash = "sha256:dbce0b29841537a2fa4a214c2bbf14de3587c9680caa9b4e217568472490b28f", size = 6472684, upload-time = "2026-07-01T11:54:19.839Z" },
+    { url = "https://files.pythonhosted.org/packages/45/89/da2f7971a317f83d807fdd4065c0af40208e59e692cc43d315a71a0e96d1/pillow-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09", size = 7227137, upload-time = "2026-07-01T11:54:22.025Z" },
+    { url = "https://files.pythonhosted.org/packages/de/47/4845a0a6c0dbf1db8456bd9fc791f13c5ced7ced20606d08a0aacfd25b49/pillow-12.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:331b624368d4f1d069149002f25f44bc61c8919ce8ddb3c45bdad8f6e2d89510", size = 2568267, upload-time = "2026-07-01T11:54:24.051Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ac/31fb64e1e7efb5a4b50cd3d92049ba89ac6e4d8d3bb6a74e15048ca3353e/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:21900ce7ba264168cd50defae43cd75d25c833ad4ad6e73ffc5596d12e25ac89", size = 4161684, upload-time = "2026-07-01T11:54:25.934Z" },
+    { url = "https://files.pythonhosted.org/packages/87/b4/9805e23d2b4d77842b468513841fda254ee42f0289d25088340e4ff46e2d/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4e8c2a84d977f50b9daed6eeaf3baef67d00d5d74d932288f02cb94518ee3ace", size = 4255487, upload-time = "2026-07-01T11:54:27.935Z" },
+    { url = "https://files.pythonhosted.org/packages/df/39/ecf519435a200c693fe053a6ee4d835b41cf963a4dfc2551c4e637cb2a71/pillow-12.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:ae26d61dfa7a47befdc7572b521024e8745f3d809bd95ca9505a7bba9ef849ec", size = 3696433, upload-time = "2026-07-01T11:54:29.813Z" },
+    { url = "https://files.pythonhosted.org/packages/42/92/2fc3ffad878ae8dd5469ec1bc8eb83b71f48e13efdf68f02709003982a32/pillow-12.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7a743ff716f746fc19a9557f60dab1600d4613255f8a7aeb3cdde4db7eb15a66", size = 5345889, upload-time = "2026-07-01T11:54:31.97Z" },
+    { url = "https://files.pythonhosted.org/packages/10/76/8803c13605b763d33d156c4678fc77f8443389c0c51c8aef707bb02015f4/pillow-12.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d69141514cc30b774ceea5e3ed3a6635c8d8a96edf664689b890f4089111fb35", size = 4780109, upload-time = "2026-07-01T11:54:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/e18aff37cb0b4aac47ac90f016d347a49aca667ef97f190b06ac2aabc928/pillow-12.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7401aebd7f581d7f83a439d87d474999317ee099218e5ad25d125290990ba65", size = 6263736, upload-time = "2026-07-01T11:54:36.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/62/de5bdd77d935331f4f802edc11e4d82950f642caad6cb2f949837b8560e2/pillow-12.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0847a763afefb695bc912d7c131e7e0632d4edc1d8698f58ddabec8e46b8b6d3", size = 6937129, upload-time = "2026-07-01T11:54:38.216Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4d/105627a13300c5e0df1d174230b32fd1273062c96f7745fd552b945d1e1d/pillow-12.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:571b9fcb07b97ef3a492028fb3d2dc0993ca23a06138b0315286566d29ef718a", size = 6339562, upload-time = "2026-07-01T11:54:40.354Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/1d/f13de01a553988ab895ba1c722e06cf3144d4f57656fd5b81b6d881f1179/pillow-12.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:756c768d0c9c2955feb7a56c37ea24aea2e369f8d36a88da270b6a9f19e62b5e", size = 7049439, upload-time = "2026-07-01T11:54:42.489Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f9/066794cca041b969964f779ee5fa66a9498bbf34248ac39c5d7954e4198f/pillow-12.3.0-cp313-cp313-win32.whl", hash = "sha256:a876864214e136f0eb367788dbd7df045f4806801518e2cfe9e13229cfe06d8f", size = 6473287, upload-time = "2026-07-01T11:54:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/7a58e61d62be561da3a356fe2384d4059a6345fc130e23ef1c36a5b81d24/pillow-12.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:1cca606cd25738df4ed873d5ad46bbdb3d83b5cbca291f6b4ff13a4df6b0bbe8", size = 7239691, upload-time = "2026-07-01T11:54:47.141Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b0/c4ed4f0ef8f8fa5ee8351537db6650bb8189f7e118842978dd6589065692/pillow-12.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:b629de27fda84b42cde7edef0d85f13b958b47f6e9bbcbba9b673c562a89bd8b", size = 2568185, upload-time = "2026-07-01T11:54:49.137Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/01/001f65b68192f0228cc1dbbc8d2530ab5d58b61037ba0587f946fea607cd/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9cf95fe4d0f84c82d282745d9bb08ad9f926efa00be4697e767b814ce40d4330", size = 4161736, upload-time = "2026-07-01T11:54:51.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d2/0219746d0fd16fc8a84498e79452375be3797d3ce4044596ce565164b84f/pillow-12.3.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:8728f216dcdb6e6d555cf971cb34076139ad74b31fc2c14da4fafc741c5f6217", size = 4255435, upload-time = "2026-07-01T11:54:53.414Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/02/8d0bc62ef0302318c46ff2a512822d2610e81c7aa46c9b3abe6cbaca5ad0/pillow-12.3.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a45650e8ce7fafffd731db8550230db6b0d306d181a90b67d3e6bca2f1990930", size = 3696262, upload-time = "2026-07-01T11:54:55.739Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e2/73c77d218410b14f5f2d565e8a998d5317b7b9c75368d29985139f7a46f0/pillow-12.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ba54cfebe86920a559a7c4d6b9050791c20513650a1952ebe3368c7dc70306f8", size = 5350344, upload-time = "2026-07-01T11:54:57.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/da/32c752228ae345f489e3a42499d817b6c3996da7e8a3bc7a04fc806b243b/pillow-12.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e158cb00350dc278f3b91551101aa7d12415a66ebf2c91d8d5ac14e56ddd3ad0", size = 4780131, upload-time = "2026-07-01T11:54:59.713Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/9d/8b2c807dbef61a5197c047afe99823787eb66f63daf9fb2432f91d6f0462/pillow-12.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9aeb04d6aef139de265b29683e119b638208f88cf73cdd1658aa07221165321", size = 6263757, upload-time = "2026-07-01T11:55:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/44/c85361f65dbe00eea8576ee467c768d25129989efb76e94f205e9ca9bb46/pillow-12.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:251bf95b67017e27b13d82f5b326234ca62d70f9cf4c2b9032de2358a3b12c7b", size = 6936962, upload-time = "2026-07-01T11:55:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7e/e483414b35800b86b6f08dbbc7803fb5cd52c4d6f897f47d53ea2c7e6f65/pillow-12.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fe3cca2e4e8a592be0f269a1ca4835c25199d9f3ce815c8491048f785b0a0198", size = 6339171, upload-time = "2026-07-01T11:55:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f4/68c491844841ede6bed70189546b3ee9731cf9f2cbad396faff5e1ccba45/pillow-12.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:23aceaa007d6172b02c277f0cd359c79492bbb14f7072b4ede9fbcaf20648130", size = 7048116, upload-time = "2026-07-01T11:55:08.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/34/77f3f793fed8efc7d243f21b33c5a3f0d1c97ee70346d3db855587e155ff/pillow-12.3.0-cp314-cp314-win32.whl", hash = "sha256:af8d94b0db561cf68b88a267c5c44b49e134f525d0dc2cb7ed413a66bc23559a", size = 6467209, upload-time = "2026-07-01T11:55:10.408Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e0/492879f69d94f91f60fc8cd05ba03650e9520afebb2fb7aa12777d7c7f38/pillow-12.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:fdafc9cce40277e0f7a0feabce0ee50dd2fa1800f3b38015e51296b5e814048d", size = 7237707, upload-time = "2026-07-01T11:55:12.745Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ac/6b11f2875f1c2ac040d84e1bbf9cf22a88038f901ca1037898b280b38365/pillow-12.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:e91206ee562682b51b98ef4b26a6ef48fd84e15fd4c4bc5ec768eb641d206838", size = 2565995, upload-time = "2026-07-01T11:55:14.736Z" },
+    { url = "https://files.pythonhosted.org/packages/52/69/c2208e56af9bfc1913afb24020297a691eb1d4ef688474c8a04913f65e04/pillow-12.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:164b31cd1a0490ab6efae01aa5df49da7061be0af1b30e035b6e9a1bfe34ee6e", size = 5352503, upload-time = "2026-07-01T11:55:17.076Z" },
+    { url = "https://files.pythonhosted.org/packages/07/70/e5686d753e898a45d778ff1718dba8516ead6ab6b95d85fc8c4b70650cf2/pillow-12.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5afb51d599ea772b8365ae807ae557f18bccfe46ab261fd1c2a9ed700fc6eb17", size = 4782956, upload-time = "2026-07-01T11:55:19.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/37/25c6692f06927ee973ff18c8d9ee98ad0b4d84ee67a09610c2dd1447958e/pillow-12.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3edce1d53195db527e0191f84b71d02022de0540bf43a16ed734ed7537b07385", size = 6322855, upload-time = "2026-07-01T11:55:21.613Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/91/420637fcb8f1bc11029e403b4538e6694744428d8246118e45719f944556/pillow-12.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf16ba1b4d0b6b7c8e534936632270cf70eb00dbe09005bc345b2677b726855c", size = 6989642, upload-time = "2026-07-01T11:55:24.006Z" },
+    { url = "https://files.pythonhosted.org/packages/10/08/b94d7811281ccf0d143a1cf768d1c49e1e54af63e7b708ab2ee3eb87face/pillow-12.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:24870b09b224f7ae3c39ed07d10e819d06f8720bc551847b1d623832b5b0e28d", size = 6391281, upload-time = "2026-07-01T11:55:26.252Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/87/24233f785f55474dc02ce3e739c5528a77e3a862e9333d1dd7a25cc31f70/pillow-12.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:30f2aa603c41533cc25c05acd0da21636e84a315768feb631c937177db558931", size = 7096716, upload-time = "2026-07-01T11:55:28.318Z" },
+    { url = "https://files.pythonhosted.org/packages/23/26/fcb2f6e37175b04f53570b59937867e2b80ee1685e744023153028fc14f9/pillow-12.3.0-cp314-cp314t-win32.whl", hash = "sha256:4b0a7fe987b14c31ebda6083f74f22b561fd3739bc0ac51e019622e3d72668c7", size = 6474125, upload-time = "2026-07-01T11:55:30.956Z" },
+    { url = "https://files.pythonhosted.org/packages/90/de/3634abee5f1c9e13c56787b7d5517b0ba8d6de51700b95578cf338349c9f/pillow-12.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:962864dc93511324d51ddbb5b9f8731bf71675b93ca612a07441896f4688fb8c", size = 7242939, upload-time = "2026-07-01T11:55:34.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/2a/fd13f8eb24de5714a6eb444a3d67e2842c6c576e159a43793adf23051351/pillow-12.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0740a512dc522224c77d9aa5a8d70d8b7d73fb91f2c21125d8d025d3b8990e45", size = 2567506, upload-time = "2026-07-01T11:55:35.988Z" },
+    { url = "https://files.pythonhosted.org/packages/75/18/2e8b40223153ccbc60df07f9e8928dc0c76202aa4e55ae9f53962b6510d6/pillow-12.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:b3c777e849237620b022f7f297dd67705f9f5cf1685f09f02e46f93e92725468", size = 5302510, upload-time = "2026-07-01T11:56:25.736Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3e/51fabf59d5ab801ceab709453d3ab6b180083496579549de4c45ced6528a/pillow-12.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b343699e8308bdc51978310e1c959c584e7869cc8c40780058c87da7781a1e94", size = 4736058, upload-time = "2026-07-01T11:56:28.041Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/20/22fe9384b7949e25fb1293bcfc84fb82590ff4ea6b37c95b24d26d793d86/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbd139c8447d25dd750ab79ee274cc5e1fe80fc56340ab10b18a195e1b6eca3e", size = 5237776, upload-time = "2026-07-01T11:56:30.263Z" },
+    { url = "https://files.pythonhosted.org/packages/08/14/f6ba68107680ffa74b39985f3f30884e41318fbc4250caa423c79b4788bb/pillow-12.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e7e480451b9fa137494bccd3a7d69adbe8ac65a87d97be61e11f1b1050a5bac3", size = 5860358, upload-time = "2026-07-01T11:56:32.68Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0169bc772ec491108b62f644f8ecf1fe5d8ae5ebafde2ee2142210166903/pillow-12.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:04f01d28a6aaff387bf842a13be313df23ba0597a44f1a976c9feb3c6ff4711a", size = 7231786, upload-time = "2026-07-01T11:56:35.046Z" },
 ]
 
 [[package]]
@@ -567,6 +1035,125 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/86/5185061a1fcc41d18c5dc2463969b3a3964b31d9ac67b2fb05d4c7ff7670/scipy-1.18.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9aac6192fac56bf2ca534389d24623f07b39ff83317d58287285e7fbd622ff76", size = 37472480, upload-time = "2026-06-19T15:01:35.136Z" },
     { url = "https://files.pythonhosted.org/packages/31/8e/f04c68e39919a010d34f2ee1367fd705b0a25a02f609d755f0bfbc0a15fc/scipy-1.18.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e40baea28ae7f5475c779741e2d90b1247c78531207b49c7030e698ff81cee3f", size = 37365390, upload-time = "2026-06-19T15:01:38.091Z" },
     { url = "https://files.pythonhosted.org/packages/d5/19/969dc072906c84dd0a3b05dcf57ea750936087d7873549e408b35cfc3f97/scipy-1.18.0-cp314-cp314t-win_arm64.whl", hash = "sha256:368e0a705903c466aa5f08eefb39e6b1b6b2d659e7352a31fd9e2438365be0f8", size = 25279661, upload-time = "2026-06-19T15:01:40.817Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "84.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449, upload-time = "2026-08-08T18:27:58.365Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216, upload-time = "2026-08-08T18:27:56.719Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/fe/cba54dc58523434919b66f13a667e36e436deddd77ca519e96553617d4ec/torch-2.13.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:e76f9bcecc52b8ff711239a2f7547d5353df95878ab232f0773c1d95928b92f8", size = 111187938, upload-time = "2026-07-08T16:05:17.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/59/1e3160e18e12aa3038390efab3ce02b36a9d4d6a527ecdd8520dca2e68d8/torch-2.13.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:092790c696a760c729fd5722835f50b9d81fd7c8f141571f3f3cf4081a8f664c", size = 427199369, upload-time = "2026-07-08T16:04:51.054Z" },
+    { url = "https://files.pythonhosted.org/packages/01/79/1f2d34ad7034ee1c7ffc1cf8bf0f8213af2a81df6ecdb3997ecec107c09d/torch-2.13.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:60fcdcb2f3876e21146cb4524ef06397d727ca9ad5f020818547e25075fe3cb7", size = 526574961, upload-time = "2026-07-08T16:04:07.075Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fd/0f2ce40f58aefbdb3392f9acce3c8171940943ae2d661f70558bfa73befb/torch-2.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:a0d8b11f16a48d60e2015d8213aa0390744cbebb98e58b62b3514dddc656e330", size = 122015870, upload-time = "2026-07-08T16:05:27.59Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045, upload-time = "2026-07-08T16:05:22.997Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a9/f6a2a4d763ff1df02e9a64c477029db614295bc9367f4131223791ccc243/torch-2.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:572df8be8ffb4599c88cbd6a0726f1f854f4da65d2e3c09f0e2c2283333cd6d4", size = 427210998, upload-time = "2026-07-08T16:04:37.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/82/fea946351658e6534db52d2cc12bc53087cbf87f9440c5f180f367c1950b/torch-2.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:796633c4cdf0fe2cdced72d8f88f22e73dbcfce83132763162f6d4bff13b820b", size = 526605292, upload-time = "2026-07-08T16:04:22.81Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d6/e8f3c6f7e01f626f77259de9860d2a78bc84c40539e28e79b7e98b0bb659/torch-2.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:024c6cc0c1b085f2f91f20a3dc27b0471d021c31ce84b81be3afdc39f791fd9d", size = 122057313, upload-time = "2026-07-08T16:03:53.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fa/c1c10b7aff4a9a3e8956d4f0a5f468fa6db7abc3208805719076772b4833/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:33449899ce5496c1b84b4853179d94fd102028ae1407314d9fb956bb79e70d09", size = 111213743, upload-time = "2026-07-08T16:03:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/11/18/9ecb37b56293a0be8d80f810bf672a72fe7e02f8b475d5ef1b9bf8a0d748/torch-2.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1e09d6a722504957c694faceca843acde562786df1144ebcc5a74075ec7f6005", size = 427213008, upload-time = "2026-07-08T16:03:44.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5a/7c50ba1b7b713d71d34669c6d13dab0a11531a3eceb0307a5162dbfec0f7/torch-2.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a3a9a21312872af8a26950b2c15680335a386a1f56ed03e780653d78b9607e9e", size = 526602329, upload-time = "2026-07-08T16:03:12.649Z" },
+    { url = "https://files.pythonhosted.org/packages/91/3d/e7adcc6aaf36961cd18f56cf8ad0f3058c3a5c84ccf391762176c94581b8/torch-2.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:49b58f1e2c52440abb6f17c28f0335fe6c6d01ad1a7f55b0183b81e4b34d64e6", size = 122057920, upload-time = "2026-07-08T16:03:01.808Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/6dcc7f0c07052102dd36f83cbc5800842a909c8c3fbf1a7f8a5844954de9/torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d849b390e07d8d333ce8ecaf91b273c656c598379a19c9acf1318a883f6b391c", size = 111227066, upload-time = "2026-07-08T16:03:33.6Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/09/2c10e8cd0e00fa5d23c052df6ce467eaa7182399f5e0f824f1e4ff42ccae/torch-2.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a3893dc2da0a972a8ca5d698c85a9f967559ac5f8ee1797b77408aa8734d073c", size = 427226309, upload-time = "2026-07-08T16:02:53.127Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c6/22c2102bbef14ca6a6cb4c20e42f088e49c5f812be4e160ae57502e325f9/torch-2.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:49f1ea385c754e54919408a9bb3b5a72b0b755bbe2c916c1d6f70afbec4908a2", size = 526614507, upload-time = "2026-07-08T16:02:16.441Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0c/7d1deb6bce5bc3e6042caf39100ac768eba3b9a098e1dddd16f75bd6489b/torch-2.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:4f8573e3ce9ebcd53fe922f01077a6085ccdfbe5f12fd215883a9d87d7a744fd", size = 122051871, upload-time = "2026-07-08T16:03:23.521Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ce/aa8b7f9949d32e0f2f624f342bc3b48112c1b8a130288465938bc83bcbf9/torch-2.13.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c28def70706c2f9ecc752574766e8ae4da9b810ab6676b611166761a78a9f1e1", size = 111537025, upload-time = "2026-07-08T16:02:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d1/491e3a0389430946145888b0203f2b6a759ce2a61481b96a85c2da4f2ced/torch-2.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:31061ff56ed8fbf26c749806905aeb749ebeb819810fd5d52508aa5afd90dddc", size = 427219769, upload-time = "2026-07-08T16:02:31.18Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1d/38006e045bf0a1fc28ef01e757c554e59e59a8770c284bc4f47b14e60441/torch-2.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:cc26eead4cf51d0b544e31e364dcf000846549c273bd148936fe9d24d29acb92", size = 526571320, upload-time = "2026-07-08T16:01:59.348Z" },
+    { url = "https://files.pythonhosted.org/packages/56/94/655c91992a882bd5071aa0b5d22a07dbb130d801e872be97c0b627a7c693/torch-2.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a7de8a313090dc5c7d7ba4bfe5c3be222528f9a4dba1acc83bddb1157360c4b8", size = 122306773, upload-time = "2026-07-08T16:02:39.832Z" },
+]
+
+[[package]]
+name = "torchreid"
+version = "0.2.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/9a/d3d8da1d1a8a189b2b2d6f191b21cd7fbdb91a587a9c992bcd9666895284/torchreid-0.2.5.tar.gz", hash = "sha256:bc1055c6fb8444968798708dd13fdad00148e9d7cf3cb18cf52f4b949857fe08", size = 92656, upload-time = "2022-10-16T12:33:29.693Z" }
+
+[[package]]
+name = "torchvision"
+version = "0.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/b2/1e010052079e4c577007b789db336ea7075f1a426e84d17121fbc3745516/torchvision-0.28.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:83fe6c020866a85acd7d97deccc45ff11d66daf42916d04396a4309c66c0ccb8", size = 1856017, upload-time = "2026-07-08T16:07:55.533Z" },
+    { url = "https://files.pythonhosted.org/packages/27/be/1b9c5de9c655ca2df4a74100fa671a7b848532ff787e077ccde14a7dea2a/torchvision-0.28.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:5a38bc6da3d72621be003400b66f66a2b4c6d644fde05f680c2cb7ca8cf8dd6c", size = 7841822, upload-time = "2026-07-08T16:07:49.207Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/9b/f1e68e861d4462e3e195a642c2b448e7b7d3fad5f209487162b9a2133d9b/torchvision-0.28.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:7e80f543b22503d9415e126db5f0ff3917036925e38560ee6b9ae38c571a4002", size = 7670718, upload-time = "2026-07-08T16:07:46.525Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/1494610ff54cbb154beb55033cc2cd50f3de04dac132fa2dd00e4f2b2556/torchvision-0.28.0-cp311-cp311-win_amd64.whl", hash = "sha256:9a45ea67235d965ef52187130d20002a4de20c54ea3d927a24286961d268dc37", size = 3814319, upload-time = "2026-07-08T16:07:37.153Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/c1cab1ecbb3ff1a380a3f99283db1dee61b8afe354f6352c643b65937130/torchvision-0.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:e9f54c30cd52e3ef7fd034cc69b7bb7e0964e1c8f8743e018ab92e95b40f9eee", size = 1856020, upload-time = "2026-07-08T16:07:52.182Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/4c/95233776e2def960e5abb7a07931230a545f43717a56a1e1140162033598/torchvision-0.28.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5cf78ebc401ce64ae19b8c55de866bb836797d559a4de9c25ccbe74cfa642d3a", size = 7842127, upload-time = "2026-07-08T16:07:53.446Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e4/e9b2495d0d57b9f60d63c57d0a910410a81b4b073bf70917bef815291119/torchvision-0.28.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:028a3d481b37d785605620d7cdad897064c5a55bae2aa1f2658766333e291940", size = 7675040, upload-time = "2026-07-08T16:07:58.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9c/55ed9cb6dfe3ee9c837df5cd0e758372e5829aa38b8dd71343aa632cc4e2/torchvision-0.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:87dc16b2df427c1318ad335f1e2be2b3b15b2cf20f7934c83b0505a48425ee5d", size = 4085785, upload-time = "2026-07-08T16:07:50.928Z" },
+    { url = "https://files.pythonhosted.org/packages/20/55/08a726c14c67b37c8aca04b077766909f1c7ed23f76116884fe63b9bd033/torchvision-0.28.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:d483b4aa3f5237569053f749cd1a2b5bb548ca456e40461a5dd087f21149d123", size = 1856021, upload-time = "2026-07-08T16:07:45.386Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/40beacd53809194f5259e590d1afaeaa8ad57da15f77c646e6560bcc4616/torchvision-0.28.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:bb6dd6918460ed89cc7644adcc2402991474d6933cf1ce92b390641cb233fddf", size = 7797014, upload-time = "2026-07-08T16:07:43.04Z" },
+    { url = "https://files.pythonhosted.org/packages/32/db/062cdb5a84380a60439775311fff34d89229760d2a50680393dc18699956/torchvision-0.28.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ad7b3a439265cc3739a4ab5b4c998c0e38ea99c0ee7ca4dea35c5d0b099ec237", size = 7674669, upload-time = "2026-07-08T16:07:38.91Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a6/b4081e2d04e1541abf82785ac9e5178a494c19330391f551356c8c18b7b3/torchvision-0.28.0-cp313-cp313-win_amd64.whl", hash = "sha256:7e9dd6f60d6e15f8dc27d4f877fdb6002fc70d70272412135f1c2ff9cfa08d3b", size = 4157380, upload-time = "2026-07-08T16:07:40.22Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b9/da40eca5bbe9596c12ae9899ab7abaf887f5e20f29d08b924b4633714821/torchvision-0.28.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3bd9dba55224a9db4a2d77f6feaa5651770d8c8e86d3d0ddb0fa6bec54c8712b", size = 1856014, upload-time = "2026-07-08T16:07:44.282Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d6/313aafd3df4eaf5f330211bd4e75b7598bddbfee4f55580d3b58536e1b20/torchvision-0.28.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:89f90e29b0966352811b12589f3a3c61943bf2bb9487b9d7bbec10efb1096bb5", size = 7796873, upload-time = "2026-07-08T16:07:30.907Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/41/31f8e959ab8f942600b6357f8999c21d779d5fd3304b0fd204ff4b518239/torchvision-0.28.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:36beb0782976906069ca03d4c9aacaf4b6b838b06ed6c20960ea9c51cce7acdd", size = 7674634, upload-time = "2026-07-08T16:07:29.657Z" },
+    { url = "https://files.pythonhosted.org/packages/15/15/4c5115253fd470672cdac0a1cf139e06b4f3e29d041238a2b255937f63be/torchvision-0.28.0-cp314-cp314-win_amd64.whl", hash = "sha256:3557cc7b539f46dabcda2b6f2b14017ccbeef024de466d4fc5835fc3f287f769", size = 4184005, upload-time = "2026-07-08T16:07:35.805Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/80/822a6163da716f8a78141cf6678d74e26a572285d4ea866ef8aa657bb307/torchvision-0.28.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:09ce8f56e81f19b9c378ae7bb109f83f6659fd8bc3cd14241a48e4af46e9ed49", size = 1856011, upload-time = "2026-07-08T16:07:33.404Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d1/cd3f9463b39a790ec8c0c2f6e6c8061edb1562114d04fcdfa786ed889345/torchvision-0.28.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:62c7d110f86a039245b587e4fae60278c649f3bd42ff79cfbc1178eca4e72542", size = 7796742, upload-time = "2026-07-08T16:07:28.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/3e0a7ad18e99831e2d7f4713d3be717b7159ff5a920862dd5c23c454aa71/torchvision-0.28.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:904cf89af220f8c6b2ed0296bb5065b474ce43b77558e48b2bf9de8b0ba17204", size = 7675526, upload-time = "2026-07-08T16:07:34.572Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/23aea03b28297bc66a4461f55ae4296368a9d85fa9a454bafcb2a5348bd7/torchvision-0.28.0-cp314-cp314t-win_amd64.whl", hash = "sha256:46f581979c010ad6da6bd85ee602aa707e1ff44312670223b7a0ee517ad06d47", size = 4291452, upload-time = "2026-07-08T16:07:32.236Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.7.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/f9/19d842d06a08559534fa1eaab6ca551b1bcf40f06620bddec1babaa2772d/triton-3.7.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a0e1cd4c4a76370ed74a8432a53cea28716827d19e40ffc732233e35ceb3f6", size = 184664887, upload-time = "2026-06-17T20:03:42.913Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/5e/fce69606f7f240297f163e25539906732b199530d486ce67ae319877e821/triton-3.7.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6744957e9fd610a29680ec2346057d0c86948ed3812468670719f391e94b44a5", size = 197701306, upload-time = "2026-06-17T19:53:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fa/f856e24deb462d5f18bd4b5a746957862ab9b6ee5834bda60605ec348366/triton-3.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9497f2e696ee368862a181a90b2dcc03ca978cc4f602abd67c7d81022a6988e1", size = 184692359, upload-time = "2026-06-17T20:03:48.288Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6f/fb96d15db6f36d6eae4cafb998c2e0353bf59d7c4ea1662d7497f269134a/triton-3.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e40869937a68206ec70d7f25bb7ec6433cb083f9135e1f36dbd318dc449a728", size = 197719725, upload-time = "2026-06-17T19:53:20.419Z" },
+    { url = "https://files.pythonhosted.org/packages/00/42/c5089d4d9327fcd1e862c599cc2927f39418f84dd11a84cb2ccff9d4787a/triton-3.7.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdbfc09d9ec58bc5e68321525653220de7515c199e7a8097a97c85e62b52cd0a", size = 184694629, upload-time = "2026-06-17T20:03:53.444Z" },
+    { url = "https://files.pythonhosted.org/packages/07/42/2c3ac59253ae8892b6f307875263dd23dc875cdf732d3aea40d6d41fb7cb/triton-3.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58c0e131da05134a2a4788ccbcc0c1105cf0f54c8e98f19e34cd465396dc15eb", size = 197729241, upload-time = "2026-06-17T19:53:27.801Z" },
+    { url = "https://files.pythonhosted.org/packages/40/71/e01aa7ad573883ed9456f130226babdec70b005e098c4d6226a6238e761b/triton-3.7.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe4ea396a06171f1f1f58cbd39c70b09294398f7dd7c620939bab54ad6f934fa", size = 184705764, upload-time = "2026-06-17T20:03:59.064Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/09/5683146fda6a2b569deb78ccfd8fbfea8bfe55f726b081c0a6bb18dd6f28/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2020153b08280415ec0da6607834e79166442147e78e144df06b508c75b186d2", size = 197729537, upload-time = "2026-06-17T19:53:35.516Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/448220c3092019f9fdfab39ec47985968181d67da34b44f6a7f6280a5cbb/triton-3.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c58e4c61f0c73b5dba3b5d19b4a7093c32f90dc18b2a7f121a7c16ccd31107b7", size = 184814760, upload-time = "2026-06-17T20:04:04.984Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ac/229b7d4589d2e5937310e72c6d46e89599d16a4a12b479ffa1499fee8eb8/triton-3.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10ba85fa2cca4a2fbdeb36bf1cb082f2c252bda55bf9fccd74f65ec5bc647e68", size = 197824404, upload-time = "2026-06-17T19:53:42.772Z" },
 ]
 
 [[package]]

--- a/libraries/getitrack/uv.lock
+++ b/libraries/getitrack/uv.lock
@@ -16,6 +16,143 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/3f/143b048436775b0f76ac3eec145c019e8173ccc2885c8f20319b996d5e83/charset_normalizer-3.5.1.tar.gz", hash = "sha256:6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3", size = 171764, upload-time = "2026-08-15T08:20:44.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/b6/034f6802e9c3f6418966cfabb7db8c9252cc2429c5098f41cc43af804149/charset_normalizer-3.5.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:eda059b6bc8bc0812d626fd91a7ce01bf583df0a61296eff390fd94141a34e30", size = 363585, upload-time = "2026-08-15T08:16:46.646Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fa/6a7e2a7c4b5451912b8c417732df79574354443592a88d616de03da66ae5/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa2bb0b37202dca27175591f761108b5d34096ade1191ffe4808bdf6b1571488", size = 251189, upload-time = "2026-08-15T08:16:48.287Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/c8/ab42b07cfd82e919f427fcfaa7c41abae8242833ad1aad66d42bae40b669/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0b2b1b3fa5670c127b246df1d0c059defd41f689a868a3b9d79df9b1cac42d22", size = 239724, upload-time = "2026-08-15T08:16:49.67Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/80/b9348b5d3041209f98b4cdad7655766369233f1d533f4f4f7558e9717bec/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6e5e4d73d588ca5ed09df1b7dcd1b203d1df3c542e3f50d126c947d432b10731", size = 280078, upload-time = "2026-08-15T08:16:51.228Z" },
+    { url = "https://files.pythonhosted.org/packages/82/38/083a24028304bc85bb9e376fed801178423dcbb67495f73b6ea0624e1894/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b54e7e13267d49ffbfe68e25b3cbd774dab38fa37238f71265e91b36146eb21c", size = 276650, upload-time = "2026-08-15T08:16:52.625Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/35/731ac04aa0a097fc1c97f0994c375bdb230c6c96619db794208fe664e9ce/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7b742bf31c88566b4bb6335a7f393bb322e580b6bb98df7bd0c25e6e3519ce8", size = 262325, upload-time = "2026-08-15T08:16:54.085Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/28/c2028e7021fb89c6e56868ed0e387b8e9aa811abdd2ab3208d6578d2c930/charset_normalizer-3.5.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6ba32c4d2abf1d2fe7cf27d280f4cca5664233b0f885549c7761719eb977f486", size = 261140, upload-time = "2026-08-15T08:16:55.604Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f0/0c0ceec6d98b7daa62e361e418135d59685811d79ba11529aad5cdf15e84/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0722590aabf9dc6a6c0343d523c05458fa2b5047dbe6302fd526bb570600753f", size = 252791, upload-time = "2026-08-15T08:16:57.103Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3e/48f4cd187b1c33189d86039e9cbe4f92c05454175504b44ff81806d4d1bf/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:aa1099b956fb795e686d073568f6dc002a0bb89765ea6d5b055dd7d9bf1b116c", size = 240730, upload-time = "2026-08-15T08:16:58.418Z" },
+    { url = "https://files.pythonhosted.org/packages/42/85/f9e22af69af67c54cce42be9455d9c81294f918b4ccc454db01f66efcac2/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:bd6c173f04743d483881bffa1478d5a4624475b8cd1d2194956a75548e191c18", size = 280791, upload-time = "2026-08-15T08:16:59.918Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4c/9044135f42127630b6fa742feb51256353f6ab87a78f2fdd1de3de955a7f/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:f298e218441525d3794428b4c8b8fb8662c6d3ea79925d4807ee6b9a96a3bca5", size = 259598, upload-time = "2026-08-15T08:17:01.421Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ed/1dd7cfebb4e75812934c49ca3b79757d11948053f7937ab7070c151f3c55/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:6e2912d4babbc65196ac13c2f53468dc57fb8b9c25ef913e8c59ddf7c6dc0e1b", size = 278217, upload-time = "2026-08-15T08:17:02.782Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/eb/239c84503cc9e3ba6eb34686a24bc66e84f3924efdd7e38e751a19f6bc10/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3d27167433c0d5f18dc850f07d0b3816221984fecdc405d6c157a6f0b8f8e9e6", size = 263417, upload-time = "2026-08-15T08:17:04.216Z" },
+    { url = "https://files.pythonhosted.org/packages/37/ab/4e4510e1e288478e2c8333131d1c1382382ba8cd2165053c79e39d1da961/charset_normalizer-3.5.1-cp311-cp311-win32.whl", hash = "sha256:ac00177c4831ffa650f8609e4bdddd5fe09c03b1c0c47acece7e6ea20421598b", size = 181774, upload-time = "2026-08-15T08:17:05.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/57/32f0ccea59e8612057c61d6fd22ef2cb63cca93c9fe594094919696ac170/charset_normalizer-3.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:f9b1e28d0e8dbfa858abdba91d6b547beaf2df1a59bec6da6faae7b96a4991a9", size = 206653, upload-time = "2026-08-15T08:17:07.075Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d4/b65c433fc521e58b5f54293982a5e51c05cb5f2dd3f1c7a6acb65b75324e/charset_normalizer-3.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:ae31a1a1db2ee6cc2942fccaf695c934bc7f3db9f2133a3fef1f367cf1a4ab10", size = 185630, upload-time = "2026-08-15T08:17:08.502Z" },
+    { url = "https://files.pythonhosted.org/packages/30/27/78873dc8b6a56357517b74b6bb9568b80450e7bb4f6ef7e3fa9d22aa0bd7/charset_normalizer-3.5.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5b6d1386bf0096d26d3a863dc0a487a5b4eb9aa93cf5ba69683d29dde6b9d60f", size = 344456, upload-time = "2026-08-15T08:17:10.072Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4c/be49ada26b1f0232d57aa89bbebf997a5cc2332a5616b6eca26ff680044d/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4582c27e8c889d64811987b5967fbd3ae0c823fe1fd933b543d55ac20bb475fa", size = 238530, upload-time = "2026-08-15T08:17:11.563Z" },
+    { url = "https://files.pythonhosted.org/packages/76/84/6f1290fa07ae6978d3960caa3eb1b8019bf9284ab7c2297b00c099ef4250/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1d1c7a53a6c2103925cdd6d7229f8c567379f211c869793df679f2e9f738c369", size = 230200, upload-time = "2026-08-15T08:17:12.919Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/a0/47b18adeed31c8f16ba9700f32c1b18594cfa09f47eb672a488c273c22bf/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e6621fb2a4988d6e53eedc455e5903e2679f3967b8acb3d639f1b63c14a2e893", size = 262222, upload-time = "2026-08-15T08:17:14.571Z" },
+    { url = "https://files.pythonhosted.org/packages/38/fe/341861ac118dae06f3ec0eb487488af52128f2ef2faf0b11003944d22259/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7c0c10730342b0c9b35dd1d619beb8214e520bd96a1f870f452680b238aab3e0", size = 258951, upload-time = "2026-08-15T08:17:16.158Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/89/bb5108dc6c3651dca963f2b0a3ba19bbcb370c94e1b6d3e0e844a58e6dca/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9af956078716df40d985fb0dfeb2c2120c5ca92ba4ff4b388acfd01cdc14d08", size = 248801, upload-time = "2026-08-15T08:17:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ba/ef83ae3aca816393decfa3530976f38a79812d707b80b580ac33b83f9877/charset_normalizer-3.5.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f9f8405c2c758532c74fed975dbee57be1f31a6e865c031870c79a6ed3212ada", size = 244070, upload-time = "2026-08-15T08:17:19.191Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/0b/c5292a2462d69b7378ea89793bbb5b2b6fcf6f7dd6d1667f9619094ad553/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:96fef3e886d6a9874b14f27fc193fbdc69d5d8035783d86aa4e1cea594e695f9", size = 240110, upload-time = "2026-08-15T08:17:20.547Z" },
+    { url = "https://files.pythonhosted.org/packages/46/22/111e5be3b740d5c2a5bfcedb3d237b6591e5c2e82ae9d6ffcb121fe0909c/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5d8531a6569d025f68e2321e7638fb7978f23db58e5f69f56913837aae03816e", size = 232836, upload-time = "2026-08-15T08:17:21.895Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/d2/d2aad6fe0dbb44b194bf3becb60f5a0ac48446ade999a47fe7bb41eb09a7/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:aae2ee51122d3ae968a3837d97dc24a0aeebb0dea23694422cd172bd30017cd6", size = 262712, upload-time = "2026-08-15T08:17:23.727Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5a/337e4663a5eae6de99db940ee8066d4145caafb61327db62deda15313cce/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7235dc28fc6dd9d832ac7c7bce95367dedb85929f17368a0c2bee1e080b9acbf", size = 242977, upload-time = "2026-08-15T08:17:25.157Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/85/f82f8a92e31c7519410e2e1afdc630f28ec47490ce2c09a11c1a43cbb459/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4abdc5f9ad448c1ecbfae2974b820535d6bc6e7eef63babbab3d81cf46968c71", size = 260207, upload-time = "2026-08-15T08:17:26.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/52/643d11ffd60e9ac2fd1fb87e167a19285b9eefeff4a40e63c87cbfbeab36/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ba501e667c17d8411f98e67a022d9604ef179aff0e459b7e292c796837c13573", size = 250562, upload-time = "2026-08-15T08:17:27.971Z" },
+    { url = "https://files.pythonhosted.org/packages/62/16/46556278c2168d12df9da7fede5dc6fc70e60301b26a82bbeec238c9cfe3/charset_normalizer-3.5.1-cp312-cp312-win32.whl", hash = "sha256:cfa1c0cc3a8f9f53f1243a5a99ac36fd003880199383b37672e86ddda9cb07e2", size = 178507, upload-time = "2026-08-15T08:17:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/4c6c298171e6b3e745633180ff59350fc0ca0db1ffd28df1e369e0579f71/charset_normalizer-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3617ac3cfd8b9888f145ad89dd6e692285834b0201c6074a5eeaad3fd4d668c2", size = 200551, upload-time = "2026-08-15T08:17:30.668Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d7/eb95a042f0dd22e304b0b6472b154f3546a1a039a9ee89ccb2a7f61591fc/charset_normalizer-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:88e85ab89cb822c1e635f51d6d32e488f94e002e70e2f492bdb8b945543f345a", size = 180700, upload-time = "2026-08-15T08:17:32.028Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/61/2cb6ad133dbbb449fa2d37ccae973232f4827e799af258d15e589a3d1e9e/charset_normalizer-3.5.1-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:4f298bdadb8f0b9e5672877f647d1be9373ef5320c9e2f049795e26cad28b6a9", size = 211584, upload-time = "2026-08-15T08:17:33.597Z" },
+    { url = "https://files.pythonhosted.org/packages/18/57/a305c968be1ca13f3dd1b32f445877e97addf55d80b65c7cb35fac82b777/charset_normalizer-3.5.1-cp313-cp313-android_24_x86_64.whl", hash = "sha256:88ca277405c2d3b71c4e1c2ee0e7966e807bcba86a69d11e19ba199d18ae4491", size = 223359, upload-time = "2026-08-15T08:17:35.022Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0a/d3646670292ce8d8f8cc11ac067d44885e697a5591f57a9221128da5e7b3/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9362dd90aa7dab48c0054a21187791ccf05473f7dba5d92b8033ae62164675e7", size = 194464, upload-time = "2026-08-15T08:17:36.452Z" },
+    { url = "https://files.pythonhosted.org/packages/de/93/d51ec556e01042fed6f993ea859311bc7917b466684182fbbceb6ca24762/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:977cdbd483a9cff38179bea4fd754289a6f2195c7abd414aba85410b3e66cc5e", size = 197676, upload-time = "2026-08-15T08:17:37.819Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/a0/562247944386f7d4ef94467e84876600cc1e0f1b93239aaa9213d2bc3cbd/charset_normalizer-3.5.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e90251c0c7bdd54a100a0dce3c07b7e637278c93af29dbf78ebb89a58c4bac7d", size = 340473, upload-time = "2026-08-15T08:17:39.303Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e7/1d994be1b93d41e9502b8b0460eaa88a1dd8df335df415db87d6c3e91ab2/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94d78ecec2605a8d0398b0f365d5f12a63248438516f5dac536a5eff7337df4a", size = 240156, upload-time = "2026-08-15T08:17:40.66Z" },
+    { url = "https://files.pythonhosted.org/packages/09/53/27923ce5cc6cbccb832037b27dca98882d9c53e9b69e866bbbef4aae7fc8/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d59b75732e9b6f27388e10c14b0259cc5f2e48c78627d185e6a177b58ad3cffe", size = 228246, upload-time = "2026-08-15T08:17:42.003Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5a97e84d63af1d55c07439cb80e56d99a8efb4295700eb4e18c0d1615d2c/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0d929fc574b4d6fd9e7c0f5c2ede8716a41911923aa7fa5fce38e0818aa4a1ac", size = 263660, upload-time = "2026-08-15T08:17:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c2/071575791dcc88316c0a9a65ce38897a82e4cfe4a325f0f7fe1b1ac47bcf/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:394fea06235c8543390050ed5f529187074b029fb027213f6c46ac11ab5d950e", size = 260354, upload-time = "2026-08-15T08:17:45.094Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/af/63240b0c0248c075c2535a1f1bd992821d8251b9f173abc13329661d09e4/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62b55f6722735a6c472f88361cde6640608773d9443cebdbb51abf436a1fcdd3", size = 250638, upload-time = "2026-08-15T08:17:46.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/66/70dfad64f15be09c15ccfee81330a7e515895dbe296dd23114e9a231268a/charset_normalizer-3.5.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa48b1b63d639f9483e0633e092f5851e2348c352f1f9bb6c8182f87884ef876", size = 244583, upload-time = "2026-08-15T08:17:47.963Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/24/ef36367d38b9ddd4bccbf72888c342e8de1f5ae506fa0b2dcf970e2732a1/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c71fb0d56c920c269cd3e2e3fe7c610e3f1fdb21a6ce60efa6430ff63676cea6", size = 242038, upload-time = "2026-08-15T08:17:49.481Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ab/55e683ba0fff2e43adafc10daa3001eac90fdaa419a97227d5a7067eedde/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:485a0d363cafefcd2538a73c7c838daa2035f09b2c9f9b5e3133f80c6aeb84c2", size = 233677, upload-time = "2026-08-15T08:17:50.845Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/67/0f40eaf8d1b6e7cf15e82382a2965efaca787fc1c2794b7021d37aaf5036/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0ea61a470e070686aa30892fed79e297d2c8d0ab46b8bcdf027d38c51da591", size = 264491, upload-time = "2026-08-15T08:17:52.61Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/64/12b4c2a11ee8df4fcc518c78b0d93e3a92bd3d5253d1617ce74ff0e8c7ef/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:90b7481fb62fbe172c558bc6fd1c4c98d82004a54a7551f20e11ac9bf0b8708c", size = 245196, upload-time = "2026-08-15T08:17:54.023Z" },
+    { url = "https://files.pythonhosted.org/packages/37/2e/651d910af6d0fba325eee1cda37ec5443462ed25360e666c144166eb6091/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:35fe081843b35aad20ffeccec3eeffbe637b15d14f3fb22cc1b59cd8ec17e93c", size = 261660, upload-time = "2026-08-15T08:17:55.491Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c6/b09e05e6db7f64338e0dc067c79577b1138da86c1e38369096851d96be88/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd0350afdc3aabd5576f60ea109228bd5538139713c7b094c5cd27c73a98bc6f", size = 252618, upload-time = "2026-08-15T08:17:57.025Z" },
+    { url = "https://files.pythonhosted.org/packages/76/4e/362d4f9fdcdf5556fb2aa3ce7d4a58ebce03ed1ff03aa1d9aca8d02f13f3/charset_normalizer-3.5.1-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:9d9a0dc7cbe9bec24c3f767c9122c41fe5a1bc43f47cd099d00d393e09769de4", size = 140362, upload-time = "2026-08-15T08:17:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d4/703be739b26acce318bd29eb3b25b7209e1b1f527f9eae3d1f1f01fdde2b/charset_normalizer-3.5.1-cp313-cp313-win32.whl", hash = "sha256:d63600d620ad0064c3a748b950ac5ea38a80190e5498532efefa4b7b3f1da1f3", size = 177755, upload-time = "2026-08-15T08:18:00.037Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/33/56d97ade41c8db611e727168c52ae46c9224c362ec28d4b65d7e9869e8da/charset_normalizer-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:aea996a6aba25260827c9ea511d1addfde2da9eb686ac961838509086188b7e6", size = 199295, upload-time = "2026-08-15T08:18:01.506Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/75/5b20dd1e6573a01a08158fe104104fa2c8abf941745596954185726cd46c/charset_normalizer-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:fd0a274c0e5f9a21565cd9d3dd749b61f96b7aa1e20a93aa1ba4029518f2e5c0", size = 179856, upload-time = "2026-08-15T08:18:02.929Z" },
+    { url = "https://files.pythonhosted.org/packages/29/cd/2b812ce5e888f1ce69a5350281e58aab07ae64a958ecae8912f30865718e/charset_normalizer-3.5.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:774d157f112367ff4abd29019f38f023c24e00e56edc7829c20e358a5a913ad8", size = 212318, upload-time = "2026-08-15T08:18:04.403Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/4a/a6ee107430768a5334e6d63f31f148a04a1a491ef161a1ac9415a73f2fa8/charset_normalizer-3.5.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:26422d45fd13551cf564c58932f7d72b4f58b93b0fcf18c35ba6be12b46bb102", size = 224897, upload-time = "2026-08-15T08:18:05.997Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d9/35ae3f64f29d0179c35c3baefe575904df2913dde519129c7f75995a2b1d/charset_normalizer-3.5.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:09a7bba9f739468c8e78c36a75c33768e53cb1959fc638f510454c14683f00d5", size = 194848, upload-time = "2026-08-15T08:18:07.397Z" },
+    { url = "https://files.pythonhosted.org/packages/74/76/f2fc7380f056cc273a53af37f50d08ad54b2c59f61078f31432edcf1c2bd/charset_normalizer-3.5.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4c9548dc78002099910abaebc0a72ac58b7d30931869e0351c09b507dff4ece3", size = 198163, upload-time = "2026-08-15T08:18:08.989Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/40/095ce62fa078483cccc1fa2b36e6bc9580b85422a20ee9f925341c50e44f/charset_normalizer-3.5.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c428c6c31eb5f4277d7f8eccaf767fbd548ddd5ce3c8b4f4cbbfab3d96b5904c", size = 341823, upload-time = "2026-08-15T08:18:10.458Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/5a/0e58b1c04a1596e0256f407274a92d5fb2ee21324409d1fab1da48a65b5b/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2f06b7eae9dbe77fe1d644ca244dad508de8d302870a43f3c559b521270938a0", size = 242458, upload-time = "2026-08-15T08:18:11.989Z" },
+    { url = "https://files.pythonhosted.org/packages/22/95/b4618ce912e6db0b1aae89ba788e38e8a7eba0f3025cc66e8c0699f977b2/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b7430cf5728e68f6c462254009a6ef4086e1bea43cf2f57aa9c55fb4f50ff96", size = 226717, upload-time = "2026-08-15T08:18:13.401Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/76/c681192bbda3d55356db5dadd64381d5202b37c6b598fcda5282e88b5d3d/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab743e9bc90c1f73552ec33e10e3331315acd2c397b36065b591b0181de533cc", size = 266111, upload-time = "2026-08-15T08:18:14.961Z" },
+    { url = "https://files.pythonhosted.org/packages/88/be/55127bfca72c0cff6c022488d140d7c5b04c771e3b72e9bdb4836d54979d/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f6f7deae3feb4edfa2efaf7c574fe88cbf055038a6abdb40188e4fff66d5699f", size = 263128, upload-time = "2026-08-15T08:18:16.515Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/91/39c3af510b0aa32bbda03374259200f28430febfd1bf5e511fe765282ce5/charset_normalizer-3.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15f024313246a4ed976c60f440bb8d257815513a681d212ff74fd46f7d715a90", size = 251240, upload-time = "2026-08-15T08:18:18.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a5/cbe418bbc6ecdfc3e05a0116002897c4b403a5e838d697e64c78e9f0190d/charset_normalizer-3.5.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:823f82903d189af463d7df250ef1f7f696f3cee08cc8d91deb565e8d425f6506", size = 245282, upload-time = "2026-08-15T08:18:19.625Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a4/689bb42e8e7cd492f3cb64907c6bc00ad247ec9a3628cd3f8eed126e8ae1/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:01e93745f7f219b703b60ba7afead36cfc4242782be5af484673fc500df12da5", size = 244597, upload-time = "2026-08-15T08:18:21.121Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ce/9962938e179cf9f699d3f1e7b3114b5d7642dee6a893745229f9dd04f274/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:329fc3ccb63ad22d867d84c2adea759a64079a37ba4a343433b02c7a2816871e", size = 231376, upload-time = "2026-08-15T08:18:22.57Z" },
+    { url = "https://files.pythonhosted.org/packages/85/54/46000450ada53bd9eac5429a2c8c54cd2d9b39c0c255f229aea9af0948a5/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:bb57753e36e4855b8ca375069482250a6246372331a3e4f3407eaebb007443f5", size = 266715, upload-time = "2026-08-15T08:18:24.235Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/bb/618749d70f792b44252a777bf89bfb86823b9bbc1ea13fe8ce759b07f38a/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fce8cbd4997efeb450bd298b54f755dcdff18d496f7a5ddbb4867c6d7c88fdc3", size = 245848, upload-time = "2026-08-15T08:18:25.726Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3f/ffb64458527c7668031d5eb095d978de561958dc9f5b53f8e488a533e603/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:6c9cdde8becb25a7fde49924511aa2644d6f8081cc8df8e9452724303348d8e3", size = 264521, upload-time = "2026-08-15T08:18:27.193Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ab/74a55fd803916a35ac461daf002708191aac19b546b80dc8cabfedc63d98/charset_normalizer-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9ac4444d8d4fd4c4bd08bf451ed3167aa9e7ec6cdb41b648794f1d1103652e36", size = 253054, upload-time = "2026-08-15T08:18:28.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2a/6a9034b7d3c60b17499afb482df5878bf9fa20b50cc3887d5ef017a833db/charset_normalizer-3.5.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:f03ac127268b43ef4fe9e6ab6794a6794b49485a0cc0c1db79876d2f33f75bc7", size = 140580, upload-time = "2026-08-15T08:18:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/46/1d362e1a00d035d66b9869e1281eee115907f7e390a16a07824ab5737360/charset_normalizer-3.5.1-cp314-cp314-win32.whl", hash = "sha256:1f5883d77fd409a261abb5dc8ccbe335720d798b1de4abb3b1d47ccbbc76b53b", size = 180325, upload-time = "2026-08-15T08:18:31.877Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/7c/4938c329b6a9d446f6a59aa2092ff7118f274209b5ed0e26893d1d30a63c/charset_normalizer-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:c658c50ac0c98cd755a2dd50b7977d3bca7df401dcc47fbdfa87db53ef7d4e8b", size = 204175, upload-time = "2026-08-15T08:18:33.466Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/33/eeb384dbd8dec570661354592f4f2e1b2fcc92585624d146a000caf53841/charset_normalizer-3.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:4bea7f8ebe90bbd7f0e4a2de42ca6924ba23e3e76418c408ff82f1d46fabd687", size = 184123, upload-time = "2026-08-15T08:18:34.913Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/6c/c73fa9d5a85f6ab05395de61c5f6984e0a9ff40bb5ff888d46dff02526c6/charset_normalizer-3.5.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:fbc597639158fd7c14d55e808718848319540f51b0e6746e3eefa59723a4a348", size = 381682, upload-time = "2026-08-15T08:18:36.349Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c7/63565f860921457feba93bae6c86fb7746deb4cffeed2f375cb845318146/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e71c909f353863b2b89c83de2ebed71ea6d0df8a6ef65a128193c5e650766bef", size = 240826, upload-time = "2026-08-15T08:18:37.887Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ae/7ae8807410dfa33f8e6f1715740adeaafa8a816cc4cb33508f54b1f7c896/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7ac76cf9afd34929d76eb7fcb63be476a4853d8a96f0dcf2d0db68a0cbdf9885", size = 227861, upload-time = "2026-08-15T08:18:39.315Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a3/887c1642f0da26000b0e0652d91071113c0e72cea33952e225cf589f49a9/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a3a370082ce34d0612f421e15fe011c53bb1feff21a26d06ad4fb244dab5a375", size = 260758, upload-time = "2026-08-15T08:18:40.88Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/11/e6f5b9a3d0e55b0ef7505cd3765cdd48f22db89994c947b316f52f801fd8/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:256dd4d85d9e4dc595e2bc983c980e73f62ddeb3165c58b4c3dfe78c5c8548c1", size = 259950, upload-time = "2026-08-15T08:18:42.351Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ee/e4e10a94d51cd1ee638aa7e00b65399e6b2a4e8376ab6d2eac9f95586671/charset_normalizer-3.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58d4aa13a59c969dbfdf9e6a9560e242cbfd9e8a8f50c2747714df1a423adf65", size = 249329, upload-time = "2026-08-15T08:18:43.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/25/d5f4198819e6059735a84e8d0bfb72dc33976da67b97adcd3fb5a5e07ec6/charset_normalizer-3.5.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0c6dfb5ca6723eeed15aa8e564a014d69fcb8812f94eef11fe3631e0508199f5", size = 243137, upload-time = "2026-08-15T08:18:45.368Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e9/e925ca7569cf9fb9701fd82503fee73eea5268fdb856bdd64947092d3daa/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c010f5581d9c612804cc59fcf7b524b707fbcb72828551237ab545bb5c7034af", size = 242820, upload-time = "2026-08-15T08:18:46.842Z" },
+    { url = "https://files.pythonhosted.org/packages/34/17/672c251a888ed2aebcdd2fe830ad0104e25ff83c43f5c4f9c15e9fc6853c/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:52ec005752a56ae79547a05c0139ca2501a0c866390b6115008456b9f0e7cde1", size = 230504, upload-time = "2026-08-15T08:18:48.353Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/fc/f6a85abebd42ce4da2f1db0aa56cc6a0df1995e318b3875d14401b8381d1/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2bced4061f000f7187254a02ad3433ae17eaf991747ceea2f478422590a5bba9", size = 263087, upload-time = "2026-08-15T08:18:49.859Z" },
+    { url = "https://files.pythonhosted.org/packages/98/66/7c42677e739ba66746b297e2046918d793078094dc239e1e72768cffccc6/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:9eea3ab2597a5e65fe65296e2d6a84570845a6b55532d90333d740d48bbc850a", size = 243269, upload-time = "2026-08-15T08:18:51.601Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d8/a50b79237f417af10f8c2a501ce8d1ca87829a22e69117891ca4ba20a69e/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:496846868fea80e479324862fa877f02411f2fd0f83b79ccee2607aa68b2a032", size = 258766, upload-time = "2026-08-15T08:18:53.23Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1d/0fc91aeaeb3c83b748f532399ce67cf84604b48297405d740000f7a9e786/charset_normalizer-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:85d5855daafc240cc045c026d7a15fd198a09b0fc8ff6f5ecbb5297b509cb11e", size = 250814, upload-time = "2026-08-15T08:18:54.768Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/10/3d8c777cf9024615295aa1b808324ad5b4a77855869c00824bad74ffaf8a/charset_normalizer-3.5.1-cp314-cp314t-win32.whl", hash = "sha256:58d3e12c88e0950bca850ae1f7c256055c097639c2edb9eb123af9807d8b15e4", size = 191074, upload-time = "2026-08-15T08:18:56.305Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/81/ae557d3c44d1a1d688696d60563413a0866a91b7ebc50f20df838be3d8c8/charset_normalizer-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:acaf604462bf330b0d07e7a07c1d6e4adac79e5fb13e9c5140590542cafacc00", size = 216476, upload-time = "2026-08-15T08:18:57.889Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e9/61c01fb8b804692569c036b3fc50495814502dcf13a60649c6055390b02c/charset_normalizer-3.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:fdb8a068947befafba9952162645dc2fecaeb400e64584829ed5e9b2fbe21a7f", size = 194115, upload-time = "2026-08-15T08:18:59.418Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/97/fb4e82231aba271ffd775a1b4993b0defc4e3059f286ae41d9433409fe85/charset_normalizer-3.5.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:41876ee62a3dddf48ff1121ad8f0798032aa03f2fd35f21f34a4cab14f18d8d2", size = 331467, upload-time = "2026-08-15T08:19:50.959Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2f/fe3f187327aac18e2d54e9d2b08e15d27bf9b642d9e51c219f130fc34d1a/charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6dac12ff6b846103483683f60c5f8fee205121adc58ffd87e90a90a3af69e99", size = 253057, upload-time = "2026-08-15T08:19:52.654Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c7/9e48cee5c161fe24da823b61bf381921d77cb994a0a4de148e95018c1984/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cee5dd7c6fb5dd52a0fe2a740f9bc6e3593f5f8b1788bde49de02086f30182b2", size = 240930, upload-time = "2026-08-15T08:19:54.163Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e0/716601f3cc69be7b198951150c75ead1ece33c3c8036ff6ffa46029659a0/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:343fb4f2821043bd87095f7b08a1a181febc8e36ac64212143bbfd0a0e1bc235", size = 230822, upload-time = "2026-08-15T08:19:55.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/05/71bfc5caa0abcc45aea1f6a4d50ac68e59605ddc7666fe8494f4cd229665/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ae4a097991662cd4fff0ddc74e0fe7874f82e00042fa0ea00855645ed0c79598", size = 260037, upload-time = "2026-08-15T08:19:57.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/92/de7e32ed05341e7a9c4c877c318418197b7f2d66a3b68d561bf2ac57ca3e/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b599739b93b2cbeded49645ae3c8d1405c29ddfbceac1545c87a3f9580a9e96", size = 255097, upload-time = "2026-08-15T08:19:59.056Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7b/ade0a122600319dfa0b1000ab0f9731c94a817904cf3c5de408c73a4ede7/charset_normalizer-3.5.1-cp37-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b39b69b347e5e47a3b5b8cfc005c68c1ba347474e3960236c4944a8ecd174962", size = 250166, upload-time = "2026-08-15T08:20:00.612Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9c/019fbb9f4834491a160951349b1a3714439376f66e5f7cf18b4f18f0c7aa/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a2028475ba855475b8b4d3cfeb4994269c967aea8b9892dfba907f4263a863a3", size = 241821, upload-time = "2026-08-15T08:20:02.321Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/11d4840bfc99330cc7fbcc2681ee5a044553a6e77655508d8f9b2bff7b34/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:36047af20e17097c3bb9476c2b7655f2f7aa51322c0ba58c07695bedf755a950", size = 232529, upload-time = "2026-08-15T08:20:04.008Z" },
+    { url = "https://files.pythonhosted.org/packages/18/96/2b3a21492d9f65171ac75d872f5018260013d00bfa0ff70ec9f179148cbd/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4c4fb141a727957c93edfe5c32a26ceb6b5f6461d67146e2d39f51e16170bea8", size = 260348, upload-time = "2026-08-15T08:20:05.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/aa/a69a2028e8bd052476c245460ab19d7de595de084dd968f2d75cd50c3e25/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:2f293479cce755c75f1697e87c409b7ae4c555c7dfecb6e988ad13abba943031", size = 247234, upload-time = "2026-08-15T08:20:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/3d130aeabcaf3d2466af76b7b141c08d9e89c9016ab4b7cdd0f7dc2d1c62/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_s390x.whl", hash = "sha256:3588e376b3ea2eea84976f67273d679f229e24c66dce7b82ae45aef04ff6e072", size = 256917, upload-time = "2026-08-15T08:20:09.142Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c2/a7379b840292d0c1ab9fbd17d1f3967aa81794dc95bc74be8999d7fedcf7/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e199fb99720074809a7720f1c0b4d919eea8b87e88713e0f8f602f7bef543d9d", size = 254846, upload-time = "2026-08-15T08:20:10.727Z" },
+    { url = "https://files.pythonhosted.org/packages/01/65/d43b714731bb2f40d4053dfa00ecfc1c5a301f8e3316c5db3a09af59fe94/charset_normalizer-3.5.1-cp37-abi3-win32.whl", hash = "sha256:dd732602a7009217f658d5863d12d79d373a4de0eebc111094bcdd3bb8e0a6cc", size = 174216, upload-time = "2026-08-15T08:20:12.334Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4f/b911ed898b26a09789eba9c9200c999aff6c61b4bafaf4838e56d1a1e1a3/charset_normalizer-3.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:70055ff39b97c99e7ae40ea3e393fb62aa2e44dbd9b29f8d14f42fb0025c3959", size = 199764, upload-time = "2026-08-15T08:20:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a7/920baf467bfd9bf689f3b318340f37aee4572a71f162bd8db51da55ba4fa/charset_normalizer-3.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:87e4f41d375c0b9be2fb5251aee4b8a689169e134535aed81bf085c3b647451e", size = 287318, upload-time = "2026-08-15T08:20:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/61/d01fc49b8dea277640b55a9e15960dbca9fdc8c9fde18e572d39c59f4019/charset_normalizer-3.5.1-py3-none-any.whl", hash = "sha256:6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6", size = 68658, upload-time = "2026-08-15T08:20:43.306Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -120,6 +257,22 @@ wheels = [
 ]
 
 [[package]]
+name = "gdown"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "filelock" },
+    { name = "requests", extra = ["socks"] },
+    { name = "tqdm" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/b5/a45f62f20664031bf74a6aeb6f8d8cd5910e411bf90d756bd6b09bdc6c35/gdown-6.1.0.tar.gz", hash = "sha256:361c6e04c6ca335df50b9d71f40bcfe9ab70fb26a1b0e890a427267781389553", size = 269670, upload-time = "2026-05-30T11:56:21.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/56/a99f0f159cce5b26d267317d436afee184f45fc7911938757d7cbbd2d10c/gdown-6.1.0-py3-none-any.whl", hash = "sha256:38a36a94275b8272f684db469bbd73b4d1f64cbbc1751bcb993a1b2be8f013c8", size = 19216, upload-time = "2026-05-30T11:56:20.016Z" },
+]
+
+[[package]]
 name = "getitrack"
 source = { editable = "." }
 dependencies = [
@@ -133,6 +286,7 @@ dependencies = [
 
 [package.optional-dependencies]
 reid = [
+    { name = "gdown" },
     { name = "openvino" },
     { name = "torch" },
     { name = "torchreid" },
@@ -152,6 +306,7 @@ lint = [
 
 [package.metadata]
 requires-dist = [
+    { name = "gdown", marker = "extra == 'reid'", specifier = ">=4.0" },
     { name = "numpy", specifier = "~=2.0" },
     { name = "opencv-python-headless", specifier = "~=4.11" },
     { name = "openvino", marker = "extra == 'reid'", specifier = ">=2024.0" },
@@ -173,6 +328,15 @@ lint = [
     { name = "pyrefly", specifier = "~=0.51.0" },
     { name = "ruff", specifier = "==0.11.13" },
     { name = "types-pyyaml", specifier = "~=6.0.12" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -802,6 +966,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -882,6 +1055,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "pysocks" },
 ]
 
 [[package]]
@@ -1047,6 +1240,15 @@ wheels = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/99/a6ca3beb3ccacb41fb3321d8a60e5566f9e6467601ef8eba6a17e1b89778/soupsieve-2.9.2.tar.gz", hash = "sha256:4a55d8cf158a9c2e587fa4922f1bbb91d68ac829e2d6f25403a85747c71daf74", size = 122445, upload-time = "2026-08-07T00:57:24.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/dc/ad025c1ee131eba60c69f4dd5779b18fcf1e6b21a343e2162a84d5d133c7/soupsieve-2.9.2-py3-none-any.whl", hash = "sha256:8089a26fd974ca7a1f30276d3d8492ab266ab15af581642dfe8aa162e0c1c823", size = 37370, upload-time = "2026-08-07T00:57:23.524Z" },
+]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1140,6 +1342,18 @@ wheels = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
 name = "triton"
 version = "3.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1184,4 +1398,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]


### PR DESCRIPTION

Adds BoT-SORT, extending ByteTrack with the paper's two contributions: appearance (ReID) fusion and global motion compensation. Both are optional and off by default, so ByteTrack behaviour is unchanged unless configured.

## Appearance (ReID)

- A bounded per-track `AppearanceGallery` (FIFO of recent descriptors plus an optional confidence-scaled EMA), with a cosine admission gate that guards it against pollution.
- On the high-score association, a cosine appearance cost is fused with IoU under an IoU proximity gate, so appearance disambiguates matches and recovers identities across occlusions but can never rescue non-overlapping boxes. The low-score stage stays IoU-only.
- ReID features come from torchreid. The backend is selectable: `torch` runs the model natively; `openvino` runs an IR auto-exported and cached from the torchreid model, or a prebuilt `.xml` supplied directly. Every backend (torch / openvino / torchreid) is imported lazily, so the core library stays importable without the `reid` extra installed.

## Camera-motion compensation (GMC)

- Per-frame camera motion is estimated and the predicted Kalman states are warped by it between predict and associate, keeping tracks aligned under a moving camera.
- Four methods via an ABC-per-file registry: `sparse_opt_flow` (default), `ecc`, `orb`, `sift`. Disable with `gmc.enabled: false`.
- Kept off the frame-agnostic `update()` path: the caller feeds frames to the estimator with `tracker.apply_camera_motion(frame)`, mirroring how `reid_provider` fills `Detections.embeddings`.

## Config and recipe

`ReIDConfig` and `GMCConfig` live in the shared config module so future appearance trackers (Deep OC-SORT, StrongSORT) reuse them. A `configs/botsort.yaml` recipe documents the appearance, ReID, and GMC knobs, and `scripts/botsort_reid_demo.py` runs the tracker end to end on a video for either backend.

## Testing

Unit tests cover the gallery, appearance fusion, both ReID providers (via injected fakes and a tiny exported IR, no network), the factory dispatch, the export cache, all four GMC estimators (dispatch, first-frame identity, real translation recovery, low-texture fallback), and the tracker-level appearance recovery and camera-motion warp. Full suite: 237 passed.

## Comparison with Ultralytics and Roboflow BoT-SORT

Both Ultralytics and Roboflow (`roboflow/trackers`) ship a BoT-SORT. Roboflow's is motion-only: ByteTrack plus camera-motion compensation (the same four methods) and a pluggable IoU metric (GIoU/DIoU/CIoU), but no appearance/ReID stage, so it implements the GMC half of BoT-SORT without the appearance half. Ultralytics is the full-featured reference (appearance + GMC), like ours.

| Dimension | getitrack (this PR) | Ultralytics | Roboflow |
| --- | --- | --- | --- |
| Two-stage association | yes | yes | yes |
| Appearance / ReID | yes (torchreid, torch + openvino) | yes (YOLO-ReID: pt/onnx/openvino) | no |
| Appearance memory | FIFO gallery + EMA | single EMA feature | n/a |
| CMC methods | sparse/ecc/orb/sift | sparse/ecc/orb/sift + none | sparse/ecc/orb/sift |
| CMC frame handling | off-path `apply_camera_motion(frame)` | `update(img)` | `update(frame)` |
| Kalman state | XYAH | XYWH | XYWH (default) |

Our appearance stage (richer FIFO + EMA memory) and frame-agnostic `update()` are the main differentiators; the one deliberate deviation is the Kalman state (XYAH, shared across every getitrack tracker, vs the paper's XYWH used by both Ultralytics and Roboflow), kept for motion-module consistency.

Throughput (tracker core, all appearance and CMC off, identical synthetic detections, same machine, FPS):

| Objects/frame | getitrack | Ultralytics | Roboflow |
| --- | --- | --- | --- |
| 20 | 4196 | 2415 | 1839 |
| 50 | 2101 | 1043 | 744 |
| 100 | 1091 | 539 | 368 |

getitrack has the fastest core, roughly 2x Ultralytics and 2.3 to 3x Roboflow, from the batched Kalman update and lower per-frame object churn (it uses scipy assignment, where Ultralytics uses the faster `lap.lapjv`).

Accuracy (ground-truth scenarios with crossings and occlusions, identical detections, motmetrics; MOTA / IDF1):

| Scenario | getitrack | Ultralytics | Roboflow |
| --- | --- | --- | --- |
| crossing | 1.000 / 1.000 | 1.000 / 1.000 | 0.995 / 0.998 |
| occlusion | 0.964 / 0.982 | 0.964 / 0.982 | 0.957 / 0.978 |
| mixed | 0.970 / 0.927 | 0.970 / 0.927 | 0.967 / 0.925 |

Association quality is within a fraction of a point across all three, with identical ID switches; getitrack and Ultralytics edge Roboflow slightly (a few more false negatives from Roboflow's stricter track confirmation). The only notable spread is MOTP (localization): Ultralytics is tighter (0.07 vs 0.10) because it reports the Kalman-smoothed box for matched tracks, while getitrack and Roboflow both report the (near-)detection box. So it is an output-reporting choice shared by two of the three implementations, not an association or state-vector difference.

## Notes

- GMC and the perf/accuracy benchmark scripts (cross-framework, cross-venv) are kept out of the library; the benchmarks live outside `libraries/getitrack`.
- Deep OC-SORT and StrongSORT can reuse the ReID and GMC layers added here.
