### PR TITLE
feat: Add tracker state accessors (tracks, tracked_objects)

### DIFF
--- a/libraries/getitrack/src/getitrack/algorithms/bytetrack.py
+++ b/libraries/getitrack/src/getitrack/algorithms/bytetrack.py
@@ -291,37 +291,3 @@ class ByteTrackTracker(BaseTracker[ByteTrackConfig]):
         active = [t for t in self._tracks.values() if t.state == TrackState.ACTIVE]
         det_indices = [self._frame_det_index.get(t.track_id, -1) for t in active]
         return self._compose_tracked_detections(active, det_indices, frame_id)
-
-    @property
-    def tracks(self) -> list[Track]:
-        """Return the tracker's current tracks across all lifecycle states.
-
-        Returns the live `Track` objects (TENTATIVE, ACTIVE, LOST) in insertion
-        order; REMOVED tracks are already pruned. The returned list is a fresh
-        copy, but the `Track` objects are shared: mutating them mutates tracker
-        state.
-        """
-        return list(self._tracks.values())
-
-    def tracked_objects(self) -> TrackedDetections:
-        """Return the confirmed-alive tracks for the last processed frame.
-
-        Includes ACTIVE tracks and coasted LOST tracks still within ``max_age``;
-        excludes TENTATIVE and REMOVED tracks. Row contents:
-
-        - ACTIVE rows match the `update` output, detection box included.
-        - LOST rows carry the Kalman-predicted box for this frame with
-          ``det_index`` -1; their score and class are the last observed values.
-
-        ``det_indices`` index into the unfiltered detections of the last
-        processed frame even when a ``class_filter`` is set.
-
-        Returns:
-            A `TrackedDetections` for the last processed frame, or an empty one
-            (with an empty int64 ``det_indices``) if no frame has run yet.
-        """
-        frame_id = self._frame_id if self._frame_id is not None else 0
-        alive = [t for t in self._tracks.values() if t.state in {TrackState.ACTIVE, TrackState.LOST}]
-        # _frame_det_index holds filtered-space rows; remap to unfiltered input rows.
-        det_indices = [self._frame_det_index.get(t.track_id, -1) for t in alive]
-        return self._remap_to_input_rows(self._compose_tracked_detections(alive, det_indices, frame_id))

--- a/libraries/getitrack/src/getitrack/algorithms/bytetrack.py
+++ b/libraries/getitrack/src/getitrack/algorithms/bytetrack.py
@@ -12,7 +12,6 @@ Every Detection Box" (ECCV 2022).
 
 from __future__ import annotations
 
-from dataclasses import replace
 from typing import TYPE_CHECKING, ClassVar
 
 import numpy as np
@@ -290,15 +289,41 @@ class ByteTrackTracker(BaseTracker[ByteTrackConfig]):
     def _compose_output(self, frame_id: int) -> TrackedDetections:
         # Output is ACTIVE tracks only; LOST tracks coast internally.
         active = [t for t in self._tracks.values() if t.state == TrackState.ACTIVE]
-        if not active:
-            empty = TrackedDetections.create_empty(frame_id=frame_id)
-            return replace(empty, det_indices=np.empty((0,), dtype=np.int64))
-        return TrackedDetections(
-            bboxes=np.stack([t.bbox for t in active], axis=0).astype(np.float32),
-            scores=np.array([t.score for t in active], dtype=np.float32),
-            class_ids=np.array([t.class_id for t in active], dtype=np.int64),
-            track_ids=np.array([t.track_id for t in active], dtype=np.int64),
-            track_states=np.array([int(t.state) for t in active], dtype=np.int8),
-            frame_id=frame_id,
-            det_indices=np.array([self._frame_det_index.get(t.track_id, -1) for t in active], dtype=np.int64),
-        )
+        det_indices = [self._frame_det_index.get(t.track_id, -1) for t in active]
+        return self._compose_tracked_detections(active, det_indices, frame_id)
+
+    @property
+    def tracks(self) -> list[Track]:
+        """Return the tracker's current tracks across all lifecycle states.
+
+        Exposes the live `Track` objects (TENTATIVE, ACTIVE, and LOST) held by
+        the tracker, in insertion order. REMOVED tracks are already pruned, so
+        they never appear. This is a cheap view for debugging and tests; the
+        returned list is a fresh copy but the `Track` objects are shared, so
+        mutating them mutates tracker state.
+        """
+        return list(self._tracks.values())
+
+    def tracked_objects(self) -> TrackedDetections:
+        """Return the confirmed-alive tracks for the current frame.
+
+        Unlike `update`, which returns ACTIVE tracks only, this also includes
+        coasted LOST tracks that are still within ``max_age``. LOST tracks
+        carry their Kalman-predicted box for this frame (set during the frame's
+        predict step) with ``det_index`` -1, since they have no detection this
+        frame; their score and class are the last observed values. ACTIVE rows
+        are identical to the `update` output, detection box and all. TENTATIVE
+        tracks (not yet confirmed) and REMOVED tracks are excluded. As in
+        `update`, ``det_indices`` index into the unfiltered detections of the
+        last processed frame even when a ``class_filter`` is set.
+
+        Returns:
+            A `TrackedDetections` for the last processed frame, or an empty one
+            (with an empty int64 ``det_indices``) if no frame has run yet.
+        """
+        frame_id = self._frame_id if self._frame_id is not None else 0
+        alive = [t for t in self._tracks.values() if t.state in {TrackState.ACTIVE, TrackState.LOST}]
+        # _frame_det_index holds filtered-space rows; remap to unfiltered input
+        # rows so det_indices match update()'s contract when a class_filter is set.
+        det_indices = [self._frame_det_index.get(t.track_id, -1) for t in alive]
+        return self._remap_to_input_rows(self._compose_tracked_detections(alive, det_indices, frame_id))

