### PR TITLE
Add label color mapping to demo files and visualization services

### DIFF
--- a/application/backend/app/api/dependencies.py
+++ b/application/backend/app/api/dependencies.py
@@ -336,9 +336,10 @@ def get_dataset_revision_service(
 
 def get_demo_files_service(
     media_service: Annotated[MediaService, Depends(get_media_service)],
+    label_service: Annotated[LabelService, Depends(get_label_service)],
 ) -> DemoFilesService:
     """Provides a DemoFilesService instance."""
-    return DemoFilesService(media_service=media_service)
+    return DemoFilesService(media_service=media_service, label_service=label_service)
 
 
 def get_project(

--- a/application/backend/app/models/model_activation.py
+++ b/application/backend/app/models/model_activation.py
@@ -19,6 +19,11 @@ class ModelActivationState(BaseModel):
     confidence_threshold: float | None = Field(
         default=None, description="Confidence threshold to apply to the model, or None to keep the model's own value"
     )
+    label_colors: dict[str, str] = Field(
+        default_factory=dict,
+        description="Mapping of project label name to its hex colour, used to render predictions "
+        "with the colours defined in the project",
+    )
 
     @field_validator("active_model_id")
     @classmethod

--- a/application/backend/app/services/active_model_service.py
+++ b/application/backend/app/services/active_model_service.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from uuid import UUID
 
 from loguru import logger
+from sqlalchemy.orm import Session
 
 from app.db.engine import get_db_session
 from app.models.model_activation import ModelActivationState
@@ -12,6 +13,7 @@ from app.models.model_revision import ModelFormat, ModelPrecision, TrainingStatu
 from app.models.system import DeviceInfo, DeviceType
 from app.repositories import ModelRevisionRepository, ModelVariantRepository
 from app.repositories.active_model_repo import ActiveModelRepo
+from app.repositories.label_repo import LabelRepository
 from app.services.inference.model_loader import LoadedModelHandle, ModelLoader
 
 from .system_service import SystemService
@@ -67,7 +69,28 @@ class ActiveModelService:
                 available_models=[UUID(m.id) for m in available_models],
                 device=geti_device,
                 confidence_threshold=active_model_repo.get_active_confidence_threshold(),
+                label_colors=self._load_label_colors(db=db, project_id=str(active_model.project_id)),
             )
+
+    @staticmethod
+    def _load_label_colors(db: Session, project_id: str) -> dict[str, str]:
+        """Load the mapping of label name to label colour for the given project.
+
+        The predictions returned by Model API carry the label names the model was trained on,
+        which are the project label names. Mapping them back to the project colours ensures the
+        rendered predictions use the same colours as the project labels shown in the UI.
+        """
+        try:
+            labels = LabelRepository(project_id=project_id, db=db).list_all()
+        except Exception:
+            logger.exception("Failed to load label colors for project '{}'", project_id)
+            return {}
+        return {label.name: label.color for label in labels if label.name and label.color}
+
+    @property
+    def label_colors(self) -> dict[str, str]:
+        """Mapping of label name to hex colour for the project owning the active model."""
+        return self._model_activation_state.label_colors
 
     def _get_model_file_path(self, project_id: UUID, model_id: UUID, variant_id: UUID, extension: str = "xml") -> Path:
         file_path = self.projects_dir / f"{project_id}/models/{model_id}/variants/{variant_id}/model.{extension}"
@@ -140,6 +163,10 @@ class ActiveModelService:
         """Re-read the pipeline inference parameters and apply them to the loaded model, without reloading it."""
         with get_db_session() as db:
             confidence_threshold = ActiveModelRepo(db=db).get_active_confidence_threshold()
+            project_id = self._model_activation_state.project_id
+            if project_id is not None:
+                # Labels may have been recoloured/renamed in the meantime; keep the overlay in sync.
+                self._model_activation_state.label_colors = self._load_label_colors(db=db, project_id=str(project_id))
         self._model_activation_state.confidence_threshold = confidence_threshold
         self._apply_confidence_threshold()
 

--- a/application/backend/app/services/demo_files_service.py
+++ b/application/backend/app/services/demo_files_service.py
@@ -28,6 +28,16 @@ _MODEL_FILENAME_BY_FORMAT: dict[ModelFormat, str] = {
 
 _DEFAULT_IMAGE_FILENAME = "image.jpg"
 
+# Git revision of 'openvino-model-api' the generated demo depends on.
+# The demos require fixes that are only available on the master branch of the Model API
+# repository; pin an exact commit so the generated demo environment stays reproducible.
+# TODO (#7346) revert to the official PyPI package after MAPI 0.4.7 or higher is released.
+_MODEL_API_GIT_REV = "70a6f83da872c50a56883b80becaf2de3ba11843"
+_MODEL_API_DEPENDENCY = (
+    "openvino-model-api[onnx] @ "
+    f"git+https://github.com/open-edge-platform/model_api@{_MODEL_API_GIT_REV}#subdirectory=model_api"
+)
+
 
 @dataclass(frozen=True)
 class DemoFile:
@@ -92,7 +102,12 @@ class DemoFilesService:
                 ).encode("utf-8"),
             )
         )
