### PR TITLE
Use spectrum link instead of react routers'

### DIFF
--- a/application/ui/src/features/models/train-model/train-model-dialog.component.tsx
+++ b/application/ui/src/features/models/train-model/train-model-dialog.component.tsx
@@ -1,21 +1,9 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-    Button,
-    ButtonGroup,
-    Content,
-    Dialog,
-    Divider,
-    Flex,
-    Footer,
-    Heading,
-    InlineAlert,
-    Link,
-    Text,
-} from '@geti-ui/ui';
+import { Button, ButtonGroup, Content, Dialog, Divider, Flex, Footer, Heading, InlineAlert, Text } from '@geti-ui/ui';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
-import { useMatch } from 'react-router-dom';
+import { Link, useMatch } from 'react-router-dom';
 
 import { toast } from '../../../components/toast/toast.component';
 import { paths } from '../../../constants/paths';
@@ -62,10 +50,7 @@ export const TrainModelDialog = ({ onClose }: TrainModelDialogProps) => {
                         <Flex alignItems={'center'} gap={'size-50'} wrap={'wrap'}>
                             <Text>
                                 Model training started successfully.{' '}
-                                <Link
-                                    href={paths.project.models({ projectId })}
-                                    routerOptions={{ viewTransition: true }}
-                                >
+                                <Link to={paths.project.models({ projectId })} viewTransition>
                                     Open models screen to see progress.
                                 </Link>
                             </Text>

--- a/application/ui/src/features/models/train-model/train-model-dialog.component.tsx
+++ b/application/ui/src/features/models/train-model/train-model-dialog.component.tsx
@@ -1,9 +1,21 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Button, ButtonGroup, Content, Dialog, Divider, Flex, Footer, Heading, InlineAlert, Text } from '@geti-ui/ui';
+import {
+    Button,
+    ButtonGroup,
+    Content,
+    Dialog,
+    Divider,
+    Flex,
+    Footer,
+    Heading,
+    InlineAlert,
+    Link,
+    Text,
+} from '@geti-ui/ui';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
-import { Link, useMatch } from 'react-router-dom';
+import { useMatch } from 'react-router-dom';
 
 import { toast } from '../../../components/toast/toast.component';
 import { paths } from '../../../constants/paths';
@@ -50,7 +62,10 @@ export const TrainModelDialog = ({ onClose }: TrainModelDialogProps) => {
                         <Flex alignItems={'center'} gap={'size-50'} wrap={'wrap'}>
                             <Text>
                                 Model training started successfully.{' '}
-                                <Link to={paths.project.models({ projectId })} viewTransition>
+                                <Link
+                                    href={paths.project.models({ projectId })}
+                                    routerOptions={{ viewTransition: true }}
+                                >
                                     Open models screen to see progress.
                                 </Link>
                             </Text>

--- a/application/ui/src/providers.tsx
+++ b/application/ui/src/providers.tsx
@@ -5,7 +5,6 @@ import { ThemeProvider } from '@geti-ui/ui';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider } from 'react-router-dom';
 
-import { Toast } from './components/toast/toast.component';
 import { queryClient } from './query-client/query-client';
 import { router } from './router';
 
@@ -19,9 +18,6 @@ export const Providers = () => {
                         v7_startTransition: true,
                     }}
                 />
-                <div data-react-aria-top-layer='true'>
-                    <Toast />
-                </div>
             </ThemeProvider>
         </QueryClientProvider>
     );

--- a/application/ui/src/routes/root/root.tsx
+++ b/application/ui/src/routes/root/root.tsx
@@ -7,6 +7,7 @@ import { $api } from '@/api';
 import { Flex, Heading, Loading } from '@geti-ui/ui';
 import { Outlet } from 'react-router-dom';
 
+import { Toast } from '../../components/toast/toast.component';
 import { LicenseCheck } from '../../features/license/license-check.component';
 import { ServerErrorFallback } from './server-error-fallback.component';
 
@@ -53,6 +54,9 @@ export const RootLayout = () => {
                     <Outlet />
                 </LicenseCheck>
             </HealthCheck>
+            <div data-react-aria-top-layer='true'>
+                <Toast />
+            </div>
         </Suspense>
     );
 };


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Fix the current issue when starting a training (error [browser] Uncaught TypeError: Cannot destructure property 'basename' of 'react__rspack_import_0.useContext(...)' as it is null)
* Reason: Sonner's toast rendered upon start training ("model training started, click here to go to models page" toast) did not have the router's context because in `providers.tsx` is rendered alongside it. So, since our spectrum provider already has router's context  (`<ThemeProvider router={router}>`), we fix this by using spectrum's link instead of using react router directly

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
