### PR TITLE
Thumbnails endpoint optimization

### DIFF
--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -33,7 +33,7 @@ from app.api.schemas.media import (
     MediaWithPagination,
     SetMediaAnnotations,
 )
-from app.api.validators import MediaID, normalize_datetime_to_utc, ProjectID
+from app.api.validators import MediaID, ProjectID, normalize_datetime_to_utc
 from app.core.models import Pagination
 from app.models import BatchInferenceResult, DatasetItemAnnotationStatus, DatasetItemSubset, Media, Project, Video
 from app.models.media import (
@@ -50,8 +50,8 @@ from app.services import (
     DatasetViewService,
     MediaPredictionService,
     MediaService,
-    SystemService,
     ProjectService,
+    SystemService,
 )
 from app.services.base import ResourceNotFoundError, ResourceType
 from app.services.dataset_service import AnnotationValidationError, SubsetAlreadyAssignedError
@@ -450,8 +450,7 @@ def get_media_thumbnail(
         thumbnail_path = media_service.get_media_thumbnail_path_by_id(project_id=project_id, media_id=video_frame.id)
         if os.path.exists(thumbnail_path):
             return _response(thumbnail_path)
-        else:
-            raise _not_found()
+        raise _not_found()
 
     # If the media is a video frame, generate the thumbnail on the fly
     frame_thumbnail = media_service.get_frame_thumbnail(project=project, video=media, frame_index=frame_index)

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -3,6 +3,7 @@
 
 import os
 from datetime import datetime
+from pathlib import Path
 from typing import Annotated
 from uuid import UUID
 
@@ -19,6 +20,7 @@ from app.api.dependencies import (
     get_media_segment_service,
     get_media_service,
     get_project,
+    get_project_service,
     get_system_service,
 )
 from app.api.io_utils import write_bytes_to_response, write_file_to_response, write_image_to_response
@@ -31,7 +33,7 @@ from app.api.schemas.media import (
     MediaWithPagination,
     SetMediaAnnotations,
 )
-from app.api.validators import MediaID, normalize_datetime_to_utc
+from app.api.validators import MediaID, normalize_datetime_to_utc, ProjectID
 from app.core.models import Pagination
 from app.models import BatchInferenceResult, DatasetItemAnnotationStatus, DatasetItemSubset, Media, Project, Video
 from app.models.media import (
@@ -43,7 +45,14 @@ from app.models.media import (
     SortDirection,
     VideoFormat,
 )
-from app.services import DatasetService, DatasetViewService, MediaPredictionService, MediaService, SystemService
+from app.services import (
+    DatasetService,
+    DatasetViewService,
+    MediaPredictionService,
+    MediaService,
+    SystemService,
+    ProjectService,
+)
 from app.services.base import ResourceNotFoundError, ResourceType
 from app.services.dataset_service import AnnotationValidationError, SubsetAlreadyAssignedError
 from app.services.inference import InferenceBusyError
@@ -402,25 +411,51 @@ def get_media_binary(
     },
 )
 def get_media_thumbnail(
-    project: Annotated[Project, Depends(get_project)],
-    media: Annotated[Media | NotAnnotatedVideoFrame, Depends(_get_request_media)],
+    project_id: ProjectID,
+    media_id: MediaID,
+    project_service: Annotated[ProjectService, Depends(get_project_service)],
     media_service: Annotated[MediaService, Depends(get_media_service)],
+    frame_index: Annotated[int | None, Query(description="Video frame index", ge=0)] = None,
 ) -> Response:
     """Get media thumbnail binary content"""
-    if isinstance(media, NotAnnotatedVideoFrame):
-        frame_thumbnail = media_service.get_frame_thumbnail(
-            project=project, video=media.video, frame_index=media.frame_index
-        )
-        return write_image_to_response(
-            image=frame_thumbnail, filename=f"{media.video.name}_frame_{media.frame_index}.jpeg"
+
+    def _response(thumbnail_path: Path) -> Response:
+        return write_file_to_response(
+            path=thumbnail_path, filename=f"{media_id}-thumb.jpeg", cache_control="public, max-age=31536000"
         )
 
-    thumbnail_path = media_service.get_media_thumbnail_path(project=project, media=media)
-    if not os.path.exists(thumbnail_path):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Media thumbnail file is not found.")
-    return write_file_to_response(
-        path=thumbnail_path, filename=f"{media.id}-thumb.jpeg", cache_control="public, max-age=31536000"
+    def _not_found() -> HTTPException:
+        return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Media thumbnail file is not found.")
+
+    thumbnail_path = media_service.get_media_thumbnail_path_by_id(project_id=project_id, media_id=media_id)
+    if os.path.exists(thumbnail_path):
+        return _response(thumbnail_path)
+
+    project = project_service.get_project_by_id(project_id=project_id)
+    media = media_service.get_media_by_id(project_id=project_id, media_id=media_id)
+    if media.type != MediaType.VIDEO or frame_index is None:
+        raise _not_found()
+
+    # Video frames can be identified by video ID and frame index
+    if frame_index >= media.frame_count:  # pyrefly: ignore[unsupported-operation]
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Video frame index {frame_index} exceeds video frames count {media.frame_count}.",
+        )
+
+    video_frame = media_service.get_video_frame_by_video_id_and_index(
+        project=project, video_id=media_id, frame_index=frame_index
     )
+    if video_frame is not None:
+        thumbnail_path = media_service.get_media_thumbnail_path_by_id(project_id=project_id, media_id=video_frame.id)
+        if os.path.exists(thumbnail_path):
+            return _response(thumbnail_path)
+        else:
+            raise _not_found()
+
+    # If the media is a video frame, generate the thumbnail on the fly
+    frame_thumbnail = media_service.get_frame_thumbnail(project=project, video=media, frame_index=frame_index)
+    return write_image_to_response(image=frame_thumbnail, filename=f"{media.name}_frame_{frame_index}.jpeg")
 
 
 @router.delete(

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -419,9 +419,9 @@ def get_media_thumbnail(
 ) -> Response:
     """Get media thumbnail binary content"""
 
-    def _response(thumbnail_path: Path) -> Response:
+    def _response(thumbnail_path: Path, media_id: str | UUID) -> Response:
         return write_file_to_response(
-            path=thumbnail_path, filename=f"{media_id}-thumb.jpeg", cache_control="public, max-age=31536000"
+            path=thumbnail_path, filename=f"{str(media_id)}-thumb.jpeg", cache_control="public, max-age=31536000"
         )
 
     def _not_found() -> HTTPException:
@@ -429,7 +429,7 @@ def get_media_thumbnail(
 
     thumbnail_path = media_service.get_media_thumbnail_path_by_id(project_id=project_id, media_id=media_id)
     if frame_index is None and os.path.exists(thumbnail_path):
-        return _response(thumbnail_path)
+        return _response(thumbnail_path=thumbnail_path, media_id=media_id)
 
     project = project_service.get_project_by_id(project_id=project_id)
     media = media_service.get_media_by_id(project_id=project_id, media_id=media_id)
@@ -449,7 +449,7 @@ def get_media_thumbnail(
     if video_frame is not None:
         thumbnail_path = media_service.get_media_thumbnail_path_by_id(project_id=project_id, media_id=video_frame.id)
         if os.path.exists(thumbnail_path):
-            return _response(thumbnail_path)
+            return _response(thumbnail_path=thumbnail_path, media_id=video_frame.id)
         raise _not_found()
 
     # If the media is a video frame, generate the thumbnail on the fly

--- a/application/backend/app/api/routers/media.py
+++ b/application/backend/app/api/routers/media.py
@@ -428,7 +428,7 @@ def get_media_thumbnail(
         return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Media thumbnail file is not found.")
 
     thumbnail_path = media_service.get_media_thumbnail_path_by_id(project_id=project_id, media_id=media_id)
-    if os.path.exists(thumbnail_path):
+    if frame_index is None and os.path.exists(thumbnail_path):
         return _response(thumbnail_path)
 
     project = project_service.get_project_by_id(project_id=project_id)

--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -323,7 +323,7 @@ class MediaService(BaseSessionManagedService):
         """Get a media thumbnail binary content"""
         return self.get_media_thumbnail_path_by_id(project_id=project.id, media_id=media.id)
 
-    def get_media_thumbnail_path_by_id(self, project_id: UUID, media_id: UUID) -> Path:
+    def get_media_thumbnail_path_by_id(self, project_id: UUID, media_id: UUID | str) -> Path:
         """Get a media thumbnail binary content"""
         return self.projects_dir / f"{project_id}/dataset/{media_id}-thumb.jpg"
 

--- a/application/backend/app/services/media_service.py
+++ b/application/backend/app/services/media_service.py
@@ -321,7 +321,11 @@ class MediaService(BaseSessionManagedService):
 
     def get_media_thumbnail_path(self, project: Project, media: MediaDB | Media) -> Path:
         """Get a media thumbnail binary content"""
-        return self.projects_dir / f"{project.id}/dataset/{media.id}-thumb.jpg"
+        return self.get_media_thumbnail_path_by_id(project_id=project.id, media_id=media.id)
+
+    def get_media_thumbnail_path_by_id(self, project_id: UUID, media_id: UUID) -> Path:
+        """Get a media thumbnail binary content"""
+        return self.projects_dir / f"{project_id}/dataset/{media_id}-thumb.jpg"
 
     @staticmethod
     def _crop_image_to_thumbnail(image: Image.Image) -> Image.Image:

--- a/application/backend/tests/unit/api/routers/test_media.py
+++ b/application/backend/tests/unit/api/routers/test_media.py
@@ -21,6 +21,7 @@ from app.api.dependencies import (
     get_media_prediction_service,
     get_media_segment_service,
     get_media_service,
+    get_project_service,
 )
 from app.api.schemas.media import ImageView, MediaViewAdapter, SetMediaAnnotations, VideoFrameView, VideoView
 from app.models import (
@@ -55,6 +56,7 @@ from app.services import (
     MediaService,
     ResourceNotFoundError,
     ResourceType,
+    ProjectService,
 )
 from app.services.dataset_service import AnnotationValidationError, SubsetAlreadyAssignedError
 from app.services.inference import InferenceBusyError
@@ -112,6 +114,13 @@ def fxt_video_frame_media():
         video_id=uuid4(),
         source_id=uuid4(),
     )
+
+
+@pytest.fixture
+def fxt_project_service(fxt_app) -> MagicMock:
+    project_service = MagicMock(spec=ProjectService)
+    fxt_app.dependency_overrides[get_project_service] = lambda: project_service
+    return project_service
 
 
 @pytest.fixture
@@ -957,47 +966,54 @@ class TestMediaEndpoints:
         fxt_media_service.get_frame_binary.assert_not_called()
         fxt_media_service.get_media_binary_path_by_id.assert_not_called()
 
-    def test_get_media_thumbnail_not_found(self, fxt_get_project, fxt_media_service, fxt_client):
-        media_id = uuid4()
-        fxt_media_service.get_media_by_id.side_effect = ResourceNotFoundError(ResourceType.MEDIA, str(media_id))
-
-        response = fxt_client.get(f"/api/projects/{str(uuid4())}/dataset/media/{str(media_id)}/thumbnail")
-
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media_id)
-
     @pytest.mark.parametrize(
-        "media, suffix",
+        "media",
         [
-            (MagicMock(spec=Image, id=uuid4(), format=ImageFormat.JPG, type=MediaType.IMAGE), ".jpg"),
-            (MagicMock(spec=Video, id=uuid4(), format=VideoFormat.MP4, type=MediaType.VIDEO), ".mp4"),
-            (MagicMock(spec=VideoFrame, id=uuid4(), format=ImageFormat.JPG, type=MediaType.VIDEO_FRAME), ".jpg"),
+            (MagicMock(spec=Image, id=uuid4(), format=ImageFormat.JPG, type=MediaType.IMAGE)),
+            (MagicMock(spec=Video, id=uuid4(), format=VideoFormat.MP4, type=MediaType.VIDEO)),
+            (MagicMock(spec=VideoFrame, id=uuid4(), format=ImageFormat.JPG, type=MediaType.VIDEO_FRAME)),
         ],
     )
-    def test_get_media_thumbnail_success(self, fxt_get_project, fxt_media_service, fxt_client, media, suffix):
+    def test_get_media_thumbnail_not_found(self, fxt_project_service, fxt_media_service, fxt_client, media):
+        project_id = uuid4()
+        media_id = uuid4()
+        fxt_media_service.get_media_thumbnail_path_by_id.return_value = Path("non_existent")
+        fxt_media_service.get_media_by_id.return_value = media
+
+        response = fxt_client.get(f"/api/projects/{str(project_id)}/dataset/media/{str(media_id)}/thumbnail")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        fxt_media_service.get_media_thumbnail_path_by_id.assert_called_once_with(
+            project_id=project_id, media_id=media_id
+        )
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=project_id, media_id=media_id)
+
+    def test_get_pregenerated_thumbnail_success(self, fxt_media_service, fxt_client):
         # Create a temporary JPEG file to act as the thumbnail
-        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp_file:
+        project_id = uuid4()
+        media_id = uuid4()
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
             thumbnail_path = Path(tmp_file.name)
             img = PILImage.new("RGB", (64, 64), color="red")
             img.save(tmp_file, format="JPEG")
 
         try:
-            fxt_media_service.get_media_by_id.return_value = media
-            fxt_media_service.get_media_thumbnail_path.return_value = thumbnail_path
+            fxt_media_service.get_media_thumbnail_path_by_id.return_value = thumbnail_path
 
-            response = fxt_client.get(f"/api/projects/{uuid4()}/dataset/media/{str(media.id)}/thumbnail")
+            response = fxt_client.get(f"/api/projects/{project_id}/dataset/media/{media_id}/thumbnail")
 
             assert response.status_code == status.HTTP_200_OK
             assert response.headers["content-type"] == "image/jpeg"
             with open(thumbnail_path, "rb") as f:
                 assert response.content == f.read()
-            fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=media.id)
-            fxt_media_service.get_media_thumbnail_path.assert_called_once_with(project=fxt_get_project, media=media)
+            fxt_media_service.get_media_thumbnail_path_by_id.assert_called_once_with(
+                project_id=project_id, media_id=media_id
+            )
         finally:
             if thumbnail_path.exists():
                 os.unlink(thumbnail_path)
 
-    def test_get_video_frame_thumbnail_on_the_fly_annotated(self, fxt_get_project, fxt_media_service, fxt_client):
+    def test_get_video_frame_thumbnail_on_the_fly_annotated(self, fxt_project_service, fxt_media_service, fxt_client):
         # Create a temporary JPEG file to act as the thumbnail
         with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp_file:
             thumbnail_path = Path(tmp_file.name)
@@ -1005,71 +1021,87 @@ class TestMediaEndpoints:
             img.save(tmp_file, format="JPEG")
 
         try:
+            project_id = uuid4()
             video_id = uuid4()
             video_frame_id = uuid4()
+
+            project = MagicMock()
 
             media = MagicMock(spec=Video, id=video_id, format=VideoFormat.MP4, type=MediaType.VIDEO, frame_count=100)
             fxt_media_service.get_media_by_id.return_value = media
 
-            fxt_media_service.get_media_thumbnail_path.return_value = thumbnail_path
+            fxt_media_service.get_media_thumbnail_path_by_id.side_effect = (Path("non_existent"), thumbnail_path)
 
             video_frame = MagicMock(spec=VideoFrame, id=video_frame_id, format=ImageFormat.JPG)
             type(video_frame).name = PropertyMock(return_value="test_10")
+            fxt_project_service.get_project_by_id.return_value = project
             fxt_media_service.get_video_frame_by_video_id_and_index.return_value = video_frame
 
             response = fxt_client.get(
-                f"/api/projects/{str(uuid4())}/dataset/media/{str(video_id)}/thumbnail?frame_index=10"
+                f"/api/projects/{project_id}/dataset/media/{str(video_id)}/thumbnail?frame_index=10"
             )
             assert response.status_code == status.HTTP_200_OK
 
-            fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=video_id)
+            fxt_media_service.get_media_by_id.assert_called_once_with(project_id=project_id, media_id=video_id)
             fxt_media_service.get_video_frame_by_video_id_and_index.assert_called_once_with(
-                project=fxt_get_project, video_id=video_id, frame_index=10
+                project=project, video_id=video_id, frame_index=10
             )
-            fxt_media_service.get_media_thumbnail_path.assert_called_once_with(
-                project=fxt_get_project, media=video_frame
+            fxt_media_service.get_media_thumbnail_path_by_id.assert_has_calls(
+                [
+                    call(project_id=project_id, media_id=video_id),
+                    call(project_id=project_id, media_id=video_frame_id),
+                ]
             )
         finally:
             if thumbnail_path.exists():
                 os.unlink(thumbnail_path)
 
-    def test_get_video_frame_thumbnail_on_the_fly_not_annotated(self, fxt_get_project, fxt_media_service, fxt_client):
+    def test_get_video_frame_thumbnail_on_the_fly_not_annotated(
+        self, fxt_project_service, fxt_media_service, fxt_client
+    ):
         video_id = uuid4()
+        project_id = uuid4()
+
+        project = MagicMock()
+
+        fxt_media_service.get_media_thumbnail_path_by_id.return_value = Path("non_existent")
 
         media = MagicMock(spec=Video, id=video_id, format=VideoFormat.MP4, type=MediaType.VIDEO, frame_count=100)
         type(media).name = PropertyMock(return_value="test")
         fxt_media_service.get_media_by_id.return_value = media
+        fxt_project_service.get_project_by_id.return_value = project
 
         fxt_media_service.get_video_frame_by_video_id_and_index.return_value = None
         test_image = PILImage.new("RGB", (64, 64), color="blue")
         fxt_media_service.get_frame_thumbnail.return_value = test_image
 
         response = fxt_client.get(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(video_id)}/thumbnail?frame_index=10"
+            f"/api/projects/{str(project_id)}/dataset/media/{str(video_id)}/thumbnail?frame_index=10"
         )
         assert response.status_code == status.HTTP_200_OK
 
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=video_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=project_id, media_id=video_id)
         fxt_media_service.get_video_frame_by_video_id_and_index.assert_called_once_with(
-            project=fxt_get_project, video_id=video_id, frame_index=10
+            project=project, video_id=video_id, frame_index=10
         )
-        fxt_media_service.get_frame_thumbnail.assert_called_once_with(
-            project=fxt_get_project, video=media, frame_index=10
-        )
+        fxt_media_service.get_frame_thumbnail.assert_called_once_with(project=project, video=media, frame_index=10)
 
-    def test_get_video_frame_thumbnail_on_the_fly_index_exceeds(self, fxt_get_project, fxt_media_service, fxt_client):
+    def test_get_video_frame_thumbnail_on_the_fly_index_exceeds(self, fxt_media_service, fxt_client):
         video_id = uuid4()
+        project_id = uuid4()
+
+        fxt_media_service.get_media_thumbnail_path_by_id.return_value = Path("non_existent")
 
         media = MagicMock(spec=Video, id=video_id, format=VideoFormat.MP4, type=MediaType.VIDEO, frame_count=10)
         type(media).name = PropertyMock(return_value="test")
         fxt_media_service.get_media_by_id.return_value = media
 
         response = fxt_client.get(
-            f"/api/projects/{str(uuid4())}/dataset/media/{str(video_id)}/thumbnail?frame_index=100"
+            f"/api/projects/{str(project_id)}/dataset/media/{str(video_id)}/thumbnail?frame_index=100"
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=fxt_get_project.id, media_id=video_id)
+        fxt_media_service.get_media_by_id.assert_called_once_with(project_id=project_id, media_id=video_id)
         fxt_media_service.get_video_frame_by_video_id_and_index.assert_not_called()
         fxt_media_service.get_frame_thumbnail.assert_not_called()
 

--- a/application/backend/tests/unit/api/routers/test_media.py
+++ b/application/backend/tests/unit/api/routers/test_media.py
@@ -54,9 +54,9 @@ from app.services import (
     DatasetViewService,
     MediaPredictionService,
     MediaService,
+    ProjectService,
     ResourceNotFoundError,
     ResourceType,
-    ProjectService,
 )
 from app.services.dataset_service import AnnotationValidationError, SubsetAlreadyAssignedError
 from app.services.inference import InferenceBusyError

--- a/application/backend/tests/unit/api/routers/test_media.py
+++ b/application/backend/tests/unit/api/routers/test_media.py
@@ -1086,7 +1086,9 @@ class TestMediaEndpoints:
         )
         fxt_media_service.get_frame_thumbnail.assert_called_once_with(project=project, video=media, frame_index=10)
 
-    def test_get_video_frame_thumbnail_on_the_fly_index_exceeds(self, fxt_media_service, fxt_client):
+    def test_get_video_frame_thumbnail_on_the_fly_index_exceeds(
+        self, fxt_project_service, fxt_media_service, fxt_client
+    ):
         video_id = uuid4()
         project_id = uuid4()
 


### PR DESCRIPTION
Refactor thumbnail serving endpoint. Return thumbnails if they are pre-generated and stored without extra requests to DB.
This way thumbnail serving time reduced from around 1s to 500ms per media (avg).

Resolves #7221
