### PR TITLE
Fix revision check in Alembic migration

### DIFF
--- a/application/backend/app/db/migration.py
+++ b/application/backend/app/db/migration.py
@@ -12,6 +12,7 @@ from alembic import command
 from alembic.config import Config
 from alembic.runtime import migration
 from alembic.script import ScriptDirectory
+from alembic.script.revision import ResolutionError
 from alembic.util.exc import CommandError
 from loguru import logger
 from sqlalchemy import text
@@ -161,7 +162,7 @@ class MigrationManager:
             if current_rev:
                 try:
                     script.get_revision(current_rev)
-                except CommandError as e:
+                except (CommandError, ResolutionError) as e:
                     raise RevisionNotFoundError(
                         f"Current revision '{current_rev}' not found in Alembic history. Please, recreate the database."
                     ) from e

--- a/application/backend/app/db/migration.py
+++ b/application/backend/app/db/migration.py
@@ -12,6 +12,7 @@ from alembic import command
 from alembic.config import Config
 from alembic.runtime import migration
 from alembic.script import ScriptDirectory
+from alembic.util.exc import CommandError
 from loguru import logger
 from sqlalchemy import text
 
@@ -157,10 +158,13 @@ class MigrationManager:
                 current_rev = context.get_current_revision()
 
             # Check if current_rev is in Alembic's tracked revisions
-            if current_rev and current_rev not in script.get_heads() + script.get_bases():
-                raise RevisionNotFoundError(
-                    f"Current revision '{current_rev}' not found in Alembic history. Please, recreate the database."
-                )
+            if current_rev:
+                try:
+                    script.get_revision(current_rev)
+                except CommandError as e:
+                    raise RevisionNotFoundError(
+                        f"Current revision '{current_rev}' not found in Alembic history. Please, recreate the database."
+                    ) from e
 
             needs_migration = current_rev != current_head
             status = f"Current: {current_rev or 'None'}, Head: {current_head or 'None'}"

--- a/application/backend/tests/unit/db/test_migration.py
+++ b/application/backend/tests/unit/db/test_migration.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from alembic.util.exc import CommandError
+from alembic.script.revision import ResolutionError
 
 from app.db.migration import MigrationManager, RevisionNotFoundError
 
@@ -49,7 +49,7 @@ def _mock_migration_script(current_head: str, known_revisions: set[str]) -> Magi
 
     def _get_revision(rev_id: str) -> MagicMock:
         if rev_id not in known_revisions:
-            raise CommandError(f"Can't locate revision identified by '{rev_id}'")
+            raise ResolutionError("Can't locate revision", rev_id)
         return MagicMock()
 
     script.get_revision.side_effect = _get_revision

--- a/application/backend/tests/unit/db/test_migration.py
+++ b/application/backend/tests/unit/db/test_migration.py
@@ -4,10 +4,15 @@
 """Unit tests for MigrationManager's real SQLite backup/restore code paths."""
 
 import sqlite3
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
-from app.db.migration import MigrationManager
+import pytest
+from alembic.util.exc import CommandError
+
+from app.db.migration import MigrationManager, RevisionNotFoundError
 
 
 def _manager(tmp_path: Path) -> MigrationManager:
@@ -25,12 +30,30 @@ def _create_db(path: Path, value: str) -> None:
         conn.close()
 
 
+@contextmanager
+def _mock_connect():
+    yield MagicMock()
+
+
 def _read_value(path: Path) -> str:
     conn = sqlite3.connect(str(path))
     try:
         return conn.execute("SELECT v FROM t").fetchone()[0]
     finally:
         conn.close()
+
+
+def _mock_migration_script(current_head: str, known_revisions: set[str]) -> MagicMock:
+    script = MagicMock()
+    script.get_current_head.return_value = current_head
+
+    def _get_revision(rev_id: str) -> MagicMock:
+        if rev_id not in known_revisions:
+            raise CommandError(f"Can't locate revision identified by '{rev_id}'")
+        return MagicMock()
+
+    script.get_revision.side_effect = _get_revision
+    return script
 
 
 class TestBackupDatabase:
@@ -46,3 +69,39 @@ class TestBackupDatabase:
         assert backup is not None
         assert backup.exists()
         assert _read_value(backup) == "original"
+
+
+class TestCheckMigrationStatus:
+    def test_intermediate_revision_is_recognized(self, tmp_path: Path) -> None:
+        """Regression test for #7355: an intermediate (non-head, non-base) revision
+        must not be mistaken for an unrecognized schema revision."""
+        manager = _manager(tmp_path)
+        script = _mock_migration_script(current_head="head_rev", known_revisions={"base_rev", "mid_rev", "head_rev"})
+
+        with (
+            patch.object(manager, "get_alembic_config", return_value=MagicMock()),
+            patch("app.db.migration.ScriptDirectory.from_config", return_value=script),
+            patch("app.db.migration.db_engine.connect", side_effect=_mock_connect),
+            patch("app.db.migration.migration.MigrationContext.configure") as mock_configure,
+        ):
+            mock_configure.return_value.get_current_revision.return_value = "mid_rev"
+
+            needs_migration, status = manager.check_migration_status()
+
+        assert needs_migration is True
+        assert "mid_rev" in status
+
+    def test_unknown_revision_raises(self, tmp_path: Path) -> None:
+        manager = _manager(tmp_path)
+        script = _mock_migration_script(current_head="head_rev", known_revisions={"base_rev", "head_rev"})
+
+        with (
+            patch.object(manager, "get_alembic_config", return_value=MagicMock()),
+            patch("app.db.migration.ScriptDirectory.from_config", return_value=script),
+            patch("app.db.migration.db_engine.connect", side_effect=_mock_connect),
+            patch("app.db.migration.migration.MigrationContext.configure") as mock_configure,
+        ):
+            mock_configure.return_value.get_current_revision.return_value = "unknown_rev"
+
+            with pytest.raises(RevisionNotFoundError):
+                manager.check_migration_status()


### PR DESCRIPTION
### Summary

The previous logic would only consider base and head revisions, ignoring intermediate versions. As a result, an error would be raised if the DB schema currently matches one of the intermediate revisions.

Fixes #7355.

### How to test

Follow the steps described in the ticket, checking out this branch in the final step.

### Checklist

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