--- a/libraries/getitrack/src/getitrack/algorithms/bytetrack.py
+++ b/libraries/getitrack/src/getitrack/algorithms/bytetrack.py
@@ -296,26 +296,25 @@ class ByteTrackTracker(BaseTracker[ByteTrackConfig]):
     def tracks(self) -> list[Track]:
         """Return the tracker's current tracks across all lifecycle states.
 
-        Exposes the live `Track` objects (TENTATIVE, ACTIVE, and LOST) held by
-        the tracker, in insertion order. REMOVED tracks are already pruned, so
-        they never appear. This is a cheap view for debugging and tests; the
-        returned list is a fresh copy but the `Track` objects are shared, so
-        mutating them mutates tracker state.
+        Returns the live `Track` objects (TENTATIVE, ACTIVE, LOST) in insertion
+        order; REMOVED tracks are already pruned. The returned list is a fresh
+        copy, but the `Track` objects are shared: mutating them mutates tracker
+        state.
         """
         return list(self._tracks.values())
 
     def tracked_objects(self) -> TrackedDetections:
-        """Return the confirmed-alive tracks for the current frame.
+        """Return the confirmed-alive tracks for the last processed frame.
 
-        Unlike `update`, which returns ACTIVE tracks only, this also includes
-        coasted LOST tracks that are still within ``max_age``. LOST tracks
-        carry their Kalman-predicted box for this frame (set during the frame's
-        predict step) with ``det_index`` -1, since they have no detection this
-        frame; their score and class are the last observed values. ACTIVE rows
-        are identical to the `update` output, detection box and all. TENTATIVE
-        tracks (not yet confirmed) and REMOVED tracks are excluded. As in
-        `update`, ``det_indices`` index into the unfiltered detections of the
-        last processed frame even when a ``class_filter`` is set.
+        Includes ACTIVE tracks and coasted LOST tracks still within ``max_age``;
+        excludes TENTATIVE and REMOVED tracks. Row contents:
+
+        - ACTIVE rows match the `update` output, detection box included.
+        - LOST rows carry the Kalman-predicted box for this frame with
+          ``det_index`` -1; their score and class are the last observed values.
+
+        ``det_indices`` index into the unfiltered detections of the last
+        processed frame even when a ``class_filter`` is set.
 
         Returns:
             A `TrackedDetections` for the last processed frame, or an empty one
@@ -323,7 +322,6 @@ class ByteTrackTracker(BaseTracker[ByteTrackConfig]):
         """
         frame_id = self._frame_id if self._frame_id is not None else 0
         alive = [t for t in self._tracks.values() if t.state in {TrackState.ACTIVE, TrackState.LOST}]
-        # _frame_det_index holds filtered-space rows; remap to unfiltered input
-        # rows so det_indices match update()'s contract when a class_filter is set.
+        # _frame_det_index holds filtered-space rows; remap to unfiltered input rows.
         det_indices = [self._frame_det_index.get(t.track_id, -1) for t in alive]
         return self._remap_to_input_rows(self._compose_tracked_detections(alive, det_indices, frame_id))

--- a/libraries/getitrack/src/getitrack/core/base.py
+++ b/libraries/getitrack/src/getitrack/core/base.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
@@ -84,32 +85,32 @@ class BaseTracker(ABC, Generic[ConfigT]):
 
     @property
     def tracks(self) -> list[Track]:
-        """Return the tracker's current tracks across all lifecycle states.
+        """Return a snapshot of the tracker's current tracks.
 
-        Returns the live `Track` objects (TENTATIVE, ACTIVE, LOST) in insertion
-        order; REMOVED tracks are already pruned. The returned list is a fresh
-        copy, but the `Track` objects are shared: mutating them mutates tracker
-        state.
+        The snapshot spans every live lifecycle state (TENTATIVE, ACTIVE, and
+        LOST); REMOVED tracks have already been pruned.
+
+        Returns:
+            Deep copies of the current `Track` objects, in insertion order.
+            The copies are independent of tracker state, so mutating them has no
+            effect on the tracker.
         """
