### PR TITLE
Remove leftover reference to non-existing 'save_predictions' parameter

### DIFF
--- a/application/ui/src/features/annotator/api/use-media-predictions.ts
+++ b/application/ui/src/features/annotator/api/use-media-predictions.ts
@@ -47,7 +47,6 @@ export const mediaPredictionsQueryOptions = ({
                 body: {
                     ...getModelIdentifierPayload(selectedModel),
                     device,
-                    save_predictions: false,
                     media: [{ media_id: mediaId, range }],
                 },
             });


### PR DESCRIPTION
### Summary

The parameter `save_predictions` does not exist anymore in `media:predict`, yet the UI was still sending it in the payload.

### How to test

Launch Geti and request a prediction in the annotator.

### Checklist

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
