### PR TITLE
Request thumbnails only when scroll stops

### DIFF
--- a/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import type { Media, MediaVideo } from '@/api/types';
 import { Flex, Skeleton } from '@geti-ui/ui';
+import { clsx } from 'clsx';
 
 import { useIsScrolling } from '../../hooks/use-is-scrolling.hook';
 import { isVideo } from '../../shared/media-item-utils';
@@ -69,7 +70,9 @@ export const MediaThumbnail = ({ onDoubleClick, onClick, url, alt, item }: Media
             <img
                 ref={imgRef}
                 alt={alt}
-                className={`${classes.img} ${isLoading ? classes.imgHidden : ''}`}
+                className={clsx(classes.img, {
+                    [classes.imgHidden]: isLoading,
+                })}
                 draggable={false}
                 decoding={'async'}
                 onLoad={() => setIsLoading(false)}

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
@@ -1,10 +1,10 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import type { Media, MediaVideo } from '@/api/types';
-import { Flex } from '@geti-ui/ui';
+import { Flex, Skeleton } from '@geti-ui/ui';
 
 import { useIsScrolling } from '../../hooks/use-is-scrolling.hook';
 import { isVideo } from '../../shared/media-item-utils';
@@ -42,6 +42,7 @@ const VideoIndicator = ({ duration }: VideoIndicatorProps) => {
 export const MediaThumbnail = ({ onDoubleClick, onClick, url, alt, item }: MediaThumbnailProps) => {
     const imgRef = useRef<HTMLImageElement>(null);
     const isScrolling = useIsScrolling();
+    const [isLoading, setIsLoading] = useState(true);
 
     // Tiles that fly past during a fast scroll would otherwise start a request and immediately
     // cancel it; enough of those wedge the connection and leave the gallery blank.
@@ -65,7 +66,20 @@ export const MediaThumbnail = ({ onDoubleClick, onClick, url, alt, item }: Media
 
     return (
         <div onDoubleClick={onDoubleClick} onClick={onClick} className={classes.imgContainer}>
-            <img ref={imgRef} alt={alt} className={classes.img} draggable={false} decoding={'async'} />
+            <img
+                ref={imgRef}
+                alt={alt}
+                className={`${classes.img} ${isLoading ? classes.imgHidden : ''}`}
+                draggable={false}
+                decoding={'async'}
+                onLoad={() => setIsLoading(false)}
+                onError={() => {
+                    if (imgRef.current?.complete === true) {
+                        setIsLoading(false);
+                    }
+                }}
+            />
+            {isLoading && <Skeleton width={'100%'} height={'100%'} className={classes.skeleton} />}
             {isVideo(item) && <VideoIndicator duration={item.duration} />}
         </div>
     );

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef } from 'react';
 import type { Media, MediaVideo } from '@/api/types';
 import { Flex } from '@geti-ui/ui';
 
+import { useIsScrolling } from '../../hooks/use-is-scrolling.hook';
 import { isVideo } from '../../shared/media-item-utils';
 import { formatCompactDuration } from './util';
 
@@ -40,24 +41,31 @@ const VideoIndicator = ({ duration }: VideoIndicatorProps) => {
 
 export const MediaThumbnail = ({ onDoubleClick, onClick, url, alt, item }: MediaThumbnailProps) => {
     const imgRef = useRef<HTMLImageElement>(null);
+    const isScrolling = useIsScrolling();
+
+    // Tiles that fly past during a fast scroll would otherwise start a request and immediately
+    // cancel it; enough of those wedge the connection and leave the gallery blank.
+    useEffect(() => {
+        if (isScrolling || imgRef.current === null) {
+            return;
+        }
+
+        imgRef.current.src = url;
+    }, [url, isScrolling]);
 
     useEffect(() => {
         const ref = imgRef.current;
-
-        if (ref) {
-            ref.src = url;
-        }
 
         return () => {
             if (ref) {
                 ref.src = '';
             }
         };
-    }, [url]);
+    }, []);
 
     return (
         <div onDoubleClick={onDoubleClick} onClick={onClick} className={classes.imgContainer}>
-            <img ref={imgRef} src={url} alt={alt} className={classes.img} draggable={false} decoding={'async'} />
+            <img ref={imgRef} alt={alt} className={classes.img} draggable={false} decoding={'async'} />
             {isVideo(item) && <VideoIndicator duration={item.duration} />}
         </div>
     );

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.module.scss
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.module.scss
@@ -18,6 +18,15 @@
     }
 }
 
+.imgHidden {
+    visibility: hidden;
+}
+
+.skeleton {
+    inset: 0;
+    position: absolute;
+}
+
 .videoIndicator {
     color: var(--spectrum-global-color-gray-900);
     padding: var(--spectrum-global-dimension-size-50);

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.module.scss
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.module.scss
@@ -3,6 +3,7 @@
     overflow: hidden;
     position: relative;
     text-align: center;
+    background-color: var(--spectrum-global-color-gray-100);
 }
 
 .img {

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.test.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.test.tsx
@@ -5,7 +5,12 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'test-utils/render';
 
+import { useIsScrolling } from '../../hooks/use-is-scrolling.hook';
 import { MediaThumbnail } from './media-thumbnail.component';
+
+vi.mock('../../hooks/use-is-scrolling.hook', () => ({
+    useIsScrolling: vi.fn(() => false),
+}));
 
 describe('MediaThumbnail', () => {
     it('calls onClick when image is clicked', async () => {
@@ -43,5 +48,21 @@ describe('MediaThumbnail', () => {
         );
 
         expect(screen.getByText('01:00')).toBeInTheDocument();
+    });
+
+    it('does not set the image src while scrolling', () => {
+        vi.mocked(useIsScrolling).mockReturnValue(true);
+
+        render(<MediaThumbnail url='test-image.jpg' alt='Test Image' item={{ type: 'image' }} />);
+
+        expect(screen.getByRole('img', { name: 'Test Image' })).not.toHaveAttribute('src');
+    });
+
+    it('sets the image src when not scrolling', () => {
+        vi.mocked(useIsScrolling).mockReturnValue(false);
+
+        render(<MediaThumbnail url='test-image.jpg' alt='Test Image' item={{ type: 'image' }} />);
+
+        expect(screen.getByRole('img', { name: 'Test Image' })).toHaveAttribute('src', 'test-image.jpg');
     });
 });

--- a/application/ui/src/components/virtualizer-grid-layout/virtualizer-grid-layout.component.tsx
+++ b/application/ui/src/components/virtualizer-grid-layout/virtualizer-grid-layout.component.tsx
@@ -7,6 +7,7 @@ import { AriaComponentsListBox, AriaListBoxItem, GridLayout, Loading, View, Virt
 import { useLoadMore } from '@react-aria/utils';
 import { GridLayoutOptions } from 'react-aria-components';
 
+import { IsScrollingProvider } from '../../hooks/use-is-scrolling.hook';
 import { useGetTargetPosition } from './use-get-target-position.hook';
 
 import classes from './virtualizer-grid-layout.module.scss';
@@ -81,40 +82,42 @@ export const VirtualizerGridLayout = <T extends GridItem>({
 
     return (
         <View UNSAFE_className={classes.mainContainer}>
-            <Virtualizer layout={GridLayout} layoutOptions={layoutOptions}>
-                <ListBox
-                    ref={ref}
-                    layout='grid'
-                    aria-label={ariaLabel}
-                    className={classes.container}
-                    selectedKeys={selectedKeys}
-                    selectionMode={selectionMode}
-                    selectionBehavior={selectionBehavior}
-                    onSelectionChange={onSelectionChange}
-                    allowDuplicateSelectionEvents={allowDuplicateSelectionEvents}
-                    selectOnFocus={selectOnFocus}
-                >
-                    {items.map((item, index) => {
-                        const itemId = getItemId(item);
+            <IsScrollingProvider scrollRef={ref}>
+                <Virtualizer layout={GridLayout} layoutOptions={layoutOptions}>
+                    <ListBox
+                        ref={ref}
+                        layout='grid'
+                        aria-label={ariaLabel}
+                        className={classes.container}
+                        selectedKeys={selectedKeys}
+                        selectionMode={selectionMode}
+                        selectionBehavior={selectionBehavior}
+                        onSelectionChange={onSelectionChange}
+                        allowDuplicateSelectionEvents={allowDuplicateSelectionEvents}
+                        selectOnFocus={selectOnFocus}
+                    >
+                        {items.map((item) => {
+                            const itemId = getItemId(item);
 
-                        return (
-                            <AriaListBoxItem
-                                id={itemId}
-                                key={`${ariaLabel}-${itemId}-${index}`}
-                                textValue={String(itemId)}
-                                className={classes.mediaItem}
-                            >
-                                {contentItem(item)}
+                            return (
+                                <AriaListBoxItem
+                                    id={itemId}
+                                    key={`${ariaLabel}-${itemId}`}
+                                    textValue={String(itemId)}
+                                    className={classes.mediaItem}
+                                >
+                                    {contentItem(item)}
+                                </AriaListBoxItem>
+                            );
+                        })}
+                        {isLoadingMore && !isPending && (
+                            <AriaListBoxItem id={'loader'} textValue={'loading'}>
+                                <Loading mode='overlay' />
                             </AriaListBoxItem>
-                        );
-                    })}
-                    {isLoadingMore && !isPending && (
-                        <AriaListBoxItem id={'loader'} textValue={'loading'}>
-                            <Loading mode='overlay' />
-                        </AriaListBoxItem>
-                    )}
-                </ListBox>
-            </Virtualizer>
+                        )}
+                    </ListBox>
+                </Virtualizer>
+            </IsScrollingProvider>
             {isPending && <Loading mode='overlay' />}
         </View>
     );

--- a/application/ui/src/hooks/use-is-scrolling.hook.test.tsx
+++ b/application/ui/src/hooks/use-is-scrolling.hook.test.tsx
@@ -1,0 +1,95 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { type ReactNode } from 'react';
+
+import { act, fireEvent, renderHook } from '@testing-library/react';
+
+import { IsScrollingProvider, SCROLL_END_FALLBACK_MS, useIsScrolling } from './use-is-scrolling.hook';
+
+describe('useIsScrolling', () => {
+    const renderIsScrolling = () => {
+        const scrollContainer = document.createElement('div');
+        document.body.appendChild(scrollContainer);
+
+        const wrapper = ({ children }: { children: ReactNode }) => (
+            <IsScrollingProvider scrollRef={{ current: scrollContainer }}>{children}</IsScrollingProvider>
+        );
+
+        return { scrollContainer, ...renderHook(() => useIsScrolling(), { wrapper }) };
+    };
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        document.body.innerHTML = '';
+    });
+
+    it('is false before any scrolling happens', () => {
+        const { result } = renderIsScrolling();
+
+        expect(result.current).toBe(false);
+    });
+
+    it('is true while the container is being scrolled', () => {
+        const { scrollContainer, result } = renderIsScrolling();
+
+        fireEvent.scroll(scrollContainer);
+
+        expect(result.current).toBe(true);
+
+        act(() => {
+            vi.advanceTimersByTime(SCROLL_END_FALLBACK_MS - 1);
+        });
+
+        expect(result.current).toBe(true);
+    });
+
+    it('becomes false once the scroll end fallback timeout elapses', () => {
+        const { scrollContainer, result } = renderIsScrolling();
+
+        fireEvent.scroll(scrollContainer);
+
+        act(() => {
+            vi.advanceTimersByTime(SCROLL_END_FALLBACK_MS);
+        });
+
+        expect(result.current).toBe(false);
+    });
+
+    it('restarts the fallback timeout on every scroll event', () => {
+        const { scrollContainer, result } = renderIsScrolling();
+
+        fireEvent.scroll(scrollContainer);
+
+        act(() => {
+            vi.advanceTimersByTime(SCROLL_END_FALLBACK_MS - 1);
+        });
+
+        fireEvent.scroll(scrollContainer);
+
+        act(() => {
+            vi.advanceTimersByTime(SCROLL_END_FALLBACK_MS - 1);
+        });
+
+        expect(result.current).toBe(true);
+    });
+
+    it('becomes false as soon as scrollend is fired', () => {
+        const { scrollContainer, result } = renderIsScrolling();
+
+        fireEvent.scroll(scrollContainer);
+        fireEvent(scrollContainer, new Event('scrollend'));
+
+        expect(result.current).toBe(false);
+
+        act(() => {
+            vi.advanceTimersByTime(SCROLL_END_FALLBACK_MS);
+        });
+
+        expect(result.current).toBe(false);
+    });
+});

--- a/application/ui/src/hooks/use-is-scrolling.hook.tsx
+++ b/application/ui/src/hooks/use-is-scrolling.hook.tsx
@@ -1,0 +1,47 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { createContext, ReactNode, RefObject, useContext, useEffect, useRef, useState } from 'react';
+
+import { useEventListener } from './event-listener.hook';
+
+const IsScrollingContext = createContext(false);
+
+// `scrollend` is not implemented by every webview (notably WKWebView), so a timeout is used as fallback.
+const SCROLL_END_FALLBACK_MS = 150;
+
+type IsScrollingProviderProps = {
+    scrollRef: RefObject<HTMLElement | null>;
+    children: ReactNode;
+};
+
+export const IsScrollingProvider = ({ scrollRef, children }: IsScrollingProviderProps) => {
+    const [isScrolling, setIsScrolling] = useState(false);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+    useEventListener(
+        'scroll',
+        () => {
+            setIsScrolling(true);
+
+            clearTimeout(timeoutRef.current);
+            timeoutRef.current = setTimeout(() => setIsScrolling(false), SCROLL_END_FALLBACK_MS);
+        },
+        scrollRef
+    );
+
+    useEventListener(
+        'scrollend',
+        () => {
+            clearTimeout(timeoutRef.current);
+            setIsScrolling(false);
+        },
+        scrollRef
+    );
+
+    useEffect(() => () => clearTimeout(timeoutRef.current), []);
+
+    return <IsScrollingContext.Provider value={isScrolling}>{children}</IsScrollingContext.Provider>;
+};
+
+export const useIsScrolling = (): boolean => useContext(IsScrollingContext);

--- a/application/ui/src/hooks/use-is-scrolling.hook.tsx
+++ b/application/ui/src/hooks/use-is-scrolling.hook.tsx
@@ -8,7 +8,7 @@ import { useEventListener } from './event-listener.hook';
 const IsScrollingContext = createContext(false);
 
 // `scrollend` is not implemented by every webview (notably WKWebView), so a timeout is used as fallback.
-const SCROLL_END_FALLBACK_MS = 150;
+export const SCROLL_END_FALLBACK_MS = 150;
 
 type IsScrollingProviderProps = {
     scrollRef: RefObject<HTMLElement | null>;

--- a/application/ui/src/index.css
+++ b/application/ui/src/index.css
@@ -141,3 +141,13 @@ svg {
         border-color: var(--spectrum-global-color-informative) !important;
     }
 }
+
+/* `Skeleton` from @geti-ui/ui sets `animation: shimmer`, but the package ships no keyframes. */
+@keyframes shimmer {
+    from {
+        background-position: 200% 0;
+    }
+    to {
+        background-position: -200% 0;
+    }
+}


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Revives https://github.com/open-edge-platform/geti/pull/7220 -> Adds a isScrollingProvider to make sure we only request thumbnails once the user stops scrolling

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
