### PR TITLE
Enable WAL mode and NORMAL synchronous in SQLite to prevent database locked errors

### DIFF
--- a/application/backend/app/alembic/env.py
+++ b/application/backend/app/alembic/env.py
@@ -47,6 +47,8 @@ def run_migrations_offline() -> None:
         dialect_opts={"paramstyle": "named"},
     )
     context.execute("PRAGMA foreign_keys=ON")  # Enable foreign keys for SQLite
+    context.execute("PRAGMA journal_mode=WAL")
+    context.execute("PRAGMA synchronous=NORMAL")
 
     with context.begin_transaction():
         context.run_migrations()
@@ -68,6 +70,8 @@ def run_migrations_online() -> None:
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)
         context.execute("PRAGMA foreign_keys=ON")  # Enable foreign keys for SQLite
+        context.execute("PRAGMA journal_mode=WAL")
+        context.execute("PRAGMA synchronous=NORMAL")
 
         with context.begin_transaction():
             context.run_migrations()

--- a/application/backend/app/db/engine.py
+++ b/application/backend/app/db/engine.py
@@ -31,6 +31,8 @@ def set_sqlite_pragma(dbapi_connection: Connection, _: Any) -> None:
     # https://docs.sqlalchemy.org/en/20/dialects/sqlite.html#foreign-key-support
     cursor = dbapi_connection.cursor()
     cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.execute("PRAGMA journal_mode=WAL")
+    cursor.execute("PRAGMA synchronous=NORMAL")
     cursor.close()
 
 


### PR DESCRIPTION


<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
Enables Write-Ahead Logging (WAL) and NORMAL synchronous mode for SQLite to resolve `sqlite3.OperationalError: database is locked` errors during concurrent access (e.g., UI interactions during background tasks).
<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

Closes:#7197 
### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