-        files.append(DemoFile(name="pyproject.toml", data=_PY_PROJECT.encode("utf-8")))
+        files.append(
+            DemoFile(
+                name="pyproject.toml",
+                data=_PY_PROJECT.format(model_api_dependency=_MODEL_API_DEPENDENCY).encode("utf-8"),
+            )
+        )
 
         readme = _README.format(model_filename=model_filename, image_filename=image_filename)
         if license == "AGPL-3.0":
@@ -363,7 +378,9 @@ requires-python = ">=3.13,<3.14"
 
 dependencies = [
     "openvino~=2026.3.0",
-    "openvino-model-api[onnx]==0.4.6",
+    # Installed straight from the Model API repository: the demos rely on fixes that are
+    # not part of a published release yet. Replace with a released version once available.
+    "{model_api_dependency}",
     "opencv-python-headless~=4.13.0",
     "numpy>=2.0",
     "pillow~=12.0",
@@ -440,6 +457,9 @@ overlaid on top.
 
 ## Notes
 
+* Installing the dependencies requires `git` to be available on your system: the
+  `openvino-model-api` package is installed directly from its source repository
+  until the required fixes land in a published release.
 * The demos default to running on CPU. To run on a different device (e.g. an
   Intel GPU), edit the scripts and pass device="GPU" to
   Model.create_model.

--- a/application/backend/app/services/demo_files_service.py
+++ b/application/backend/app/services/demo_files_service.py
@@ -339,19 +339,11 @@ def load_image() -> cv2.Mat:
     return image_raw
 
 
-def build_visualizer() -> Visualizer:
-    try:
-        return Visualizer(label_colors=LABEL_COLORS)
-    except TypeError:
-        # Older Model API releases do not support custom label colors.
-        return Visualizer()
-
-
 def visualise_result(image, result) -> None:
     if image.dtype != np.uint8:
         image = cv2.normalize(image, None, 0, 255, cv2.NORM_MINMAX).astype(np.uint8)
 
-    visualizer = build_visualizer()
+    visualizer = Visualizer(label_colors=LABEL_COLORS)
     visualizer.show(image, result)
 
     display_image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)

--- a/application/backend/app/services/demo_files_service.py
+++ b/application/backend/app/services/demo_files_service.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
@@ -16,6 +17,7 @@ from app.models.model_revision import ModelFormat
 
 if TYPE_CHECKING:
     from app.services import MediaService
+    from app.services.label_service import LabelService
 
 
 # Filename of the model weights inside the archive, depending on the format.
@@ -36,8 +38,9 @@ class DemoFile:
 
 
 class DemoFilesService:
-    def __init__(self, media_service: MediaService):
+    def __init__(self, media_service: MediaService, label_service: LabelService | None = None):
         self._media_service: MediaService = media_service