-        return list(self._tracks.values())
+        return deepcopy(list(self._tracks.values()))
 
     @property
     def tracked_objects(self) -> TrackedDetections:
         """Return the confirmed-alive tracks for the last processed frame.
 
-        Includes ACTIVE tracks and coasted LOST tracks still within ``max_age``;
-        excludes TENTATIVE and REMOVED tracks. Row contents:
-
-        - ACTIVE rows match the `update` output, detection box included.
-        - LOST rows carry the predicted box for this frame with ``det_index``
-          -1; their score and class are the last observed values.
-
-        ``det_indices`` index into the unfiltered detections of the last
-        processed frame even when a ``class_filter`` is set.
+        Includes ACTIVE tracks and coasted LOST tracks still within ``max_age``,
+        and excludes TENTATIVE and REMOVED tracks. ACTIVE rows mirror the `update`
+        output, including the detection box; LOST rows carry the predicted box for
+        the frame with a ``det_index`` of -1 and the last observed score and class.
+        ``det_indices`` index into the unfiltered detections of the last processed
+        frame even when a ``class_filter`` is set.
 
         Returns:
             A `TrackedDetections` for the last processed frame, or an empty one
-            (with an empty int64 ``det_indices``) if no frame has run yet.
+            (with an empty int64 ``det_indices``) when no frame has been processed.
         """
         frame_id = self._frame_id if self._frame_id is not None else 0
         alive = [t for t in self._tracks.values() if t.state in {TrackState.ACTIVE, TrackState.LOST}]

--- a/libraries/getitrack/src/getitrack/core/base.py
+++ b/libraries/getitrack/src/getitrack/core/base.py
@@ -20,6 +20,7 @@ import numpy as np
 from getitrack.config import TrackerConfig
 from getitrack.core.detection import TrackedDetections
 from getitrack.core.registry import ALGORITHM_REGISTRY, resolve_tracker_config
+from getitrack.core.track import TrackState
 from getitrack.logger import enable_logging
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,6 +49,11 @@ class BaseTracker(ABC, Generic[ConfigT]):
     config_cls: ClassVar[type[TrackerConfig]]
     config: ConfigT
 
+    # Populated by every concrete tracker's ``__init__`` (see subclasses); the
+    # shared accessors below read them, so they are declared on the base.
+    _tracks: dict[int, Track]
+    _frame_det_index: dict[int, int]
+
     def __init__(self, config: ConfigT) -> None:
         self.config = config
         self._next_id: int = 1
@@ -75,6 +81,41 @@ class BaseTracker(ABC, Generic[ConfigT]):
         if self.config.verbose:
             self._log_update(filtered, tracked)
         return tracked
