### PR TITLE
Remove onChange from checkbox, delegating it to media item

### DIFF
--- a/application/ui/src/features/dataset/gallery/gallery.component.test.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.test.tsx
@@ -160,7 +160,7 @@ describe('Gallery item deletion and selection', () => {
         const user = userEvent.setup();
         await renderGalleryWithItems([item]);
 
-        await user.click(screen.getByRole('checkbox', { name: `Select media item ${item.id}` }));
+        await user.click(screen.getAllByRole('option')[0]);
         expect(screen.getByText('1 selected')).toBeInTheDocument();
 
         await user.click(screen.getByRole('button', { name: 'Media actions' }));
@@ -258,18 +258,19 @@ describe('Gallery item deletion and selection', () => {
             expect(getCheckbox('item-4')).not.toBeChecked();
         });
 
-        it('toggles a single item through its checkbox', async () => {
+        it('replaces the selection when clicking on the checkbox of another item', async () => {
             const user = userEvent.setup();
             await renderGalleryWithItems(items);
 
-            await user.click(getCheckbox('item-1'));
-            expect(screen.getByText('1 selected')).toBeInTheDocument();
+            // The checkbox itself ignores pointer events, so a click lands on the item behind it
+            const checkboxArea = (id: string) => getCheckbox(id).closest('[data-floating-container]') as HTMLElement;
 
-            await user.click(getCheckbox('item-2'));
-            expect(screen.getByText('2 selected')).toBeInTheDocument();
+            await user.click(checkboxArea('item-1'));
+            await user.click(checkboxArea('item-3'));
 
-            await user.click(getCheckbox('item-1'));
             expect(screen.getByText('1 selected')).toBeInTheDocument();
+            expect(getCheckbox('item-1')).not.toBeChecked();
+            expect(getCheckbox('item-3')).toBeChecked();
         });
 
         it('does not select an item when using its actions menu', async () => {

--- a/application/ui/src/features/dataset/gallery/gallery.component.test.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.test.tsx
@@ -176,7 +176,18 @@ describe('Gallery item deletion and selection', () => {
 
         const getItem = (index: number) => screen.getAllByRole('option')[index];
 
-        const getCheckbox = (id: string) => screen.getByRole('checkbox', { name: `Select media item ${id}` });
+        const getCheckbox = (id: string) =>
+            screen.getByRole('checkbox', { name: `Selection state of media item ${id}` });
+
+        const getCheckboxContainer = (id: string) => {
+            const container = getCheckbox(id).closest('[data-floating-container]');
+
+            if (container === null) {
+                throw new Error(`Could not find the container wrapping the checkbox of ${id}`);
+            }
+
+            return container;
+        };
 
         const clickWithModifier = async (
             user: ReturnType<typeof userEvent.setup>,
@@ -258,15 +269,13 @@ describe('Gallery item deletion and selection', () => {
             expect(getCheckbox('item-4')).not.toBeChecked();
         });
 
-        it('replaces the selection when clicking on the checkbox of another item', async () => {
+        it('replaces the selection when clicking on the checkbox overlay of another item', async () => {
             const user = userEvent.setup();
             await renderGalleryWithItems(items);
 
             // The checkbox itself ignores pointer events, so a click lands on the item behind it
-            const checkboxArea = (id: string) => getCheckbox(id).closest('[data-floating-container]') as HTMLElement;
-
-            await user.click(checkboxArea('item-1'));
-            await user.click(checkboxArea('item-3'));
+            await user.click(getCheckboxContainer('item-1'));
+            await user.click(getCheckboxContainer('item-3'));
 
             expect(screen.getByText('1 selected')).toBeInTheDocument();
             expect(getCheckbox('item-1')).not.toBeChecked();

--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -105,8 +105,8 @@ const GalleryList = ({
                                 height={'size-200'}
                                 alignItems={'center'}
                                 justifyContent={'center'}
-                                // Clicks fall through to the grid item so the checkbox area follows the same
-                                // replace/ctrl/shift selection semantics as clicking anywhere else on the item.
+                                // Set pointerEvents to 'none' to allow clicks to pass through
+                                // to the MediaItemActions component
                                 UNSAFE_style={{ margin: dimensionValue('size-150'), pointerEvents: 'none' }}
                             >
                                 <Checkbox

--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -105,12 +105,14 @@ const GalleryList = ({
                                 height={'size-200'}
                                 alignItems={'center'}
                                 justifyContent={'center'}
-                                UNSAFE_style={{ margin: dimensionValue('size-150') }}
+                                // Clicks fall through to the grid item so the checkbox area follows the same
+                                // replace/ctrl/shift selection semantics as clicking anywhere else on the item.
+                                UNSAFE_style={{ margin: dimensionValue('size-150'), pointerEvents: 'none' }}
                             >
                                 <Checkbox
                                     aria-label={`Select media item ${item.id}`}
-                                    onChange={() => toggleSelectedKeys([String(item.id)])}
                                     isSelected={selected}
+                                    isReadOnly
                                 />
                             </Flex>
                         )}

--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -110,7 +110,7 @@ const GalleryList = ({
                                 UNSAFE_style={{ margin: dimensionValue('size-150'), pointerEvents: 'none' }}
                             >
                                 <Checkbox
-                                    aria-label={`Select media item ${item.id}`}
+                                    aria-label={`Selection state of media item ${item.id}`}
                                     isSelected={selected}
                                     isReadOnly
                                 />

--- a/application/ui/tests/datasets/dataset-page.ts
+++ b/application/ui/tests/datasets/dataset-page.ts
@@ -27,7 +27,7 @@ export class DatasetPage {
     async selectMediaItem(mediaId: string) {
         await this.getMediaGrid()
             .getByRole('checkbox', {
-                name: `Select media item ${mediaId}`,
+                name: `Selection state of media item ${mediaId}`,
                 exact: true,
             })
             .click();

--- a/application/ui/tests/datasets/dataset-page.ts
+++ b/application/ui/tests/datasets/dataset-page.ts
@@ -24,13 +24,21 @@ export class DatasetPage {
         return this.page.getByRole('listbox', { name: 'data-collection-grid' });
     }
 
+    getMediaItemById(mediaId: string) {
+        return this.getMediaGrid()
+            .getByRole('option')
+            .filter({
+                has: this.page.getByRole('checkbox', {
+                    name: `Selection state of media item ${mediaId}`,
+                    exact: true,
+                }),
+            });
+    }
+
     async selectMediaItem(mediaId: string) {
-        await this.getMediaGrid()
-            .getByRole('checkbox', {
-                name: `Selection state of media item ${mediaId}`,
-                exact: true,
-            })
-            .click();
+        // The checkbox only reflects the state, selection happens on the item itself,
+        // where a plain click replaces the selection and a ctrl click adds to it
+        await this.getMediaItemById(mediaId).click({ modifiers: ['Control'] });
     }
 
     getMediaItemByName(name: string) {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Behavior:
```
if u click on checkbox, u can select more items without pressing cmd key
if u click on media item, u select media 1, if clicking on media 2 without the shift/cmd, media 1 is not selected anymore
```

The second one is what we want, and now works for both checkbox and media item.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
