### PR TITLE
Add 'high_bit_depth_images' capability to model manifests

### DIFF
--- a/application/backend/app/models/model_manifest.py
+++ b/application/backend/app/models/model_manifest.py
@@ -90,6 +90,11 @@ class Capabilities(BaseModel):
         title="Tiling Support",
         description="Whether the model supports image tiling for processing large images",
     )
+    high_bit_depth_images: bool = Field(
+        default=True,
+        title="High Bit Depth Images Support",
+        description="Whether the model supports input images with a bit depth greater than 8 bits per channel",
+    )
 
 
 class PretrainedWeights(BaseModel):

--- a/application/backend/app/models/training_configuration/dataset_preparation.py
+++ b/application/backend/app/models/training_configuration/dataset_preparation.py
@@ -242,7 +242,7 @@ class TaskLevelDatasetPreparationParameters(BaseModel):
             "improve the model performance by removing noisy annotations."
         ),
     )
-    intensity_mapping: IntensityMapping = Field(
+    intensity_mapping: IntensityMapping | None = Field(
         default_factory=IntensityMapping,
         title="Intensity mapping",
         description=(

--- a/application/backend/app/services/training_configuration_service.py
+++ b/application/backend/app/services/training_configuration_service.py
@@ -78,6 +78,8 @@ class TrainingConfigurationService(BaseSessionManagedService):
         """
         if not model_manifest.capabilities.tiling:
             training_configuration.algo_level_parameters.dataset_preparation.augmentation.tiling = None
+        if not model_manifest.capabilities.high_bit_depth_images:
+            training_configuration.task_level_parameters.dataset_preparation.intensity_mapping = None
 
     def get_by_model_architecture(self, project_id: UUID, model_architecture_id: str) -> TrainingConfiguration:
         """

--- a/application/backend/app/supported_models/manifests/base.yaml
+++ b/application/backend/app/supported_models/manifests/base.yaml
@@ -1,6 +1,7 @@
 capabilities:
   tiling: false
   xai: true # by default, all models support XAI features (unless specified otherwise)
+  high_bit_depth_images: true # by default, all models support high bit depth images (unless specified otherwise)
 
 support_status: active
 

--- a/application/backend/app/supported_models/manifests/detection/yolox_l.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_l.yaml
@@ -13,6 +13,9 @@ stats:
     coco_map_50_95: 50.2
     coco_map_50: 68.5
 
+capabilities:
+  high_bit_depth_images: false # YOLOX-L is not compatible with 16-bit images because its pretrained weights were trained on 8-bit RGB images without normalization.
+
 hyperparameters:
   dataset_preparation:
     augmentation:

--- a/application/backend/app/supported_models/manifests/detection/yolox_s.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_s.yaml
@@ -12,6 +12,9 @@ stats:
   benchmark_metrics:
     coco_map_50_95: 40.5
 
+capabilities:
+  high_bit_depth_images: false # YOLOX-S is not compatible with 16-bit images because its pretrained weights were trained on 8-bit RGB images without normalization.
+
 hyperparameters:
   dataset_preparation:
     augmentation:

--- a/application/backend/app/supported_models/manifests/detection/yolox_x.yaml
+++ b/application/backend/app/supported_models/manifests/detection/yolox_x.yaml
@@ -13,6 +13,9 @@ stats:
     coco_map_50_95: 51.5
     coco_map_50: 69.6
 
+capabilities:
+  high_bit_depth_images: false # YOLOX-X is not compatible with 16-bit images because its pretrained weights were trained on 8-bit RGB images without normalization.
+
 hyperparameters:
   dataset_preparation:
     augmentation:

--- a/application/backend/tests/integration/services/test_training_configuration_service.py
+++ b/application/backend/tests/integration/services/test_training_configuration_service.py
@@ -196,6 +196,62 @@ class TestTrainingConfigurationService:
 
         assert result.algo_level_parameters.dataset_preparation.augmentation.tiling is None
 
+    def test_get_default_by_model_architecture_strips_intensity_mapping_when_unsupported(
+        self,
+        fxt_training_configuration_service: TrainingConfigurationService,
+    ):
+        """Intensity mapping should be removed from the default config when the architecture doesn't support
+        high bit depth images."""
+        TrainingConfigurationService.get_default_by_model_architecture.cache_clear()
+
+        # YOLOX-S does not support high bit depth images (capabilities.high_bit_depth_images: false in its manifest)
+        result = TrainingConfigurationService.get_default_by_model_architecture(
+            model_architecture_id="object-detection-yolox-s",
+        )
+
+        assert result.task_level_parameters.dataset_preparation.intensity_mapping is None
+
+        # Sanity check: a model that supports high bit depth images still exposes the intensity mapping parameters
+        TrainingConfigurationService.get_default_by_model_architecture.cache_clear()
+        yolo11_result = TrainingConfigurationService.get_default_by_model_architecture(
+            model_architecture_id="object-detection-yolo11-n",
+        )
+        assert yolo11_result.task_level_parameters.dataset_preparation.intensity_mapping is not None
+
+        TrainingConfigurationService.get_default_by_model_architecture.cache_clear()
+
+    def test_get_by_model_architecture_strips_intensity_mapping_when_unsupported(
+        self,
+        fxt_training_configuration: TrainingConfiguration,
+        fxt_training_configuration_service: TrainingConfigurationService,
+        fxt_project: ProjectDB,
+        db_session: Session,
+    ):
+        """Persisted intensity mapping values should be stripped when the architecture doesn't support high bit
+        depth images."""
+        # Persist a task-level configuration with intensity_mapping populated (simulating an older configuration)
+        task_level_data = fxt_training_configuration.task_level_parameters.model_dump()
+        task_level_data["dataset_preparation"]["intensity_mapping"] = {
+            "mode": "window",
+            "window_center": 500.0,
+            "window_width": 1000.0,
+        }
+        task_level_config = TrainingConfigurationDB(
+            id=str(uuid4()),
+            project_id=fxt_project.id,
+            model_architecture_id=None,
+            configuration_data=task_level_data,
+        )
+        db_session.add(task_level_config)
+        db_session.flush()
+
+        result = fxt_training_configuration_service.get_by_model_architecture(
+            project_id=UUID(fxt_project.id),
+            model_architecture_id="object-detection-yolox-s",
+        )
+
+        assert result.task_level_parameters.dataset_preparation.intensity_mapping is None
+
     def test_get_by_model_architecture_with_existing_config(
         self,
         fxt_training_configuration: TrainingConfiguration,

--- a/application/backend/tests/unit/api/routers/test_model_architectures.py
+++ b/application/backend/tests/unit/api/routers/test_model_architectures.py
@@ -40,6 +40,7 @@ class TestModelArchitecturesEndpoint:
         assert "capabilities" in detection_model
         assert detection_model["capabilities"]["xai"] is True
         assert detection_model["capabilities"]["tiling"] is True
+        assert detection_model["capabilities"]["high_bit_depth_images"] is True
 
         # Verify stats structure
         assert "stats" in detection_model

--- a/application/backend/tests/unit/models/test_training_configuration.py
+++ b/application/backend/tests/unit/models/test_training_configuration.py
@@ -136,6 +136,7 @@ class TestTrainingConfiguration:
     def test_apply_updates_intensity_mapping_mode(self) -> None:
         config = make_config()
         config.apply_updates({"dataset_preparation.intensity_mapping.mode": "Windowing"})
+        assert config.task_level_parameters.dataset_preparation.intensity_mapping is not None
         assert config.task_level_parameters.dataset_preparation.intensity_mapping.mode == IntensityMappingMode.WINDOW
 
     def test_apply_updates_intensity_mapping_window_params(self) -> None:
@@ -147,6 +148,7 @@ class TestTrainingConfiguration:
             }
         )
         im = config.task_level_parameters.dataset_preparation.intensity_mapping
+        assert im is not None
         assert im.window_center == pytest.approx(500.0)
         assert im.window_width == pytest.approx(1000.0)
 

--- a/application/ui/mocks/mock-model.ts
+++ b/application/ui/mocks/mock-model.ts
@@ -39,6 +39,7 @@ export const getMockedModelArchitecture = (
     capabilities: {
         xai: true,
         tiling: true,
+        high_bit_depth_images: true,
     },
     stats: {
         gigaflops: 91,


### PR DESCRIPTION

### Summary

By adding a new capability `high_bit_depth_images` (bool) to the model manifests, we can selectively hide the intensity mapping parameters for architectures that don't support 16-bit images, namely YOLOX-S/L/X.

Fixes #6722 

### How to test

- [x] Check the configuration of a model other than YOLOX-S/L/X -> intensity parameters are shown
<img width="802" height="608" alt="image" src="https://github.com/user-attachments/assets/15a97b0c-8acc-4a14-bd52-d1e19045d261" />
- [x] Check the configuration of YOLOX-S/L/X -> intensity parameters are not shown
<img width="316" height="373" alt="image" src="https://github.com/user-attachments/assets/3ead924f-4cb6-4e71-82c5-6fce5294da17" />
- [x] Train YOLOX-S/L/X
- [x] Train a different model with custom intensity params

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