+
+    @property
+    def tracks(self) -> list[Track]:
+        """Return the tracker's current tracks across all lifecycle states.
+
+        Returns the live `Track` objects (TENTATIVE, ACTIVE, LOST) in insertion
+        order; REMOVED tracks are already pruned. The returned list is a fresh
+        copy, but the `Track` objects are shared: mutating them mutates tracker
+        state.
+        """
+        return list(self._tracks.values())
+
+    @property
+    def tracked_objects(self) -> TrackedDetections:
+        """Return the confirmed-alive tracks for the last processed frame.
+
+        Includes ACTIVE tracks and coasted LOST tracks still within ``max_age``;
+        excludes TENTATIVE and REMOVED tracks. Row contents:
+
+        - ACTIVE rows match the `update` output, detection box included.
+        - LOST rows carry the predicted box for this frame with ``det_index``
+          -1; their score and class are the last observed values.
+
+        ``det_indices`` index into the unfiltered detections of the last
+        processed frame even when a ``class_filter`` is set.
+
+        Returns:
+            A `TrackedDetections` for the last processed frame, or an empty one
+            (with an empty int64 ``det_indices``) if no frame has run yet.
+        """
+        frame_id = self._frame_id if self._frame_id is not None else 0
+        alive = [t for t in self._tracks.values() if t.state in {TrackState.ACTIVE, TrackState.LOST}]
+        # _frame_det_index holds filtered-space rows; remap to unfiltered input rows.
+        det_indices = [self._frame_det_index.get(t.track_id, -1) for t in alive]
+        return self._remap_to_input_rows(self._compose_tracked_detections(alive, det_indices, frame_id))
 
     def _remap_to_input_rows(self, tracked: TrackedDetections) -> TrackedDetections:
         """Remap ``det_indices`` from the last frame's filtered space to input rows.

--- a/libraries/getitrack/src/getitrack/core/base.py
+++ b/libraries/getitrack/src/getitrack/core/base.py
@@ -15,16 +15,20 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
 
+import numpy as np
+
 from getitrack.config import TrackerConfig
+from getitrack.core.detection import TrackedDetections
 from getitrack.core.registry import ALGORITHM_REGISTRY, resolve_tracker_config
 from getitrack.logger import enable_logging
 
 _LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    import numpy as np
+    from collections.abc import Sequence
 
-    from getitrack.core.detection import Detections, TrackedDetections
+    from getitrack.core.detection import Detections
+    from getitrack.core.track import Track
 
 ConfigT = TypeVar("ConfigT", bound=TrackerConfig)
 
@@ -48,6 +52,9 @@ class BaseTracker(ABC, Generic[ConfigT]):
         self.config = config
         self._next_id: int = 1
         self._frame_id: int | None = None
+        # source_rows of the last processed frame, used to remap filtered-space
+        # det_indices back to input rows for both update() and state accessors.
+        self._last_source_rows: np.ndarray | None = None
         if config.verbose:
             enable_logging()
 
@@ -63,13 +70,26 @@ class BaseTracker(ABC, Generic[ConfigT]):
             filtered, source_rows = detections, None
         else:
             filtered, source_rows = detections.filter_by_class(class_filter)
-        tracked = self._update_impl(filtered)
-        if source_rows is not None and tracked.det_indices is not None:
-            remapped = self._remap_det_indices(source_rows, tracked.det_indices)
-            tracked = replace(tracked, det_indices=remapped)
+        self._last_source_rows = source_rows
+        tracked = self._remap_to_input_rows(self._update_impl(filtered))
         if self.config.verbose:
             self._log_update(filtered, tracked)
         return tracked
+
+    def _remap_to_input_rows(self, tracked: TrackedDetections) -> TrackedDetections:
+        """Remap ``det_indices`` from the last frame's filtered space to input rows.
+
+        ``det_indices`` produced against the class-filtered detections index into
+        filtered-row space; this maps the matched (``>= 0``) entries back to rows
+        of the unfiltered `Detections` passed to `update`, leaving -1 rows (no
+        source detection) untouched. A no-op when no ``class_filter`` was applied.
+        Shared by `update` and the state accessors so both honour the same
+        "``det_indices`` index the unfiltered detections" contract.
+        """
+        if self._last_source_rows is None or tracked.det_indices is None:
+            return tracked
+        remapped = self._remap_det_indices(self._last_source_rows, tracked.det_indices)
+        return replace(tracked, det_indices=remapped)
 
     @staticmethod
     def _remap_det_indices(source_rows: np.ndarray, det_indices: np.ndarray) -> np.ndarray:
@@ -82,6 +102,44 @@ class BaseTracker(ABC, Generic[ConfigT]):
     @abstractmethod
     def _update_impl(self, detections: Detections) -> TrackedDetections:
         """Algorithm-specific tracking step for one frame."""
+
+    @staticmethod
+    def _compose_tracked_detections(
+        tracks: Sequence[Track],
+        det_indices: Sequence[int],
+        frame_id: int,
+    ) -> TrackedDetections:
+        """Assemble a `TrackedDetections` from tracks and their det indices.
+
+        Reads ``bbox``, ``score``, ``class_id``, ``track_id``, and ``state`` off
+        each `Track` in order, pairing row ``i`` with ``det_indices[i]``. The
+        caller decides which tracks to emit and supplies -1 for rows with no
+        source detection this frame (e.g. coasted tracks). This is the shared
+        output-building step for any track-collection tracker, kept on the base
+        so per-frame output and state accessors stay row-for-row consistent.
+
+        Args:
+            tracks: Tracks to emit, one per output row.
+            det_indices: Row indices into the frame's input `Detections`,
+                aligned with ``tracks``; -1 marks a row with no source detection.
+            frame_id: Frame the output belongs to.
+
+        Returns:
+            A `TrackedDetections` with one row per track. When ``tracks`` is
+            empty the result still carries an empty int64 ``det_indices`` array.
+        """
+        if not tracks:
+            empty = TrackedDetections.create_empty(frame_id=frame_id)
+            return replace(empty, det_indices=np.empty((0,), dtype=np.int64))
+        return TrackedDetections(
+            bboxes=np.stack([t.bbox for t in tracks], axis=0).astype(np.float32),
+            scores=np.array([t.score for t in tracks], dtype=np.float32),
+            class_ids=np.array([t.class_id for t in tracks], dtype=np.int64),
+            track_ids=np.array([t.track_id for t in tracks], dtype=np.int64),
+            track_states=np.array([int(t.state) for t in tracks], dtype=np.int8),
+            frame_id=frame_id,
+            det_indices=np.asarray(det_indices, dtype=np.int64),
+        )
 
     def _log_update(self, detections: Detections, tracked: TrackedDetections) -> None:
         """Emit a one-line per-frame summary on the ``getitrack`` logger."""
@@ -106,6 +164,7 @@ class BaseTracker(ABC, Generic[ConfigT]):
         """Clear internal state between videos or sequences."""
         self._next_id = 1
         self._frame_id = None
+        self._last_source_rows = None
 
     def _allocate_id(self) -> int:
         """Return a fresh monotonic id for a new track."""

--- a/libraries/getitrack/src/getitrack/core/base.py
+++ b/libraries/getitrack/src/getitrack/core/base.py
@@ -52,8 +52,8 @@ class BaseTracker(ABC, Generic[ConfigT]):
         self.config = config
         self._next_id: int = 1
         self._frame_id: int | None = None
-        # source_rows of the last processed frame, used to remap filtered-space
-        # det_indices back to input rows for both update() and state accessors.
+        # source_rows of the last processed frame, for remapping filtered-space
+        # det_indices back to input rows.
         self._last_source_rows: np.ndarray | None = None
         if config.verbose:
             enable_logging()
@@ -79,12 +79,9 @@ class BaseTracker(ABC, Generic[ConfigT]):
     def _remap_to_input_rows(self, tracked: TrackedDetections) -> TrackedDetections:
         """Remap ``det_indices`` from the last frame's filtered space to input rows.
 
