### PR TITLE
Pin SAM encoder precision to f32

### DIFF
--- a/application/backend/app/services/sam/media_segment_service.py
+++ b/application/backend/app/services/sam/media_segment_service.py
@@ -44,6 +44,17 @@ SAM_ENCODER_CONFIGURATION = {
     "pad_value": 0,
 }
 
+# The mobile_sam encoder IR is numerically unstable in f16: the graph emits the same
+# embedding for every input, so the client decodes an empty mask with no error anywhere.
+# f16 is the CPU plugin default on Apple Silicon (x86 defaults to bf16/f32), so this only
+# reproduces on macOS ARM. Pin f32 explicitly on every platform.
+SAM_ENCODER_PLUGIN_CONFIG = {"INFERENCE_PRECISION_HINT": "f32"}
+
+# OpenVINO's blob cache does NOT key on INFERENCE_PRECISION_HINT, so a cache populated
+# before the hint was pinned would silently keep serving the f16 blob. Compiling into a
+# dedicated sub-directory sidesteps that; bump the name whenever the encoder config changes.
+SAM_ENCODER_CACHE_NAMESPACE = "encoder-f32"
+
 
 class MediaSegmentService(BaseSessionManagedService):
     def __init__(
@@ -69,8 +80,16 @@ class MediaSegmentService(BaseSessionManagedService):
         core = create_core()
         core.set_property({"PERFORMANCE_HINT": "LATENCY"})
         if self.ov_cache_path is not None:
-            core.set_property({"CACHE_DIR": str(self.ov_cache_path)})
-        adapter = OpenvinoAdapter(core, str(self.model_xml_path), device=device, max_num_requests=1)
+            cache_dir = self.ov_cache_path / SAM_ENCODER_CACHE_NAMESPACE
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            core.set_property({"CACHE_DIR": str(cache_dir)})
+        adapter = OpenvinoAdapter(
+            core,
+            str(self.model_xml_path),
+            device=device,
+            plugin_config=SAM_ENCODER_PLUGIN_CONFIG,
+            max_num_requests=1,
+        )
         return Model.create_model(adapter, configuration=SAM_ENCODER_CONFIGURATION)
 
     def _unload(self, model: "Model") -> None:

--- a/application/backend/app/services/sam/media_segment_service.py
+++ b/application/backend/app/services/sam/media_segment_service.py
@@ -50,11 +50,6 @@ SAM_ENCODER_CONFIGURATION = {
 # reproduces on macOS ARM. Pin f32 explicitly on every platform.
 SAM_ENCODER_PLUGIN_CONFIG = {"INFERENCE_PRECISION_HINT": "f32"}
 
-# OpenVINO's blob cache does NOT key on INFERENCE_PRECISION_HINT, so a cache populated
-# before the hint was pinned would silently keep serving the f16 blob. Compiling into a
-# dedicated sub-directory sidesteps that; bump the name whenever the encoder config changes.
-SAM_ENCODER_CACHE_NAMESPACE = "encoder-f32"
-
 
 class MediaSegmentService(BaseSessionManagedService):
     def __init__(
@@ -80,9 +75,7 @@ class MediaSegmentService(BaseSessionManagedService):
         core = create_core()
         core.set_property({"PERFORMANCE_HINT": "LATENCY"})
         if self.ov_cache_path is not None:
-            cache_dir = self.ov_cache_path / SAM_ENCODER_CACHE_NAMESPACE
-            cache_dir.mkdir(parents=True, exist_ok=True)
-            core.set_property({"CACHE_DIR": str(cache_dir)})
+            core.set_property({"CACHE_DIR": str(self.ov_cache_path)})
         adapter = OpenvinoAdapter(
             core,
             str(self.model_xml_path),

--- a/application/backend/tests/unit/services/test_media_segment_service.py
+++ b/application/backend/tests/unit/services/test_media_segment_service.py
@@ -16,7 +16,12 @@ from app.models.media import Image, MediaType, NotAnnotatedVideoFrame, VideoFram
 from app.models.system import DeviceInfo, DeviceType
 from app.services.media_numpy_loader import MediaNumpyLoader
 from app.services.media_service import MediaService
-from app.services.sam.media_segment_service import SAM_EMBEDDING_MODEL_VERSION, MediaSegmentService
+from app.services.sam.media_segment_service import (
+    SAM_EMBEDDING_MODEL_VERSION,
+    SAM_ENCODER_CACHE_NAMESPACE,
+    SAM_ENCODER_PLUGIN_CONFIG,
+    MediaSegmentService,
+)
 
 
 def _read_safetensors_metadata(blob: bytes) -> dict[str, str]:
@@ -100,6 +105,30 @@ class TestMediaSegmentService:
 
         tensors = safetensors_load(blob)
         np.testing.assert_array_equal(tensors["image_embeddings"], embeddings)
+
+    def test_load_model_pins_f32_precision_and_namespaced_cache(
+        self, fxt_media_service, fxt_media_numpy_loader, tmp_path
+    ):
+        service = MediaSegmentService(
+            media_service=fxt_media_service,
+            media_numpy_loader=fxt_media_numpy_loader,
+            model_xml_path=Path("/tmp/mobile_sam.encoder.xml"),
+            ov_cache_path=tmp_path,
+            db_session=MagicMock(spec=Session),
+        )
+        core = MagicMock()
+
+        with (
+            patch("model_api.adapters.create_core", return_value=core),
+            patch("model_api.adapters.OpenvinoAdapter") as mock_adapter,
+            patch("model_api.models.Model.create_model"),
+        ):
+            service._load_model(device="CPU")
+
+        expected_cache_dir = tmp_path / SAM_ENCODER_CACHE_NAMESPACE
+        assert expected_cache_dir.is_dir()
+        core.set_property.assert_any_call({"CACHE_DIR": str(expected_cache_dir)})
+        assert mock_adapter.call_args.kwargs["plugin_config"] == SAM_ENCODER_PLUGIN_CONFIG
 
     def test_encode_media_image(self, fxt_media_segment_service, fxt_media_numpy_loader):
         project = MagicMock(spec=Project, id=uuid4())

--- a/application/backend/tests/unit/services/test_media_segment_service.py
+++ b/application/backend/tests/unit/services/test_media_segment_service.py
@@ -18,7 +18,6 @@ from app.services.media_numpy_loader import MediaNumpyLoader
 from app.services.media_service import MediaService
 from app.services.sam.media_segment_service import (
     SAM_EMBEDDING_MODEL_VERSION,
-    SAM_ENCODER_CACHE_NAMESPACE,
     SAM_ENCODER_PLUGIN_CONFIG,
     MediaSegmentService,
 )
@@ -106,9 +105,7 @@ class TestMediaSegmentService:
         tensors = safetensors_load(blob)
         np.testing.assert_array_equal(tensors["image_embeddings"], embeddings)
 
-    def test_load_model_pins_f32_precision_and_namespaced_cache(
-        self, fxt_media_service, fxt_media_numpy_loader, tmp_path
-    ):
+    def test_load_model_pins_f32_precision(self, fxt_media_service, fxt_media_numpy_loader, tmp_path):
         service = MediaSegmentService(
             media_service=fxt_media_service,
             media_numpy_loader=fxt_media_numpy_loader,
@@ -125,9 +122,7 @@ class TestMediaSegmentService:
         ):
             service._load_model(device="CPU")
 
-        expected_cache_dir = tmp_path / SAM_ENCODER_CACHE_NAMESPACE
-        assert expected_cache_dir.is_dir()
-        core.set_property.assert_any_call({"CACHE_DIR": str(expected_cache_dir)})
+        core.set_property.assert_any_call({"CACHE_DIR": str(tmp_path)})
         assert mock_adapter.call_args.kwargs["plugin_config"] == SAM_ENCODER_PLUGIN_CONFIG
 
     def test_encode_media_image(self, fxt_media_segment_service, fxt_media_numpy_loader):


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Issue: When the plugin_config from OPENVINO's adapter picks f16, we wont see any masks/contours on dev mode. 
Fix: Pin the precision && add namespace for cache bust

INFERENCE_PRECISION_HINT has no fixed default; each plugin picks one from the hardware:

Examples:
CPU on Apple Silicon → f16 (your repro)
CPU on x86 with AMX/avx512_bf16 → bf16
GPU plugin → f16, everywhere

I dont know if we could solve this BEFORE exporting the the encoder? (openvino part, up to the backend)

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
