### PR TITLE
Add confidence threshold slider to pipeline configuration

### DIFF
--- a/application/ui/src/components/confidence-threshold/confidence-threshold.component.tsx
+++ b/application/ui/src/components/confidence-threshold/confidence-threshold.component.tsx
@@ -3,10 +3,8 @@
 
 import { useRef, useState } from 'react';
 
-import { ActionButton, Flex, NumberField, Slider, Text, View } from '@geti-ui/ui';
+import { ActionButton, Flex, NumberField, Slider, View } from '@geti-ui/ui';
 import { Refresh } from '@geti-ui/ui/icons';
-
-import classes from './confidence-threshold.module.scss';
 
 const THRESHOLD_CONFIG = {
     defaultValue: 0.3,
@@ -37,9 +35,10 @@ const ThresholdField = ({ onChange, value, isDisabled, name }: ThresholdFieldPro
     };
 
     return (
-        <Flex gap={'size-100'}>
+        <Flex gap={'size-100'} alignItems={'end'}>
             <Slider
-                aria-label={`Change ${name} slider`}
+                label={name}
+                showValueLabel={false}
                 value={parameterValue}
                 minValue={THRESHOLD_CONFIG.min}
                 maxValue={THRESHOLD_CONFIG.max}
@@ -65,15 +64,20 @@ const ThresholdField = ({ onChange, value, isDisabled, name }: ThresholdFieldPro
     );
 };
 
-export const ConfidenceThreshold = ({ isDisabled }: { isDisabled: boolean }) => {
+type ConfidenceThresholdProps = {
+    isDisabled?: boolean;
+    maxWidth?: string;
+    width?: string;
+};
+
+export const ConfidenceThreshold = ({ isDisabled = false, maxWidth, width = '100%' }: ConfidenceThresholdProps) => {
     // TODO: Default confidence threshold value will come from the server side
     const defaultValue = THRESHOLD_CONFIG.defaultValue;
     const [threshold, setThreshold] = useState<number>(defaultValue);
 
     return (
-        <View>
-            <Text UNSAFE_className={classes.label}>Confidence threshold</Text>
-            <Flex width={'100%'} gap={'size-175'} alignItems={'center'}>
+        <View maxWidth={maxWidth} width={width}>
+            <Flex width={'100%'} gap={'size-175'} alignItems={'end'}>
                 <ThresholdField
                     onChange={setThreshold}
                     name={'Confidence threshold'}

--- a/application/ui/src/components/confidence-threshold/confidence-threshold.component.tsx
+++ b/application/ui/src/components/confidence-threshold/confidence-threshold.component.tsx
@@ -77,7 +77,7 @@ export const ConfidenceThreshold = ({ isDisabled = false, maxWidth, width = '100
 
     return (
         <View maxWidth={maxWidth} width={width}>
-            <Flex width={'100%'} gap={'size-175'} alignItems={'end'}>
+            <Flex width={'100%'} justifyContent={'space-between'} gap={'size-175'} alignItems={'end'}>
                 <ThresholdField
                     onChange={setThreshold}
                     name={'Confidence threshold'}

--- a/application/ui/src/components/inference-devices/inference-devices.component.tsx
+++ b/application/ui/src/components/inference-devices/inference-devices.component.tsx
@@ -17,8 +17,7 @@ type InferenceDevicesProps = {
     onSelectionChange: (selectedKey: string) => void;
     isQuiet?: boolean;
     isDisabled?: boolean;
-    ariaLabel?: string;
-    label?: string;
+    label: string;
     maxWidth?: string;
     width?: string;
 };
@@ -28,7 +27,6 @@ export const InferenceDevices = ({
     onSelectionChange,
     isDisabled = false,
     isQuiet = false,
-    ariaLabel,
     label,
     maxWidth,
     width = '100%',
@@ -54,7 +52,6 @@ export const InferenceDevices = ({
             onSelectionChange={handleSelectionChange}
             selectedKey={selectedKey}
             isDisabled={isDisabled}
-            aria-label={ariaLabel}
             label={label}
         >
             {(device) => <Item key={device.id}>{device.name}</Item>}

--- a/application/ui/src/components/inference-devices/inference-devices.test.tsx
+++ b/application/ui/src/components/inference-devices/inference-devices.test.tsx
@@ -22,12 +22,12 @@ describe('InferenceDevices', () => {
 
     it('renders picker items from the devices API', async () => {
         const onSelectionChange = vi.fn();
-        render(<InferenceDevices selectedKey='cpu' onSelectionChange={onSelectionChange} ariaLabel='device picker' />);
+        render(<InferenceDevices selectedKey='cpu' onSelectionChange={onSelectionChange} label='device picker' />);
 
-        const picker = await screen.findByLabelText('device picker');
+        const picker = await screen.findByRole('button', { name: /device picker/i });
         expect(picker).toBeInTheDocument();
 
-        await userEvent.click(screen.getByRole('button', { name: /device picker/i }));
+        await userEvent.click(picker);
 
         expect(await screen.findByRole('option', { name: /CPU/i })).toBeInTheDocument();
         expect(screen.getByRole('option', { name: /XPU/i })).toBeInTheDocument();
@@ -35,10 +35,9 @@ describe('InferenceDevices', () => {
 
     it('calls onSelectionChange with the device key when a different device is selected', async () => {
         const onSelectionChange = vi.fn();
-        render(<InferenceDevices selectedKey='cpu' onSelectionChange={onSelectionChange} ariaLabel='device picker' />);
+        render(<InferenceDevices selectedKey='cpu' onSelectionChange={onSelectionChange} label='device picker' />);
 
-        await screen.findByLabelText('device picker');
-        await userEvent.click(screen.getByRole('button', { name: /device picker/i }));
+        await userEvent.click(await screen.findByRole('button', { name: /device picker/i }));
         await userEvent.click(await screen.findByRole('option', { name: /XPU/i }));
 
         await waitFor(() => {
@@ -48,10 +47,9 @@ describe('InferenceDevices', () => {
 
     it('does not call onSelectionChange when the already-selected key is clicked again', async () => {
         const onSelectionChange = vi.fn();
-        render(<InferenceDevices selectedKey='cpu' onSelectionChange={onSelectionChange} ariaLabel='device picker' />);
+        render(<InferenceDevices selectedKey='cpu' onSelectionChange={onSelectionChange} label='device picker' />);
 
-        await screen.findByLabelText('device picker');
-        await userEvent.click(screen.getByRole('button', { name: /device picker/i }));
+        await userEvent.click(await screen.findByRole('button', { name: /device picker/i }));
         await userEvent.click(await screen.findByRole('option', { name: /CPU/i }));
 
         expect(onSelectionChange).not.toHaveBeenCalled();
@@ -65,10 +63,9 @@ describe('InferenceDevices', () => {
         server.use(http.get('/api/system/devices/inference', () => HttpResponse.json(devicesWithIndex)));
 
         const onSelectionChange = vi.fn();
-        render(<InferenceDevices selectedKey='cpu' onSelectionChange={onSelectionChange} ariaLabel='device picker' />);
+        render(<InferenceDevices selectedKey='cpu' onSelectionChange={onSelectionChange} label='device picker' />);
 
-        await screen.findByLabelText('device picker');
-        await userEvent.click(screen.getByRole('button', { name: /device picker/i }));
+        await userEvent.click(await screen.findByRole('button', { name: /device picker/i }));
         await userEvent.click(await screen.findByRole('option', { name: /XPU/i }));
 
         await waitFor(() => {

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/confidence-threshold/confidence-threshold.module.scss
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/confidence-threshold/confidence-threshold.module.scss
@@ -1,4 +1,0 @@
-.label {
-    font-size: var(--spectrum-global-dimension-size-150);
-    color: var(--spectrum-global-color-gray-700);
-}

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/prediction-inference-devices/prediction-inference-devices.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/prediction-inference-devices/prediction-inference-devices.component.tsx
@@ -18,12 +18,10 @@ export const PredictionInferenceDevices = ({ isDisabled }: PredictionInferenceDe
     return (
         <Suspense fallback={<Loading mode={'inline'} />}>
             <InferenceDevices
-                ariaLabel={'Inference devices'}
-                label={'Inference accelerator'}
+                label={'Inference device'}
                 selectedKey={selectedDevice}
                 onSelectionChange={changeSelectedDevice}
                 isDisabled={isDisabled}
-                width={'100%'}
             />
         </Suspense>
     );

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
@@ -22,6 +22,7 @@ import { useProject } from 'hooks/api/project.hook';
 import { isEmpty } from 'lodash-es';
 import { useHotkeys } from 'react-hotkeys-hook';
 
+import { ConfidenceThreshold } from '../../../../components/confidence-threshold/confidence-threshold.component';
 import { FEATURE_FLAGS } from '../../../../constants/feature-flags';
 import { useAnnotationActions } from '../../../../shared/annotator/annotation-actions-provider.component';
 import type { AnnotatorMode } from '../../../../shared/annotator/annotator-mode';
@@ -34,7 +35,6 @@ import { isClassificationTask, isMultiLabelClassificationTask } from '../../../p
 import { DeleteMediaItem } from '../../gallery/delete-media-item/delete-media-item.component';
 import { Toolbar } from '../toolbar-container/toolbar-container.component';
 import { AnnotatorModes } from './annotator-modes/annotator-modes-toggle.component';
-import { ConfidenceThreshold } from './confidence-threshold/confidence-threshold.component';
 import { PredictionInferenceDevices } from './prediction-inference-devices/prediction-inference-devices.component';
 import { PredictionModelSelector } from './prediction-model-selector/prediction-model-selector.component';
 import { PredictionButtons } from './predictions-buttons.component';

--- a/application/ui/src/features/inference/aside/graphs.component.tsx
+++ b/application/ui/src/features/inference/aside/graphs.component.tsx
@@ -110,7 +110,7 @@ export const Graphs = () => {
                 <IllustratedMessage>
                     <Heading>No statistics available</Heading>
                     <Content>
-                        Model statistics will appear here once the pipeline starts running and starts processing data.
+                        Pipeline metrics will show here once the pipeline starts running and starts processing data.
                     </Content>
                 </IllustratedMessage>
             ) : (

--- a/application/ui/src/features/inference/aside/graphs.component.tsx
+++ b/application/ui/src/features/inference/aside/graphs.component.tsx
@@ -110,7 +110,7 @@ export const Graphs = () => {
                 <IllustratedMessage>
                     <Heading>No statistics available</Heading>
                     <Content>
-                        Pipeline metrics will show here once the pipeline starts running and starts processing data.
+                        Pipeline metrics will show here once the pipeline starts running and processing data.
                     </Content>
                 </IllustratedMessage>
             ) : (

--- a/application/ui/src/features/inference/aside/pipeline-configuration.component.tsx
+++ b/application/ui/src/features/inference/aside/pipeline-configuration.component.tsx
@@ -3,8 +3,10 @@
 
 import { ReactNode, Suspense } from 'react';
 
-import { Flex, Heading, Item, Loading, TabList, TabPanels, Tabs, Text, View } from '@geti-ui/ui';
+import { Flex, Item, Loading, TabList, TabPanels, Tabs, Text, View } from '@geti-ui/ui';
 
+import { ConfidenceThreshold } from '../../../components/confidence-threshold/confidence-threshold.component';
+import { FEATURE_FLAGS } from '../../../constants/feature-flags';
 import { SinkActions } from '../sinks/sink-actions.component';
 import { SourceActions } from '../sources/source-actions.component';
 import { StreamInferenceDevices } from './stream-inference-devices.component';
@@ -20,10 +22,12 @@ const ConfigurationItem = ({ children }: { children: ReactNode }) => {
 export const PipelineConfiguration = () => {
     return (
         <Flex direction={'column'} gap={'size-100'} minHeight={0}>
-            <Heading level={3}>Inference device</Heading>
             <Suspense fallback={<Loading />}>
                 <StreamInferenceDevices />
             </Suspense>
+
+            {FEATURE_FLAGS.CONFIDENCE_THRESHOLD && <ConfidenceThreshold />}
+
             <Tabs
                 aria-label={'Pipeline configuration tabs'}
                 flex={1}

--- a/application/ui/src/features/inference/aside/pipeline-configuration.component.tsx
+++ b/application/ui/src/features/inference/aside/pipeline-configuration.component.tsx
@@ -21,7 +21,7 @@ const ConfigurationItem = ({ children }: { children: ReactNode }) => {
 
 export const PipelineConfiguration = () => {
     return (
-        <Flex direction={'column'} gap={'size-100'} minHeight={0}>
+        <Flex direction={'column'} gap={'size-150'} minHeight={0}>
             <Suspense fallback={<Loading />}>
                 <StreamInferenceDevices />
             </Suspense>

--- a/application/ui/src/features/inference/aside/sidebar-tabs.component.tsx
+++ b/application/ui/src/features/inference/aside/sidebar-tabs.component.tsx
@@ -16,7 +16,7 @@ import styles from './sidebar-tabs.module.scss';
 const TABS = [
     { label: 'Pipeline configuration', icon: <PipelineIcon />, content: <PipelineConfiguration /> },
     { label: 'Data collection policy', icon: <Gear />, content: <DataCollection /> },
-    { label: 'Model statistics', icon: <GraphChart />, content: <Graphs /> },
+    { label: 'Pipeline metrics', icon: <GraphChart />, content: <Graphs /> },
 ];
 
 type TabProps = {

--- a/application/ui/src/features/inference/aside/stream-inference-devices.component.tsx
+++ b/application/ui/src/features/inference/aside/stream-inference-devices.component.tsx
@@ -31,12 +31,5 @@ export const StreamInferenceDevices = () => {
         );
     };
 
-    return (
-        <InferenceDevices
-            label={'Inference device'}
-            selectedKey={selectedKey}
-            onSelectionChange={handleChange}
-            maxWidth={'size-3000'}
-        />
-    );
+    return <InferenceDevices label={'Inference device'} selectedKey={selectedKey} onSelectionChange={handleChange} />;
 };

--- a/application/ui/src/features/inference/aside/stream-inference-devices.component.tsx
+++ b/application/ui/src/features/inference/aside/stream-inference-devices.component.tsx
@@ -33,7 +33,7 @@ export const StreamInferenceDevices = () => {
 
     return (
         <InferenceDevices
-            ariaLabel='inference compute'
+            label={'Inference device'}
             selectedKey={selectedKey}
             onSelectionChange={handleChange}
             maxWidth={'size-3000'}

--- a/application/ui/src/features/inference/aside/stream-inference-devices.test.tsx
+++ b/application/ui/src/features/inference/aside/stream-inference-devices.test.tsx
@@ -52,23 +52,22 @@ describe('StreamInferenceDevices', () => {
     it('displays current device selection', async () => {
         renderApp(200, mockDevices, { ...mockPipeline, device: 'xpu' });
 
-        expect(await screen.findByLabelText('inference compute')).toHaveTextContent('GPU');
+        expect(await screen.findByRole('button', { name: /inference device/i })).toHaveTextContent('GPU');
     });
 
     it('updates device on selection change', async () => {
         const pipelinePatchSpy = renderApp();
 
-        const picker = await screen.findByLabelText('inference compute');
+        const picker = await screen.findByRole('button', { name: /inference device/i });
         expect(picker).toHaveTextContent('CPU');
 
-        const button = screen.getByRole('button', { name: /inference compute/i });
-        await userEvent.click(button);
+        await userEvent.click(picker);
 
         const option = await screen.findByRole('option', { name: /GPU/i });
         await userEvent.click(option);
 
         await waitFor(() => {
-            expect(screen.getByLabelText('inference compute')).toHaveTextContent('GPU');
+            expect(picker).toHaveTextContent('GPU');
             expect(pipelinePatchSpy).toHaveBeenCalled();
         });
     });
@@ -76,9 +75,7 @@ describe('StreamInferenceDevices', () => {
     it('shows error toast on update failure', async () => {
         renderApp(500);
 
-        await screen.findByLabelText('inference compute');
-
-        await userEvent.click(screen.getByRole('button', { name: /inference compute/i }));
+        await userEvent.click(await screen.findByRole('button', { name: /inference device/i }));
         await userEvent.click(screen.getByRole('option', { name: /GPU/i }));
 
         expect(await screen.findByLabelText('toast')).toBeVisible();
@@ -87,14 +84,15 @@ describe('StreamInferenceDevices', () => {
     it('reverts selection on error', async () => {
         renderApp(500, mockDevices, { ...mockPipeline, device: 'cpu' });
 
-        expect(await screen.findByLabelText('inference compute')).toHaveTextContent('CPU');
+        const picker = await screen.findByRole('button', { name: /inference device/i });
+        expect(picker).toHaveTextContent('CPU');
 
-        await userEvent.click(screen.getByRole('button', { name: /inference compute/i }));
+        await userEvent.click(picker);
         await userEvent.click(screen.getByRole('option', { name: /GPU/i }));
 
         await screen.findByLabelText('toast');
 
-        expect(await screen.findByLabelText('inference compute')).toHaveTextContent('CPU');
+        expect(picker).toHaveTextContent('CPU');
     });
 
     it('renders devices with same type and name correctly', async () => {
@@ -105,8 +103,7 @@ describe('StreamInferenceDevices', () => {
         ];
         const pipelinePatchSpy = renderApp(200, devicesResponse, { ...mockPipeline, device: 'cpu' });
 
-        await screen.findByLabelText('inference compute');
-        await userEvent.click(screen.getByRole('button', { name: /inference compute/i }));
+        await userEvent.click(await screen.findByRole('button', { name: /inference device/i }));
 
         const options = await screen.findAllByRole('option');
         expect(options).toHaveLength(3);

--- a/application/ui/tests/annotator/annotator.spec.ts
+++ b/application/ui/tests/annotator/annotator.spec.ts
@@ -1350,7 +1350,7 @@ test.describe('Annotator', () => {
                 const predictResponsePromise = page.waitForResponse((res) => res.url().includes('media:predict'));
 
                 await annotatorPage.openPredictionSettings();
-                await page.getByRole('button', { name: 'Inference devices' }).click();
+                await page.getByRole('button', { name: /inference device/i }).click();
                 await page.getByRole('option', { name: /XPU/i }).click();
 
                 await expect(page.getByRole('button', { name: /XPU/i })).toBeVisible();

--- a/application/ui/tests/inference/inference.spec.ts
+++ b/application/ui/tests/inference/inference.spec.ts
@@ -113,8 +113,8 @@ test.describe('Inference', () => {
             await page.goto('/projects/id-1/inference');
 
             // Open both tabs just to make sure everything works
-            await page.getByRole('button', { name: 'Toggle Model statistics tab' }).click();
-            await expect(page.getByText('Model statistics', { exact: true })).toBeVisible();
+            await page.getByRole('button', { name: 'Toggle Pipeline metrics tab' }).click();
+            await expect(page.getByText('Pipeline metrics', { exact: true })).toBeVisible();
 
             await page.getByRole('button', { name: 'Toggle Data collection policy' }).click();
             await expect(page.getByRole('heading', { name: 'Data collection' })).toBeVisible();


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Add confidence threshold slider to pipeline configuration
* Make InferenceDevices consistent in terms of labels
* Update "model statistics" to "pipeline metrics"
* This closes part of https://github.com/open-edge-platform/geti/issues/7306 (still pending integration after backend merges their changes)

<img width="885" height="549" alt="Screenshot 2026-08-20 at 16 06 07" src="https://github.com/user-attachments/assets/1112f883-ec44-423b-a5c5-fa68dfe73074" />

The inference picker is the same width (last commit), so the screenshot is outdated
<img width="539" height="823" alt="Screenshot 2026-08-20 at 16 07 07" src="https://github.com/user-attachments/assets/94043929-a501-4b51-aeb3-87a59061ddd8" />
<img width="519" height="864" alt="Screenshot 2026-08-20 at 16 07 14" src="https://github.com/user-attachments/assets/00dafe8a-cf0f-46ac-9094-0e18daa33b74" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