-        ``det_indices`` produced against the class-filtered detections index into
-        filtered-row space; this maps the matched (``>= 0``) entries back to rows
-        of the unfiltered `Detections` passed to `update`, leaving -1 rows (no
-        source detection) untouched. A no-op when no ``class_filter`` was applied.
-        Shared by `update` and the state accessors so both honour the same
-        "``det_indices`` index the unfiltered detections" contract.
+        Maps matched (``>= 0``) entries back to rows of the unfiltered
+        `Detections` passed to `update`, leaving -1 rows untouched. A no-op when
+        no ``class_filter`` was applied.
         """
         if self._last_source_rows is None or tracked.det_indices is None:
             return tracked
@@ -112,11 +109,7 @@ class BaseTracker(ABC, Generic[ConfigT]):
         """Assemble a `TrackedDetections` from tracks and their det indices.
 
         Reads ``bbox``, ``score``, ``class_id``, ``track_id``, and ``state`` off
-        each `Track` in order, pairing row ``i`` with ``det_indices[i]``. The
-        caller decides which tracks to emit and supplies -1 for rows with no
-        source detection this frame (e.g. coasted tracks). This is the shared
-        output-building step for any track-collection tracker, kept on the base
-        so per-frame output and state accessors stay row-for-row consistent.
+        each `Track` in order, pairing row ``i`` with ``det_indices[i]``.
 
         Args:
             tracks: Tracks to emit, one per output row.

--- a/libraries/getitrack/tests/unit/test_bytetrack.py
+++ b/libraries/getitrack/tests/unit/test_bytetrack.py
@@ -301,8 +301,8 @@ class TestStateAccessors:
         assert bt.tracks == []
 
     def test_tracked_objects_only_tentative_hits_empty_branch(self):
-        # A non-empty _tracks whose tracks are all TENTATIVE yields no alive rows,
-        # so the empty-output branch runs even though the tracker holds a track.
+        # An all-TENTATIVE _tracks yields no alive rows: empty output with a
+        # non-empty tracker.
         bt = ByteTrackTracker(ByteTrackConfig())
         box = np.array([0, 0, 40, 40], dtype=np.float32)
         bt._tracks = {1: Track(track_id=1, class_id=0, bbox=box, score=0.9, state=TrackState.TENTATIVE)}

--- a/libraries/getitrack/tests/unit/test_bytetrack.py
+++ b/libraries/getitrack/tests/unit/test_bytetrack.py
@@ -248,7 +248,7 @@ class TestStateAccessors:
 
     def test_tracked_objects_includes_coasted_lost_track(self):
         bt, out2 = _mixed_state_tracker()
-        to = bt.tracked_objects()
+        to = bt.tracked_objects
         assert to.det_indices is not None
         rows = {int(tid): i for i, tid in enumerate(to.track_ids)}
         # ACTIVE and LOST are both emitted; TENTATIVE (id 3) is not.
@@ -277,11 +277,11 @@ class TestStateAccessors:
             bt.update(_dets([[200, 200, 240, 240]], [0.9], frame_id=f))
         live_ids = {t.track_id for t in bt.tracks}
         assert 1 not in live_ids
-        assert 1 not in bt.tracked_objects().track_ids.tolist()
+        assert 1 not in bt.tracked_objects.track_ids.tolist()
 
     def test_tracked_objects_dtypes_and_shape_match_update(self):
         bt, out2 = _mixed_state_tracker()
-        to = bt.tracked_objects()
+        to = bt.tracked_objects
         assert to.det_indices is not None
         assert to.bboxes.dtype == out2.bboxes.dtype == np.float32
         assert to.scores.dtype == out2.scores.dtype == np.float32
@@ -293,7 +293,7 @@ class TestStateAccessors:
 
     def test_tracked_objects_before_any_frame_is_empty(self):
         bt = ByteTrackTracker(ByteTrackConfig())
-        to = bt.tracked_objects()
+        to = bt.tracked_objects
         assert len(to) == 0
         assert to.det_indices is not None
         assert to.det_indices.dtype == np.int64
@@ -306,7 +306,7 @@ class TestStateAccessors:
         bt = ByteTrackTracker(ByteTrackConfig())
         box = np.array([0, 0, 40, 40], dtype=np.float32)
         bt._tracks = {1: Track(track_id=1, class_id=0, bbox=box, score=0.9, state=TrackState.TENTATIVE)}
-        to = bt.tracked_objects()
+        to = bt.tracked_objects
         assert len(to) == 0
         assert to.det_indices is not None
         assert len(to.det_indices) == 0
@@ -319,7 +319,7 @@ class TestStateAccessors:
         bt = ByteTrackTracker(cfg)
         dets = _dets([[10, 10, 50, 50], [100, 100, 140, 140]], [0.9, 0.9], frame_id=0, class_ids=[0, 5])
         out = bt.update(dets)