+        self._label_service: LabelService | None = label_service
 
     def build_demo_files(
         self, project_id: UUID, model_format: ModelFormat, *, license: str = "Apache 2.0"
@@ -82,7 +85,11 @@ class DemoFilesService:
         files.append(
             DemoFile(
                 name="utils.py",
-                data=_UTILS.format(model_filename=model_filename, image_filename=image_filename).encode("utf-8"),
+                data=_UTILS.format(
+                    model_filename=model_filename,
+                    image_filename=image_filename,
+                    label_colors=self._format_label_colors(project_id=project_id),
+                ).encode("utf-8"),
             )
         )
         files.append(DemoFile(name="pyproject.toml", data=_PY_PROJECT.encode("utf-8")))
@@ -94,6 +101,27 @@ class DemoFilesService:
 
         files.append(DemoFile(name="README.md", data=readme.encode("utf-8")))
         return files
+
+    def _format_label_colors(self, project_id: UUID) -> str:
+        """Render the project label colours as a Python dict literal for the demo scripts.
+
+        The exported model predicts the project label names, so mapping those names to the
+        project label colours makes the demo visualisations match the colours shown in Geti.
+        Returns "{}" when the labels cannot be resolved.
+        """
+        if self._label_service is None:
+            return "{}"
+        try:
+            labels = self._label_service.list_all(project_id=project_id)
+        except Exception:
+            logger.warning("Could not resolve label colors for project {}; using default colors.", project_id)
+            return "{}"
+
+        entries = {label.name: label.color for label in labels if label.name and label.color}
+        if not entries:
+            return "{}"
+        lines = "\n".join(f"    {json.dumps(name)}: {json.dumps(color)}," for name, color in sorted(entries.items()))
+        return "{\n" + lines + "\n}"
 
     def _pick_sample_image(self, project_id: UUID) -> tuple[str, bytes] | None:  # noqa: C901
         """Pick a sample image from the project's dataset.
@@ -277,6 +305,11 @@ MODEL_PATH = HERE / "{model_filename}"
 IMAGE_PATH = HERE / "{image_filename}"
 OUTPUT_PATH = HERE / "result.jpg"
 
+# Colors of the labels as defined in the Geti project, so that the rendered predictions
+# match the label colors shown in the Geti UI. Edit or clear this mapping to use the
+# Model API default color palette instead.
+LABEL_COLORS = {label_colors}
+
 if not MODEL_PATH.exists():
     raise FileNotFoundError(f"Model file not found: {{MODEL_PATH}}")
 if not IMAGE_PATH.exists():
@@ -306,14 +339,23 @@ def load_image() -> cv2.Mat:
     return image_raw
 
 
+def build_visualizer() -> Visualizer:
+    try:
+        return Visualizer(label_colors=LABEL_COLORS)
+    except TypeError:
+        # Older Model API releases do not support custom label colors.
+        return Visualizer()
+
+
 def visualise_result(image, result) -> None:
     if image.dtype != np.uint8:
         image = cv2.normalize(image, None, 0, 255, cv2.NORM_MINMAX).astype(np.uint8)
 
-    Visualizer().show(image, result)
-    
+    visualizer = build_visualizer()
+    visualizer.show(image, result)
+
     display_image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-    output = Visualizer().render(display_image, result)
+    output = visualizer.render(display_image, result)
     cv2.imwrite(str(OUTPUT_PATH), output)
     print(f"Saved annotated result to {{OUTPUT_PATH}}")
 

--- a/application/backend/app/services/demo_files_service.py
+++ b/application/backend/app/services/demo_files_service.py
@@ -114,7 +114,7 @@ class DemoFilesService:
         try:
             labels = self._label_service.list_all(project_id=project_id)
         except Exception:
-            logger.warning("Could not resolve label colors for project {}; using default colors.", project_id)
+            logger.exception("Could not resolve label colors for project {}; using default colors.", project_id)
             return "{}"
 
         entries = {label.name: label.color for label in labels if label.name and label.color}

--- a/application/backend/app/utils/__init__.py
+++ b/application/backend/app/utils/__init__.py
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from app.utils.singleton import Singleton
-from app.utils.visualization import Visualizer
+from app.utils.visualization import LabelColors, Visualizer
 
-__all__ = ["Singleton", "Visualizer"]
+__all__ = ["LabelColors", "Singleton", "Visualizer"]

--- a/application/backend/app/utils/visualization.py
+++ b/application/backend/app/utils/visualization.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -12,6 +13,10 @@ from app.utils.singleton import Singleton
 
 if TYPE_CHECKING:
     from model_api.models.result import ClassificationResult, DetectionResult, InstanceSegmentationResult, Result
+
+# Mapping of label name to the colour used to render it, e.g. {"cat": "#00FF00"}.
+# Colours are hex strings (as stored on the project labels) or (R, G, B) tuples.
+LabelColors = Mapping[str, str | tuple[int, int, int]]
 
 
 def _compute_scale(image: np.ndarray) -> float:
@@ -37,8 +42,17 @@ class VisualizerCreator(ABC):
         self,
         original_image: np.ndarray,
         predictions: "Result",
+        label_colors: LabelColors | None = None,
     ) -> np.ndarray:
-        """Create a visualization of the predictions on the original image."""
+        """Create a visualization of the predictions on the original image.
+
+        Args:
+            original_image: RGB numpy image to draw on.
+            predictions: Model API prediction result.
+            label_colors: Optional mapping of label name to colour, used to render the
+                predictions with the colours defined on the project labels. Labels absent
+                from the mapping keep their automatically assigned palette colour.
+        """
 
 
 class ClassificationVisualizerCreator(VisualizerCreator):
@@ -48,6 +62,7 @@ class ClassificationVisualizerCreator(VisualizerCreator):
         self,
         original_image: np.ndarray,
         predictions: "ClassificationResult",
+        label_colors: LabelColors | None = None,
     ) -> np.ndarray:
         from model_api.visualizer.scene import ClassificationScene
 
@@ -57,6 +72,7 @@ class ClassificationVisualizerCreator(VisualizerCreator):
             image=image_pil,
             result=predictions,
             scale=scale,
+            label_colors=label_colors,
         )
         rendered = classification_scene.render()
         return np.array(rendered)
@@ -69,6 +85,7 @@ class DetectionVisualizerCreator(VisualizerCreator):
         self,
         original_image: np.ndarray,
         predictions: "DetectionResult",
+        label_colors: LabelColors | None = None,
     ) -> np.ndarray:
         from model_api.visualizer import BoundingBox, Flatten, Label
         from model_api.visualizer.scene import DetectionScene
@@ -80,6 +97,7 @@ class DetectionVisualizerCreator(VisualizerCreator):
             result=predictions,
             layout=Flatten(BoundingBox, Label),
             scale=scale,
+            label_colors=label_colors,
         )
         rendered = detection_scene.render()
         return np.array(rendered)
@@ -92,6 +110,7 @@ class InstanceSegmentationVisualizerCreator(VisualizerCreator):
         self,
         original_image: np.ndarray,
         predictions: "InstanceSegmentationResult",
+        label_colors: LabelColors | None = None,
     ) -> np.ndarray:
         from model_api.visualizer import Flatten, Label, Polygon
         from model_api.visualizer.scene import InstanceSegmentationScene
@@ -103,6 +122,7 @@ class InstanceSegmentationVisualizerCreator(VisualizerCreator):
             result=predictions,
             layout=Flatten(Polygon, Label),
             scale=scale,
+            label_colors=label_colors,
         )
         rendered = segmentation_scene.render()
         return np.array(rendered)
@@ -124,13 +144,14 @@ class VisualizationDispatcher(metaclass=Singleton):
         self,
         original_image: np.ndarray,
         predictions: "Result",
+        label_colors: LabelColors | None = None,
     ) -> np.ndarray | None:
         if original_image.size == 0:
             raise ValueError("The image provided through the 'original_image' parameter cannot be empty.")
 
         creator = self._creator_map.get(type(predictions))
         if creator is not None:
-            return creator.create_visualization(original_image, predictions)
+            return creator.create_visualization(original_image, predictions, label_colors)
         logger.error("Visualization for {} is not supported.", type(predictions))
         return None
 
@@ -140,15 +161,21 @@ class Visualizer:
     def overlay_predictions(
         original_image: np.ndarray,
         predictions: "Result",
+        label_colors: LabelColors | None = None,
     ) -> np.ndarray:
         """Overlay predictions on the original image.
 
         Args:
             original_image: BGR/RGB numpy image.
             predictions: Model API prediction result.
+            label_colors: Optional mapping of label name to colour (e.g. the colours of the
+                project labels), so that the rendered predictions match the project's label
+                colours. Labels absent from the mapping keep their default palette colour.
         """
         try:
-            visualization = VisualizationDispatcher().create_visualization(original_image, predictions)
+            visualization = VisualizationDispatcher().create_visualization(
+                original_image, predictions, label_colors=label_colors
+            )
             if visualization is None:
                 return original_image
         except Exception:

--- a/application/backend/app/workers/inference.py
+++ b/application/backend/app/workers/inference.py
@@ -132,6 +132,16 @@ class InferenceWorker(BaseProcessWorker):
             raise RuntimeError("Prediction buffer not initialized (method 'setup' not called?)")
         return self.__prediction_buffer
 
+    def _label_colors(self) -> dict[str, str]:
+        """Colours of the labels of the project owning the active model, keyed by label name.
+
+        Used to render the predictions with the same colours as the project labels.
+        """
+        model_service = getattr(self, "_model_service", None)
+        if model_service is None:
+            return {}
+        return model_service.label_colors
+
     def _on_inference_completed(self, inf_result: "Result", userdata: dict[str, Any]) -> None:
         # This callback runs on the Model API / OpenVINO inference thread. An unhandled exception
         # here would be raised inside that thread and can wedge the async inference queue, so every
@@ -144,7 +154,9 @@ class InferenceWorker(BaseProcessWorker):
 
             stream_data: StreamData = userdata["stream_data"]
             frame_with_predictions = Visualizer.overlay_predictions(
-                original_image=stream_data.frame_data, predictions=inf_result
+                original_image=stream_data.frame_data,
+                predictions=inf_result,
+                label_colors=self._label_colors(),
             )
             inference_data = InferenceData(
                 prediction=inf_result,

--- a/application/backend/tests/integration/services/test_active_model_service.py
+++ b/application/backend/tests/integration/services/test_active_model_service.py
@@ -8,7 +8,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from app.db.schema import ModelRevisionDB, ModelVariantDB, PipelineDB, ProjectDB
+from app.db.schema import LabelDB, ModelRevisionDB, ModelVariantDB, PipelineDB, ProjectDB
 from app.models.model_revision import ModelFormat, ModelPrecision, TrainingStatus
 from app.models.system import DeviceInfo, DeviceType
 from app.services import ActiveModelService, SystemService
@@ -243,3 +243,57 @@ class TestActiveModelServiceConfidenceThreshold:
 
         mock_load.assert_called_once()  # the model was not reloaded
         assert model.set_param.call_args_list[-1].args == ("confidence_threshold", 0.2)
+
+
+class TestActiveModelServiceLabelColors:
+    """The colors of the project labels must be exposed so that the predictions can be
+    rendered with the same colors as the labels defined in the project."""
+
+    @pytest.fixture
+    def fxt_pipeline_with_labels(self, fxt_project, fxt_successful_model, fxt_fp16_openvino_variant, db_session):
+        def _create(labels: dict[str, str]) -> list[LabelDB]:
+            db_labels = [
+                LabelDB(id=str(uuid4()), project_id=fxt_project.id, name=name, color=color)
+                for name, color in labels.items()
+            ]
+            db_session.add_all([fxt_successful_model, fxt_fp16_openvino_variant, *db_labels])
+            db_session.flush()
+            db_session.add(
+                PipelineDB(
+                    project_id=fxt_project.id,
+                    is_running=True,
+                    model_revision_id=fxt_successful_model.id,
+                    model_variant_id=fxt_fp16_openvino_variant.id,
+                    device="cpu",
+                )
+            )
+            db_session.flush()
+            return db_labels
+
+        return _create
+
+    def test_label_colors_of_the_active_project_are_loaded(self, fxt_pipeline_with_labels, db_session, tmp_path):
+        fxt_pipeline_with_labels({"cat": "#00FF00", "dog": "#FF0000"})
+
+        with _make_db_session_patcher(db_session):
+            service = ActiveModelService(data_dir=tmp_path, system_service=SystemService())
+
+        assert service.label_colors == {"cat": "#00FF00", "dog": "#FF0000"}
+
+    def test_label_colors_are_empty_without_active_model(self, db_session, tmp_path):
+        with _make_db_session_patcher(db_session):
+            service = ActiveModelService(data_dir=tmp_path, system_service=SystemService())
+
+        assert service.label_colors == {}
+
+    def test_recolored_labels_are_picked_up_on_refresh(self, fxt_pipeline_with_labels, db_session, tmp_path):
+        """Recoloring a label in the project is reflected without reloading the model."""
+        db_labels = fxt_pipeline_with_labels({"cat": "#00FF00"})
+
+        with _make_db_session_patcher(db_session):
+            service = ActiveModelService(data_dir=tmp_path, system_service=SystemService())
+            db_labels[0].color = "#123456"
+            db_session.flush()
+            service.refresh_inference_params()
+
+        assert service.label_colors == {"cat": "#123456"}

--- a/application/backend/tests/integration/services/test_demo_files_service.py
+++ b/application/backend/tests/integration/services/test_demo_files_service.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import ast
 from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import patch
@@ -18,12 +19,13 @@ from app.models.media import ImageFormat, Media, VideoFormat
 from app.models.model_revision import ModelFormat
 from app.services import MediaService
 from app.services.demo_files_service import DemoFile, DemoFilesService
+from app.services.label_service import LabelService
 from app.services.media_service import ImageMetadata
 
 
 @pytest.fixture
-def fxt_demo_files_service(fxt_media_service: MediaService) -> DemoFilesService:
-    return DemoFilesService(media_service=fxt_media_service)
+def fxt_demo_files_service(fxt_media_service: MediaService, fxt_label_service: LabelService) -> DemoFilesService:
+    return DemoFilesService(media_service=fxt_media_service, label_service=fxt_label_service)
 
 
 @pytest.fixture
@@ -317,6 +319,45 @@ class TestDemoFilesServiceIntegration:
         readme = by_name["README.md"].decode("utf-8")
         assert expected_name in readme
         assert "image.jpg" not in readme
+
+    def test_label_colors_are_baked_into_the_demo(
+        self,
+        fxt_demo_files_service: DemoFilesService,
+        fxt_project_with_image: tuple[Project, MediaDB],
+    ) -> None:
+        """The generated utils.py pins the project label colors so that the demo
+        visualizations match the label colors shown in Geti."""
+        project, _ = fxt_project_with_image
+
+        files = fxt_demo_files_service.build_demo_files(project_id=project.id, model_format=ModelFormat.OPENVINO)
+
+        script = {f.name: f.data for f in files}["utils.py"].decode("utf-8")
+        assert '"cat": "#00FF00",' in script
+        assert '"dog": "#FF0000",' in script
+        assert "Visualizer(label_colors=LABEL_COLORS)" in script
+
+        # The generated module must be valid Python and expose the mapping.
+        module = ast.parse(script)
+        assignment = next(
+            node
+            for node in module.body
+            if isinstance(node, ast.Assign) and getattr(node.targets[0], "id", None) == "LABEL_COLORS"
+        )
+        assert ast.literal_eval(assignment.value) == {"cat": "#00FF00", "dog": "#FF0000"}
+
+    def test_label_colors_default_to_empty_without_label_service(
+        self,
+        fxt_media_service: MediaService,
+        fxt_project_with_image: tuple[Project, MediaDB],
+    ) -> None:
+        """Without a label service the demo falls back to the Model API default palette."""
+        project, _ = fxt_project_with_image
+        service = DemoFilesService(media_service=fxt_media_service)
+
+        files = service.build_demo_files(project_id=project.id, model_format=ModelFormat.OPENVINO)
+
+        script = {f.name: f.data for f in files}["utils.py"].decode("utf-8")
+        assert "LABEL_COLORS = {}" in script
 
     def test_video_without_binary_falls_back_gracefully(
         self,

--- a/application/backend/tests/integration/services/test_demo_files_service.py
+++ b/application/backend/tests/integration/services/test_demo_files_service.py
@@ -323,7 +323,7 @@ class TestDemoFilesServiceIntegration:
     def test_label_colors_are_baked_into_the_demo(
         self,
         fxt_demo_files_service: DemoFilesService,
-        fxt_project_with_image: tuple[Project, MediaDB],
+        fxt_project_with_image: tuple[Project, Media],
     ) -> None:
         """The generated utils.py pins the project label colors so that the demo
         visualizations match the label colors shown in Geti."""

--- a/application/backend/tests/unit/test_visualization.py
+++ b/application/backend/tests/unit/test_visualization.py
@@ -16,6 +16,7 @@ from app.utils.visualization import (
     DetectionVisualizerCreator,
     InstanceSegmentationVisualizerCreator,
     VisualizationDispatcher,
+    Visualizer,
     _compute_scale,
 )
 
@@ -106,3 +107,62 @@ class TestVisualizationHelpers(unittest.TestCase):
         # 4K longer edge → ~3.0
         img = np.zeros((2160, 3840, 3), dtype=np.uint8)
         assert _compute_scale(img) == pytest.approx(3.0, rel=1e-3)
+
+
+class TestLabelColors(unittest.TestCase):
+    """The project label colors must be forwarded to Model API so that the rendered
+    predictions use the same colors as the labels defined in the project."""
+
+    LABEL_COLORS = {"1": "#00FF00", "2": "#FF0000", "3": "#0000FF"}
+
+    def test_detection_creator_forwards_label_colors(self):
+        creator = DetectionVisualizerCreator()
+        original_image = np.zeros((100, 100, 3), dtype=np.uint8)
+        predictions = DetectionResult(bboxes, labels)
+        with mock.patch("model_api.visualizer.scene.DetectionScene") as mock_scene:
+            creator.create_visualization(original_image, predictions, self.LABEL_COLORS)
+        self.assertEqual(mock_scene.call_args.kwargs["label_colors"], self.LABEL_COLORS)
+
+    def test_instance_segmentation_creator_forwards_label_colors(self):
+        creator = InstanceSegmentationVisualizerCreator()
+        original_image = np.zeros((100, 100, 3), dtype=np.uint8)
+        predictions = InstanceSegmentationResult(bboxes, labels, masks)
+        with mock.patch("model_api.visualizer.scene.InstanceSegmentationScene") as mock_scene:
+            creator.create_visualization(original_image, predictions, self.LABEL_COLORS)
+        self.assertEqual(mock_scene.call_args.kwargs["label_colors"], self.LABEL_COLORS)
+
+    def test_classification_creator_forwards_label_colors(self):
+        creator = ClassificationVisualizerCreator()
+        original_image = np.zeros((100, 100, 3), dtype=np.uint8)
+        predictions = ClassificationResult([Label(id=1, name="1", confidence=0.9)])
+        with mock.patch("model_api.visualizer.scene.ClassificationScene") as mock_scene:
+            creator.create_visualization(original_image, predictions, self.LABEL_COLORS)
+        self.assertEqual(mock_scene.call_args.kwargs["label_colors"], self.LABEL_COLORS)
+
+    def test_dispatcher_forwards_label_colors(self):
+        dispatcher = VisualizationDispatcher()
+        original_image = np.zeros((100, 100, 3), dtype=np.uint8)
+        predictions = DetectionResult(bboxes, labels)
+        creator = mock.Mock()
+        with mock.patch.dict(dispatcher._creator_map, {DetectionResult: creator}):
+            dispatcher.create_visualization(original_image, predictions, self.LABEL_COLORS)
+        creator.create_visualization.assert_called_once_with(original_image, predictions, self.LABEL_COLORS)
+
+    def test_overlay_predictions_forwards_label_colors(self):
+        original_image = np.zeros((100, 100, 3), dtype=np.uint8)
+        predictions = DetectionResult(bboxes, labels)
+        with mock.patch.object(VisualizationDispatcher, "create_visualization", return_value=original_image) as mocked:
+            Visualizer.overlay_predictions(original_image, predictions, label_colors=self.LABEL_COLORS)
+        self.assertEqual(mocked.call_args.kwargs["label_colors"], self.LABEL_COLORS)
+
+    def test_rendered_detection_uses_the_requested_color(self):
+        original_image = np.zeros((100, 100, 3), dtype=np.uint8)
+        predictions = DetectionResult(bboxes, labels, label_names=["cat", "dog", "fish"])
+        creator = DetectionVisualizerCreator()
+
+        default_render = creator.create_visualization(original_image, predictions)
+        custom_render = creator.create_visualization(original_image, predictions, {"cat": (255, 0, 255)})
+
+        self.assertFalse(np.array_equal(default_render, custom_render))
+        # The requested color must actually be drawn on the image
+        self.assertTrue(np.any(np.all(custom_render == np.array([255, 0, 255], dtype=np.uint8), axis=-1)))

--- a/application/backend/tests/unit/workers/test_inference.py
+++ b/application/backend/tests/unit/workers/test_inference.py
@@ -206,6 +206,31 @@ class TestInferenceStatusReporting:
         assert status.code == InferenceWorkerStatusCode.OK
         assert status.model_id == model_id
 
+    def test_on_inference_completed_uses_project_label_colors(
+        self, fxt_status_shm, fxt_status_shm_lock, fxt_create_stream_data
+    ):
+        """Predictions are rendered with the colors of the labels of the active project."""
+        label_colors = {"cat": "#00FF00", "dog": "#FF0000"}
+        worker = object.__new__(InferenceWorker)
+        worker._inference_status_shm = fxt_status_shm
+        worker._inference_status_shm_lock = fxt_status_shm_lock
+        worker._metrics_service = Mock()
+        worker._model_service = Mock(label_colors=label_colors)
+        worker._pred_queue = queue.Queue(maxsize=4)  # pyrefly: ignore[bad-assignment]
+        setattr(worker, "_InferenceWorker__prediction_buffer", PredictionReorderBuffer())
+
+        ts = 1.0
+        worker._prediction_buffer.register_expected_timestamp(ts)
+        stream_data = fxt_create_stream_data(ts)
+        userdata = {"inference_start_time": ts, "model_id": uuid4(), "stream_data": stream_data}
+
+        with patch(
+            "app.workers.inference.Visualizer.overlay_predictions", return_value=stream_data.frame_data
+        ) as mock_overlay:
+            worker._on_inference_completed(Mock(), userdata)
+
+        assert mock_overlay.call_args.kwargs["label_colors"] == label_colors
+
     def test_report_status_error(self, fxt_status_shm, fxt_status_shm_lock):
         """_report_status writes an ERROR status (with message) that can be read back."""
         worker = object.__new__(InferenceWorker)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Uses the ModelAPI added label colour data to match the label colour between the project and the prediction.


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
