### PR TITLE
add deterministic sorting to model revision list query

### DIFF
--- a/application/backend/app/repositories/model_revision_repo.py
+++ b/application/backend/app/repositories/model_revision_repo.py
@@ -38,6 +38,8 @@ class ModelRevisionRepository(BaseRepository[ModelRevisionDB]):
             stmt = stmt.where(ModelRevisionDB.training_dataset_id == training_dataset_id)
         if training_status is not None:
             stmt = stmt.where(ModelRevisionDB.training_status == training_status)
+
+        stmt = stmt.order_by(ModelRevisionDB.created_at.desc(), ModelRevisionDB.name.asc())
         return self.db.execute(stmt).scalars().all()
 
     def get_by_id(self, obj_id: str) -> ModelRevisionDB | None:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary
Added an `order_by` clause to `ModelRevisionRepository.list_all` to order by `created_at` descending and `name` ascending. This fixes inconsistent model ordering observed between environments.
 
 Closes:#6212
<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->


### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