-        to = bt.tracked_objects()
+        to = bt.tracked_objects
         assert out.det_indices is not None
         assert to.det_indices is not None
         # The single tracked object came from input row 1 in both views.
@@ -335,7 +335,7 @@ class TestStateAccessors:
         assert bt._tracks[1].state == TrackState.LOST
         bt.update(_dets([[22, 22, 62, 62]], [0.9], frame_id=3))
         assert bt._tracks[1].state == TrackState.ACTIVE
-        to = bt.tracked_objects()
+        to = bt.tracked_objects
         assert to.det_indices is not None
         rows = {int(tid): i for i, tid in enumerate(to.track_ids)}
         recovered_row = rows[1]
@@ -347,7 +347,7 @@ class TestStateAccessors:
         bt, _ = _mixed_state_tracker()
 
         def lost_x1() -> float:
-            to = bt.tracked_objects()
+            to = bt.tracked_objects
             rows = {int(tid): i for i, tid in enumerate(to.track_ids)}
             return float(to.bboxes[rows[1]][0])
 

--- a/libraries/getitrack/tests/unit/test_bytetrack.py
+++ b/libraries/getitrack/tests/unit/test_bytetrack.py
@@ -16,7 +16,7 @@ from getitrack.algorithms.bytetrack import _subset
 from getitrack.algorithms.configs.bytetrack import ByteTrackConfig
 from getitrack.config import LifecycleConfig, TrackerConfig
 from getitrack.core.base import BaseTracker
-from getitrack.core.detection import Detections
+from getitrack.core.detection import Detections, TrackedDetections
 from getitrack.core.track import Track, TrackState
 
 
@@ -211,6 +211,156 @@ class TestDetIndices:
         out = bt.update(_dets([], [], frame_id=0))
         assert out.det_indices is not None
         assert len(out.det_indices) == 0
+
+
+def _mixed_state_tracker() -> tuple[ByteTrackTracker, TrackedDetections]:
+    """Drive a tracker to a frame holding one ACTIVE, one LOST, one TENTATIVE track.
+
+    Returns the tracker and the frame-2 ``update`` output (ACTIVE only). After
+    frame 2: track 1 (A) coasts as LOST, track 2 (B) stays ACTIVE, and track 3
+    (C) is freshly spawned TENTATIVE.
+    """
+    cfg = ByteTrackConfig(lifecycle=LifecycleConfig(min_hits=2, tentative_max_age=3, max_age=3))
+    bt = ByteTrackTracker(cfg)
+    # Frame 0: both born ACTIVE (first frame bypasses TENTATIVE). A=id1, B=id2.
+    bt.update(_dets([[10, 10, 50, 50], [200, 200, 240, 240]], [0.9, 0.9], frame_id=0))
+    # Frame 1: A drifts +10 (still matches), B is stationary.
+    bt.update(_dets([[20, 20, 60, 60], [200, 200, 240, 240]], [0.9, 0.9], frame_id=1))
+    # Frame 2: A absent -> LOST; B (row 0) matched; C (row 1) new -> TENTATIVE id3.
+    out2 = bt.update(_dets([[200, 200, 240, 240], [400, 400, 440, 440]], [0.9, 0.9], frame_id=2))
+    return bt, out2
+
+
+class TestStateAccessors:
+    def test_tracks_exposes_all_lifecycle_states(self):
+        bt, _ = _mixed_state_tracker()
+        tracks = bt.tracks
+        assert all(isinstance(t, Track) for t in tracks)
+        by_id = {t.track_id: t.state for t in tracks}
+        assert by_id == {1: TrackState.LOST, 2: TrackState.ACTIVE, 3: TrackState.TENTATIVE}
+
+    def test_tracks_returns_a_fresh_list(self):
+        bt, _ = _mixed_state_tracker()
+        tracks = bt.tracks
+        tracks.clear()
+        # Mutating the returned list must not disturb tracker state.
+        assert len(bt.tracks) == 3
+
+    def test_tracked_objects_includes_coasted_lost_track(self):
+        bt, out2 = _mixed_state_tracker()
+        to = bt.tracked_objects()
+        assert to.det_indices is not None
+        rows = {int(tid): i for i, tid in enumerate(to.track_ids)}
+        # ACTIVE and LOST are both emitted; TENTATIVE (id 3) is not.
+        assert set(rows) == {1, 2}
+        # The LOST track coasts: no source detection this frame -> det_index -1.
+        lost_row = rows[1]
+        assert to.track_states[lost_row] == TrackState.LOST
+        assert int(to.det_indices[lost_row]) == -1
+        # A drifted in +x/+y, so the coasted Kalman prediction advances past the
+        # last observed box [20, 20, 60, 60] rather than reusing it.
+        lost_box = to.bboxes[lost_row]
+        assert lost_box[0] > 20.0
+        assert lost_box[1] > 20.0
+        # The ACTIVE track keeps its real detection index (B is input row 0).
+        active_row = rows[2]
+        assert to.track_states[active_row] == TrackState.ACTIVE
+        assert int(to.det_indices[active_row]) == 0
+        # update() stays ACTIVE-only, so tracked_objects() is strictly larger here.
+        assert out2.track_ids.tolist() == [2]
+        assert len(to) == 2
+
+    def test_tracked_objects_excludes_removed_track(self):
+        bt, _ = _mixed_state_tracker()
+        # Keep feeding only B; A (id1) coasts until it ages past max_age -> REMOVED.
+        for f in range(3, 8):
+            bt.update(_dets([[200, 200, 240, 240]], [0.9], frame_id=f))
+        live_ids = {t.track_id for t in bt.tracks}
+        assert 1 not in live_ids
+        assert 1 not in bt.tracked_objects().track_ids.tolist()
+
+    def test_tracked_objects_dtypes_and_shape_match_update(self):
+        bt, out2 = _mixed_state_tracker()
+        to = bt.tracked_objects()
+        assert to.det_indices is not None
+        assert to.bboxes.dtype == out2.bboxes.dtype == np.float32
+        assert to.scores.dtype == out2.scores.dtype == np.float32
+        assert to.class_ids.dtype == out2.class_ids.dtype == np.int64
+        assert to.track_ids.dtype == out2.track_ids.dtype == np.int64
+        assert to.track_states.dtype == out2.track_states.dtype == np.int8
+        assert to.det_indices.dtype == np.int64
+        assert to.bboxes.shape[1] == 4
+
+    def test_tracked_objects_before_any_frame_is_empty(self):
+        bt = ByteTrackTracker(ByteTrackConfig())
+        to = bt.tracked_objects()
+        assert len(to) == 0
+        assert to.det_indices is not None
+        assert to.det_indices.dtype == np.int64
+        assert len(to.det_indices) == 0
+        assert bt.tracks == []
+
+    def test_tracked_objects_only_tentative_hits_empty_branch(self):
+        # A non-empty _tracks whose tracks are all TENTATIVE yields no alive rows,
+        # so the empty-output branch runs even though the tracker holds a track.
+        bt = ByteTrackTracker(ByteTrackConfig())
+        box = np.array([0, 0, 40, 40], dtype=np.float32)
+        bt._tracks = {1: Track(track_id=1, class_id=0, bbox=box, score=0.9, state=TrackState.TENTATIVE)}
+        to = bt.tracked_objects()
+        assert len(to) == 0
+        assert to.det_indices is not None
+        assert len(to.det_indices) == 0
+        assert len(bt.tracks) == 1
+
+    def test_tracked_objects_det_indices_index_unfiltered_rows_under_class_filter(self):
+        # Row 0 (class 0) is filtered out; row 1 (class 5) is tracked. det_indices
+        # must point at input row 1, matching update(), not the filtered-space 0.
+        cfg = ByteTrackConfig(class_filter=[5], lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1))
+        bt = ByteTrackTracker(cfg)
+        dets = _dets([[10, 10, 50, 50], [100, 100, 140, 140]], [0.9, 0.9], frame_id=0, class_ids=[0, 5])
+        out = bt.update(dets)
+        to = bt.tracked_objects()
+        assert out.det_indices is not None
+        assert to.det_indices is not None
+        # The single tracked object came from input row 1 in both views.
+        assert out.track_ids.tolist() == [1]
+        assert out.det_indices.tolist() == [1]
+        assert to.track_ids.tolist() == [1]
+        assert to.det_indices.tolist() == [1]
+
+    def test_tracked_objects_det_index_becomes_valid_after_lost_recovery(self):
+        bt, _ = _mixed_state_tracker()
+        # Track 1 is LOST after frame 2 (det_index -1); its predicted box sits
+        # near [21, 21, 61, 61]. A detection there re-matches and reactivates it.
+        assert bt._tracks[1].state == TrackState.LOST
+        bt.update(_dets([[22, 22, 62, 62]], [0.9], frame_id=3))
+        assert bt._tracks[1].state == TrackState.ACTIVE
+        to = bt.tracked_objects()
+        assert to.det_indices is not None
+        rows = {int(tid): i for i, tid in enumerate(to.track_ids)}
+        recovered_row = rows[1]
+        assert to.track_states[recovered_row] == TrackState.ACTIVE
+        # The recovered track now carries a real detection index again (input row 0).
+        assert int(to.det_indices[recovered_row]) == 0
+
+    def test_tracked_objects_lost_box_advances_over_multiple_coasted_frames(self):
+        bt, _ = _mixed_state_tracker()
+
+        def lost_x1() -> float:
+            to = bt.tracked_objects()
+            rows = {int(tid): i for i, tid in enumerate(to.track_ids)}
+            return float(to.bboxes[rows[1]][0])
+
+        # Frame 2: track 1 just went LOST. Keep feeding only B so track 1 keeps
+        # coasting; its predicted x should advance each frame while still LOST.
+        x2 = lost_x1()
+        bt.update(_dets([[200, 200, 240, 240]], [0.9], frame_id=3))
+        x3 = lost_x1()
+        bt.update(_dets([[200, 200, 240, 240]], [0.9], frame_id=4))
+        x4 = lost_x1()
+        assert bt._tracks[1].state == TrackState.LOST
+        assert x3 > x2
+        assert x4 > x3
 
 
 class TestSubset:

--- a/libraries/getitrack/tests/unit/test_bytetrack.py
+++ b/libraries/getitrack/tests/unit/test_bytetrack.py
@@ -246,6 +246,16 @@ class TestStateAccessors:
         # Mutating the returned list must not disturb tracker state.
         assert len(bt.tracks) == 3
 
+    def test_tracks_are_deep_copies(self):
+        bt, _ = _mixed_state_tracker()
+        returned = bt.tracks[0]
+        returned.state = TrackState.REMOVED
+        returned.bbox[0] = -999.0
+        # Mutating a returned copy must not leak into the tracker's own Track.
+        internal = bt._tracks[returned.track_id]
+        assert internal.state != TrackState.REMOVED
+        assert internal.bbox[0] != -999.0
+
     def test_tracked_objects_includes_coasted_lost_track(self):
         bt, out2 = _mixed_state_tracker()
         to = bt.tracked_objects

--- a/libraries/getitrack/tests/unit/test_ocsort.py
+++ b/libraries/getitrack/tests/unit/test_ocsort.py
@@ -58,6 +58,24 @@ class TestSingleObject:
         assert idx[1] == 1
 
 
+class TestAccessors:
+    def test_tracks_and_tracked_objects_after_update(self, fast_confirm):
+        ocs = OCSortTracker(fast_confirm)
+        for f in range(3):
+            ocs.update(_dets([[10, 10, 50, 50]], [0.9], frame_id=f))
+        assert [t.track_id for t in ocs.tracks] == [1]
+        to = ocs.tracked_objects
+        assert to.track_ids.tolist() == [1]
+        assert to.det_indices is not None
+
+    def test_tracked_objects_before_any_frame_is_empty(self):
+        ocs = OCSortTracker(OCSortConfig())
+        to = ocs.tracked_objects
+        assert len(to) == 0
+        assert to.det_indices is not None
+        assert ocs.tracks == []
+
+
 class TestRecovery:
     def test_first_pass_recovers_track_near_predicted_trajectory(self, fast_confirm):
         # Object seen, gone for 3 frames, reappears on its trajectory: the

--- a/libraries/getitrack/tests/unit/test_sort.py
+++ b/libraries/getitrack/tests/unit/test_sort.py
@@ -56,6 +56,24 @@ class TestSingleObject:
         assert idx[1] == 1
 
 
+class TestAccessors:
+    def test_tracks_and_tracked_objects_after_update(self, fast_confirm):
+        sort = SortTracker(fast_confirm)
+        for f in range(3):
+            sort.update(_dets([[10, 10, 50, 50]], [0.9], frame_id=f))
+        assert [t.track_id for t in sort.tracks] == [1]
+        to = sort.tracked_objects
+        assert to.track_ids.tolist() == [1]
+        assert to.det_indices is not None
+
+    def test_tracked_objects_before_any_frame_is_empty(self):
+        sort = SortTracker(SortConfig())
+        to = sort.tracked_objects
+        assert len(to) == 0
+        assert to.det_indices is not None
+        assert sort.tracks == []
+
+
 class TestScoreGate:
     def test_detection_at_or_below_score_threshold_is_dropped(self):
         cfg = SortConfig(score_threshold=0.5, lifecycle=LifecycleConfig(min_hits=1))


### PR DESCRIPTION
## What

Adds read-only accessors so a caller can inspect the tracker's current state between frames, without re-running `update()`.

- `tracks -> list[Track]`: the live Track objects across all lifecycle states (TENTATIVE, ACTIVE, LOST), returned as a fresh list. A low-level view for debugging and tests; the Track objects are shared, so mutating them mutates tracker state.
- `tracked_objects() -> TrackedDetections`: the confirmed-alive tracks for the last processed frame. Unlike `update()` (which returns ACTIVE tracks only), it also includes coasted LOST tracks still within `max_age`, carrying their Kalman-predicted box for the frame with `det_index` of -1 (score and class are the last observed values), so consumers can render or report continuity across occlusions. Contract-compatible with `update()`: matching dtypes and shape, `det_indices` remapped to the unfiltered input rows under a `class_filter`, and an empty result before the first frame.

## Why

`update()` answers "what did you match this frame?" and its return value is transient. Consumers that integrate the tracker (the Geti application, visualizers, evaluation harnesses) need to ask "what do you currently believe exists, including objects being coasted through occlusion?" without feeding new detections. These accessors provide that read side, and expose coasted LOST tracks with predicted boxes, which the per-frame `update()` output does not.

## Implementation

`_compose_tracked_detections` and `_remap_to_input_rows` are added to the base tracker so every algorithm builds the snapshot and remaps detection indices to the original input rows consistently.

## Testing

10 new tests (`TestStateAccessors`): lifecycle-state exposure, fresh-list copy, coasted-LOST inclusion with an advancing predicted box over multiple frames, REMOVED exclusion, dtype and shape parity with `update()`, empty-before-first-frame, the tentative-only empty branch, and `det_indices` remap under a `class_filter` including after a lost-track recovery.
