### PR TITLE
Confidence threshold integration for prediction screen

### DIFF
--- a/application/ui/src/components/confidence-threshold/confidence-threshold.component.test.tsx
+++ b/application/ui/src/components/confidence-threshold/confidence-threshold.component.test.tsx
@@ -28,6 +28,26 @@ describe('ConfidenceThreshold', () => {
         expect(onChange).toHaveBeenCalledWith(0.8);
     });
 
+    it('does not call onChange while the user is still typing', async () => {
+        const onChange = vi.fn();
+        render(<ConfidenceThreshold value={0.65} defaultValue={0.65} onChange={onChange} />);
+
+        await userEvent.clear(getInput());
+        await userEvent.type(getInput(), '0.8');
+
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('commits the numeric input when Enter is pressed', async () => {
+        const onChange = vi.fn();
+        render(<ConfidenceThreshold value={0.65} defaultValue={0.65} onChange={onChange} />);
+
+        await userEvent.clear(getInput());
+        await userEvent.type(getInput(), '0.8{Enter}');
+
+        expect(onChange).toHaveBeenCalledExactlyOnceWith(0.8);
+    });
+
     it('restores the default value when reset is pressed', async () => {
         const onChange = vi.fn();
         render(<ConfidenceThreshold value={0.8} defaultValue={0.65} onChange={onChange} />);

--- a/application/ui/src/components/confidence-threshold/confidence-threshold.component.test.tsx
+++ b/application/ui/src/components/confidence-threshold/confidence-threshold.component.test.tsx
@@ -1,0 +1,45 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from 'test-utils/render';
+
+import { ConfidenceThreshold } from './confidence-threshold.component';
+
+const getInput = () => screen.getByRole('textbox', { name: 'Change Confidence threshold' });
+const getResetButton = () => screen.getByRole('button', { name: 'Reset confidence threshold' });
+
+describe('ConfidenceThreshold', () => {
+    it('renders the provided value', () => {
+        render(<ConfidenceThreshold value={0.65} defaultValue={0.65} onChange={vi.fn()} />);
+
+        expect(getInput()).toHaveValue('0.65');
+    });
+
+    it('calls onChange when the value is committed in the numeric input', async () => {
+        const onChange = vi.fn();
+        render(<ConfidenceThreshold value={0.65} defaultValue={0.65} onChange={onChange} />);
+
+        await userEvent.clear(getInput());
+        await userEvent.type(getInput(), '0.8');
+        await userEvent.tab();
+
+        expect(onChange).toHaveBeenCalledWith(0.8);
+    });
+
+    it('restores the default value when reset is pressed', async () => {
+        const onChange = vi.fn();
+        render(<ConfidenceThreshold value={0.8} defaultValue={0.65} onChange={onChange} />);
+
+        await userEvent.click(getResetButton());
+
+        expect(onChange).toHaveBeenCalledWith(0.65);
+    });
+
+    it('disables reset when the value already equals the default', () => {
+        render(<ConfidenceThreshold value={0.65} defaultValue={0.65} onChange={vi.fn()} />);
+
+        expect(getResetButton()).toBeDisabled();
+    });
+});

--- a/application/ui/src/components/confidence-threshold/confidence-threshold.component.tsx
+++ b/application/ui/src/components/confidence-threshold/confidence-threshold.component.tsx
@@ -7,7 +7,6 @@ import { ActionButton, Flex, NumberField, Slider, View } from '@geti-ui/ui';
 import { Refresh } from '@geti-ui/ui/icons';
 
 const THRESHOLD_CONFIG = {
-    defaultValue: 0.3,
     step: 0.001,
     min: 0,
     max: 1,
@@ -65,30 +64,36 @@ const ThresholdField = ({ onChange, value, isDisabled, name }: ThresholdFieldPro
 };
 
 type ConfidenceThresholdProps = {
+    value: number;
+    defaultValue: number;
+    onChange: (value: number) => void;
     isDisabled?: boolean;
     maxWidth?: string;
     width?: string;
 };
 
-export const ConfidenceThreshold = ({ isDisabled = false, maxWidth, width = '100%' }: ConfidenceThresholdProps) => {
-    // TODO: Default confidence threshold value will come from the server side
-    const defaultValue = THRESHOLD_CONFIG.defaultValue;
-    const [threshold, setThreshold] = useState<number>(defaultValue);
-
+export const ConfidenceThreshold = ({
+    value,
+    defaultValue,
+    onChange,
+    isDisabled = false,
+    maxWidth,
+    width = '100%',
+}: ConfidenceThresholdProps) => {
     return (
         <View maxWidth={maxWidth} width={width}>
             <Flex width={'100%'} justifyContent={'space-between'} gap={'size-175'} alignItems={'end'}>
                 <ThresholdField
-                    onChange={setThreshold}
+                    onChange={onChange}
                     name={'Confidence threshold'}
-                    value={threshold}
+                    value={value}
                     isDisabled={isDisabled}
                 />
                 <ActionButton
                     isQuiet
                     aria-label={'Reset confidence threshold'}
-                    onPress={() => setThreshold(defaultValue)}
-                    isDisabled={isDisabled}
+                    onPress={() => onChange(defaultValue)}
+                    isDisabled={isDisabled || value === defaultValue}
                 >
                     <Refresh />
                 </ActionButton>

--- a/application/ui/src/features/annotator/api/use-media-predictions.ts
+++ b/application/ui/src/features/annotator/api/use-media-predictions.ts
@@ -20,12 +20,14 @@ export const mediaPredictionsQueryOptions = ({
     selectedModel,
     mediaId,
     device,
+    confidenceThreshold,
     range = null,
 }: {
     projectId: string;
     selectedModel: SelectableModel | undefined;
     mediaId: string;
     device: string;
+    confidenceThreshold: number | null;
     range?: PredictionVideoRangePayload | null;
 }) =>
     queryOptions({
@@ -36,6 +38,7 @@ export const mediaPredictionsQueryOptions = ({
             device,
             selectedModel?.modelId,
             selectedModel?.modelVariantId,
+            confidenceThreshold,
             range,
         ],
         queryFn: async ({ signal }) => {
@@ -47,6 +50,7 @@ export const mediaPredictionsQueryOptions = ({
                 body: {
                     ...getModelIdentifierPayload(selectedModel),
                     device,
+                    confidence_threshold: confidenceThreshold,
                     media: [{ media_id: mediaId, range }],
                 },
             });
@@ -81,16 +85,25 @@ export const useMediaPredictions = ({
     selectedModel,
     range,
     device,
+    confidenceThreshold,
     enabled = true,
 }: {
     mediaId: string;
     selectedModel: SelectableModel | undefined;
     range?: PredictionVideoRangePayload | null;
     device: string;
+    confidenceThreshold: number | null;
     enabled?: boolean;
 }) => {
     const projectId = useProjectIdentifier();
-    const options = mediaPredictionsQueryOptions({ projectId, selectedModel, mediaId, range, device });
+    const options = mediaPredictionsQueryOptions({
+        projectId,
+        selectedModel,
+        mediaId,
+        range,
+        device,
+        confidenceThreshold,
+    });
 
     return useQuery({ ...options, enabled: options.enabled && enabled });
 };
@@ -99,21 +112,30 @@ export const useIsFetchingMediaPredictions = ({
     mediaId,
     selectedModel,
     device,
+    confidenceThreshold,
     range = null,
 }: {
     mediaId: string;
     selectedModel: SelectableModel | undefined;
     device: string;
+    confidenceThreshold: number | null;
     range?: PredictionVideoRangePayload | null;
 }) => {
     const projectId = useProjectIdentifier();
-    const { queryKey } = mediaPredictionsQueryOptions({ projectId, selectedModel, mediaId, device, range });
+    const { queryKey } = mediaPredictionsQueryOptions({
+        projectId,
+        selectedModel,
+        mediaId,
+        device,
+        confidenceThreshold,
+        range,
+    });
 
     return useIsFetching({ queryKey, exact: true }) > 0;
 };
 
 export const useIsFetchingCurrentRangeFramesPredictions = (mediaId: string) => {
-    const { selectedModel, selectedDevice } = usePredictionSetup();
+    const { selectedModel, selectedDevice, confidenceThreshold } = usePredictionSetup();
     const videoContext = useVideoPlayerContext();
 
     const frameNumber = videoContext?.videoFrame.frame_number ?? 0;
@@ -131,12 +153,13 @@ export const useIsFetchingCurrentRangeFramesPredictions = (mediaId: string) => {
         mediaId,
         selectedModel,
         device: selectedDevice,
+        confidenceThreshold,
         range: { stride: PREDICTION_FRAME_SKIP, start_frame: startFrameIndex, end_frame: endFrameIndex },
     });
 };
 
 const useIsFetchingCurrentFramePredictions = (mediaId: string) => {
-    const { selectedModel, selectedDevice } = usePredictionSetup();
+    const { selectedModel, selectedDevice, confidenceThreshold } = usePredictionSetup();
     const { mediaItem } = useSelectedMediaItem();
 
     const singleFrameRange = isVideoFrame(mediaItem)
@@ -147,6 +170,7 @@ const useIsFetchingCurrentFramePredictions = (mediaId: string) => {
         mediaId,
         selectedModel,
         device: selectedDevice,
+        confidenceThreshold,
         range: singleFrameRange,
     });
 };

--- a/application/ui/src/features/annotator/predictions-setup-provider.component.tsx
+++ b/application/ui/src/features/annotator/predictions-setup-provider.component.tsx
@@ -47,26 +47,6 @@ const useSelectedModelId = (models: Model[]) => {
     return useLocalStorage<string | null>(`${projectId}-model-variant-id`, defaultSelectedId);
 };
 
-// The threshold is a model specific parameter, so an edited value only applies to the model it was set for.
-const useConfidenceThreshold = (selectedModel: SelectableModel | undefined) => {
-    const [editedThreshold, setEditedThreshold] = useState<{ modelVariantId: string; value: number } | null>(null);
-
-    const confidenceThreshold =
-        editedThreshold !== null && editedThreshold.modelVariantId === selectedModel?.modelVariantId
-            ? editedThreshold.value
-            : (selectedModel?.optimalConfidenceThreshold ?? null);
-
-    const changeConfidenceThreshold = (value: number) => {
-        if (selectedModel === undefined) {
-            return;
-        }
-
-        setEditedThreshold({ modelVariantId: selectedModel.modelVariantId, value });
-    };
-
-    return [confidenceThreshold, changeConfidenceThreshold] as const;
-};
-
 export const PredictionsSetupProvider = ({ children }: { children: ReactNode }) => {
     const { data: models } = useGetSuccessfulModels();
 
@@ -76,7 +56,18 @@ export const PredictionsSetupProvider = ({ children }: { children: ReactNode }) 
 
     const selectedModel = selectableModels.find((model) => model.modelVariantId === selectedModelId);
 
-    const [confidenceThreshold, changeConfidenceThreshold] = useConfidenceThreshold(selectedModel);
+    const [confidenceThreshold, setConfidenceThreshold] = useState<number | null>(
+        selectedModel?.optimalConfidenceThreshold ?? null
+    );
+
+    // The threshold is a model specific parameter, so it always follows the selected model
+    const changeSelectedModelId = (modelId: string | null) => {
+        setSelectedModelId(modelId);
+
+        const newModel = selectableModels.find((model) => model.modelVariantId === modelId);
+
+        setConfidenceThreshold(newModel?.optimalConfidenceThreshold ?? null);
+    };
 
     const { data: pipeline } = usePipeline();
 
@@ -87,12 +78,12 @@ export const PredictionsSetupProvider = ({ children }: { children: ReactNode }) 
             value={{
                 selectedModelId,
                 selectedModel,
-                changeSelectedModelId: setSelectedModelId,
+                changeSelectedModelId,
                 selectableModels,
                 selectedDevice,
                 changeSelectedDevice: setSelectedDevice,
                 confidenceThreshold,
-                changeConfidenceThreshold,
+                changeConfidenceThreshold: setConfidenceThreshold,
             }}
         >
             {children}

--- a/application/ui/src/features/annotator/predictions-setup-provider.component.tsx
+++ b/application/ui/src/features/annotator/predictions-setup-provider.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
+import { createContext, ReactNode, useContext, useMemo, useRef, useState } from 'react';
 
 import type { Model } from '@/api/types';
 import { usePipeline } from 'hooks/api/pipeline.hook';
@@ -21,6 +21,9 @@ type PredictionsSetupContextProps = {
 
     selectedDevice: string;
     changeSelectedDevice: (device: string) => void;
+
+    confidenceThreshold: number | null;
+    changeConfidenceThreshold: (confidenceThreshold: number) => void;
 };
 
 const PredictionSetupContext = createContext<PredictionsSetupContextProps | null>(null);
@@ -44,6 +47,20 @@ const useSelectedModelId = (models: Model[]) => {
     return useLocalStorage<string | null>(`${projectId}-model-variant-id`, defaultSelectedId);
 };
 
+// The threshold is a model specific parameter, so selecting another model always resets to that model's value.
+const useConfidenceThreshold = (selectedModel: SelectableModel | undefined) => {
+    const optimalConfidenceThreshold = selectedModel?.optimalConfidenceThreshold ?? null;
+    const [confidenceThreshold, setConfidenceThreshold] = useState<number | null>(optimalConfidenceThreshold);
+    const previousModelVariantIdRef = useRef(selectedModel?.modelVariantId);
+
+    if (previousModelVariantIdRef.current !== selectedModel?.modelVariantId) {
+        previousModelVariantIdRef.current = selectedModel?.modelVariantId;
+        setConfidenceThreshold(optimalConfidenceThreshold);
+    }
+
+    return [confidenceThreshold, setConfidenceThreshold] as const;
+};
+
 export const PredictionsSetupProvider = ({ children }: { children: ReactNode }) => {
     const { data: models } = useGetSuccessfulModels();
 
@@ -52,6 +69,8 @@ export const PredictionsSetupProvider = ({ children }: { children: ReactNode }) 
     const [selectedModelId, setSelectedModelId] = useSelectedModelId(models);
 
     const selectedModel = selectableModels.find((model) => model.modelVariantId === selectedModelId);
+
+    const [confidenceThreshold, setConfidenceThreshold] = useConfidenceThreshold(selectedModel);
 
     const { data: pipeline } = usePipeline();
 
@@ -66,6 +85,8 @@ export const PredictionsSetupProvider = ({ children }: { children: ReactNode }) 
                 selectableModels,
                 selectedDevice,
                 changeSelectedDevice: setSelectedDevice,
+                confidenceThreshold,
+                changeConfidenceThreshold: setConfidenceThreshold,
             }}
         >
             {children}

--- a/application/ui/src/features/annotator/predictions-setup-provider.component.tsx
+++ b/application/ui/src/features/annotator/predictions-setup-provider.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { createContext, ReactNode, useContext, useMemo, useRef, useState } from 'react';
+import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
 
 import type { Model } from '@/api/types';
 import { usePipeline } from 'hooks/api/pipeline.hook';
@@ -47,18 +47,24 @@ const useSelectedModelId = (models: Model[]) => {
     return useLocalStorage<string | null>(`${projectId}-model-variant-id`, defaultSelectedId);
 };
 
-// The threshold is a model specific parameter, so selecting another model always resets to that model's value.
+// The threshold is a model specific parameter, so an edited value only applies to the model it was set for.
 const useConfidenceThreshold = (selectedModel: SelectableModel | undefined) => {
-    const optimalConfidenceThreshold = selectedModel?.optimalConfidenceThreshold ?? null;
-    const [confidenceThreshold, setConfidenceThreshold] = useState<number | null>(optimalConfidenceThreshold);
-    const previousModelVariantIdRef = useRef(selectedModel?.modelVariantId);
+    const [editedThreshold, setEditedThreshold] = useState<{ modelVariantId: string; value: number } | null>(null);
 
-    if (previousModelVariantIdRef.current !== selectedModel?.modelVariantId) {
-        previousModelVariantIdRef.current = selectedModel?.modelVariantId;
-        setConfidenceThreshold(optimalConfidenceThreshold);
-    }
+    const confidenceThreshold =
+        editedThreshold !== null && editedThreshold.modelVariantId === selectedModel?.modelVariantId
+            ? editedThreshold.value
+            : (selectedModel?.optimalConfidenceThreshold ?? null);
 
-    return [confidenceThreshold, setConfidenceThreshold] as const;
+    const changeConfidenceThreshold = (value: number) => {
+        if (selectedModel === undefined) {
+            return;
+        }
+
+        setEditedThreshold({ modelVariantId: selectedModel.modelVariantId, value });
+    };
+
+    return [confidenceThreshold, changeConfidenceThreshold] as const;
 };
 
 export const PredictionsSetupProvider = ({ children }: { children: ReactNode }) => {
@@ -70,7 +76,7 @@ export const PredictionsSetupProvider = ({ children }: { children: ReactNode }) 
 
     const selectedModel = selectableModels.find((model) => model.modelVariantId === selectedModelId);
 
-    const [confidenceThreshold, setConfidenceThreshold] = useConfidenceThreshold(selectedModel);
+    const [confidenceThreshold, changeConfidenceThreshold] = useConfidenceThreshold(selectedModel);
 
     const { data: pipeline } = usePipeline();
 
@@ -86,7 +92,7 @@ export const PredictionsSetupProvider = ({ children }: { children: ReactNode }) 
                 selectedDevice,
                 changeSelectedDevice: setSelectedDevice,
                 confidenceThreshold,
-                changeConfidenceThreshold: setConfidenceThreshold,
+                changeConfidenceThreshold,
             }}
         >
             {children}

--- a/application/ui/src/features/annotator/video-player/api/use-video-frames-predictions.ts
+++ b/application/ui/src/features/annotator/video-player/api/use-video-frames-predictions.ts
@@ -26,7 +26,7 @@ const useVideoFramesPredictionsQueryOptions = ({
 }) => {
     const projectId = useProjectIdentifier();
     const { videoFrame } = useVideoPlayer();
-    const { selectedModel, selectedDevice } = usePredictionSetup();
+    const { selectedModel, selectedDevice, confidenceThreshold } = usePredictionSetup();
 
     const { startFrameIndex, endFrameIndex } = getVideoFrameRangeIndexes({
         frames: videoFrame.frame_count - 1,
@@ -39,6 +39,7 @@ const useVideoFramesPredictionsQueryOptions = ({
         projectId,
         selectedModel,
         device: selectedDevice,
+        confidenceThreshold,
         mediaId: videoFrame.id,
         range: { stride: rangeStride ?? frameSkip, start_frame: startFrameIndex, end_frame: endFrameIndex },
     });

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -102,13 +102,14 @@ const MediaPreviewContent = ({
     isMediaItemReviewedById,
 }: MediaPreviewContentProps) => {
     const { mediaItem } = useSelectedMediaItem();
-    const { selectedModel, selectedDevice } = usePredictionSetup();
+    const { selectedModel, selectedDevice, confidenceThreshold } = usePredictionSetup();
 
     const { data: annotationsData } = useAnnotationsQuery(mediaItem);
     const { data: predictionsData } = useMediaPredictions({
         mediaId: mediaItem.id,
         selectedModel,
         device: selectedDevice,
+        confidenceThreshold,
         range: isVideoFrame(mediaItem)
             ? { start_frame: mediaItem.frame_number, end_frame: mediaItem.frame_number, stride: mediaItem.frame_stride }
             : null,

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/prediction-confidence-threshold/prediction-confidence-threshold.component.test.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/prediction-confidence-threshold/prediction-confidence-threshold.component.test.tsx
@@ -1,0 +1,107 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Model } from '@/api/types';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { getMockedModel } from 'mocks/mock-model';
+import { getMockedVariant } from 'mocks/mock-model-variant';
+import { getMockedPipeline } from 'mocks/mock-pipeline';
+import { HttpResponse } from 'msw';
+import { render } from 'test-utils/render';
+
+import { http } from '../../../../../api/utils';
+import { server } from '../../../../../msw-node-setup';
+import { PredictionsSetupProvider } from '../../../../annotator/predictions-setup-provider.component';
+import { PredictionModelSelector } from '../prediction-model-selector/prediction-model-selector.component';
+import { PredictionConfidenceThreshold } from './prediction-confidence-threshold.component';
+
+const modelA = getMockedModel({
+    id: 'model-a',
+    name: 'Model A',
+    variants: [
+        getMockedVariant({
+            id: 'variant-a',
+            format: 'openvino',
+            precision: 'fp16',
+            optimal_confidence_threshold: 0.65,
+        }),
+    ],
+});
+
+const modelB = getMockedModel({
+    id: 'model-b',
+    name: 'Model B',
+    variants: [
+        getMockedVariant({
+            id: 'variant-b',
+            format: 'openvino',
+            precision: 'fp32',
+            optimal_confidence_threshold: 0.2,
+        }),
+    ],
+});
+
+const getInput = () => screen.getByRole('textbox', { name: 'Change Confidence threshold' });
+
+const renderApp = async (models: Model[]) => {
+    server.use(
+        http.get('/api/projects/{project_id}/models', () => HttpResponse.json(models)),
+        http.get('/api/projects/{project_id}/pipeline', () => HttpResponse.json(getMockedPipeline()))
+    );
+
+    render(
+        <PredictionsSetupProvider>
+            <PredictionModelSelector isDisabled={false} />
+            <PredictionConfidenceThreshold />
+        </PredictionsSetupProvider>
+    );
+
+    await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Select prediction model/ })).toBeInTheDocument();
+    });
+};
+
+const selectModel = async (name: string) => {
+    await userEvent.click(screen.getByRole('button', { name: /Select prediction model/ }));
+    await userEvent.click(await screen.findByRole('option', { name }));
+};
+
+describe('PredictionConfidenceThreshold', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    it("shows the selected model variant's optimal confidence threshold", async () => {
+        await renderApp([modelA]);
+
+        expect(getInput()).toHaveValue('0.65');
+    });
+
+    it('is not rendered when the selected model variant has no optimal confidence threshold', async () => {
+        const modelWithoutThreshold = getMockedModel({
+            id: 'model-c',
+            name: 'Model C',
+            variants: [getMockedVariant({ id: 'variant-c', optimal_confidence_threshold: null })],
+        });
+
+        await renderApp([modelWithoutThreshold]);
+
+        expect(screen.queryByRole('textbox', { name: 'Change Confidence threshold' })).not.toBeInTheDocument();
+    });
+
+    it('resets to the optimal confidence threshold of the newly selected model', async () => {
+        await renderApp([modelA, modelB]);
+
+        await selectModel('Model B [FP32]');
+        expect(getInput()).toHaveValue('0.2');
+
+        await userEvent.clear(getInput());
+        await userEvent.type(getInput(), '0.9');
+        await userEvent.tab();
+        expect(getInput()).toHaveValue('0.9');
+
+        await selectModel('Model A [FP16]');
+        expect(getInput()).toHaveValue('0.65');
+    });
+});

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/prediction-confidence-threshold/prediction-confidence-threshold.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/prediction-confidence-threshold/prediction-confidence-threshold.component.tsx
@@ -1,0 +1,29 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { ConfidenceThreshold } from '../../../../../components/confidence-threshold/confidence-threshold.component';
+import { usePredictionSetup } from '../../../../annotator/predictions-setup-provider.component';
+
+type PredictionConfidenceThresholdProps = {
+    isDisabled?: boolean;
+};
+
+export const PredictionConfidenceThreshold = ({ isDisabled }: PredictionConfidenceThresholdProps) => {
+    const { selectedModel, confidenceThreshold, changeConfidenceThreshold } = usePredictionSetup();
+
+    const defaultValue = selectedModel?.optimalConfidenceThreshold ?? null;
+
+    // Models whose task does not use a confidence threshold have no optimal value
+    if (defaultValue === null || confidenceThreshold === null) {
+        return null;
+    }
+
+    return (
+        <ConfidenceThreshold
+            value={confidenceThreshold}
+            defaultValue={defaultValue}
+            onChange={changeConfidenceThreshold}
+            isDisabled={isDisabled}
+        />
+    );
+};

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
@@ -22,7 +22,6 @@ import { useProject } from 'hooks/api/project.hook';
 import { isEmpty } from 'lodash-es';
 import { useHotkeys } from 'react-hotkeys-hook';
 
-import { ConfidenceThreshold } from '../../../../components/confidence-threshold/confidence-threshold.component';
 import { FEATURE_FLAGS } from '../../../../constants/feature-flags';
 import { useAnnotationActions } from '../../../../shared/annotator/annotation-actions-provider.component';
 import type { AnnotatorMode } from '../../../../shared/annotator/annotator-mode';
@@ -35,6 +34,7 @@ import { isClassificationTask, isMultiLabelClassificationTask } from '../../../p
 import { DeleteMediaItem } from '../../gallery/delete-media-item/delete-media-item.component';
 import { Toolbar } from '../toolbar-container/toolbar-container.component';
 import { AnnotatorModes } from './annotator-modes/annotator-modes-toggle.component';
+import { PredictionConfidenceThreshold } from './prediction-confidence-threshold/prediction-confidence-threshold.component';
 import { PredictionInferenceDevices } from './prediction-inference-devices/prediction-inference-devices.component';
 import { PredictionModelSelector } from './prediction-model-selector/prediction-model-selector.component';
 import { PredictionButtons } from './predictions-buttons.component';
@@ -100,7 +100,9 @@ const PredictionActions = ({ isDisabled }: { isDisabled: boolean }) => {
                     <Flex gap={'size-300'} direction={'column'}>
                         <PredictionModelSelector isDisabled={isDisabled} />
                         <PredictionInferenceDevices isDisabled={isDisabled} />
-                        {FEATURE_FLAGS.CONFIDENCE_THRESHOLD && <ConfidenceThreshold isDisabled={isDisabled} />}
+                        {FEATURE_FLAGS.CONFIDENCE_THRESHOLD && (
+                            <PredictionConfidenceThreshold isDisabled={isDisabled} />
+                        )}
                     </Flex>
                 </Content>
             </Dialog>

--- a/application/ui/src/features/dataset/media-preview/use-next-prediction-prefetch.hook.ts
+++ b/application/ui/src/features/dataset/media-preview/use-next-prediction-prefetch.hook.ts
@@ -11,7 +11,7 @@ import { usePredictionSetup } from '../../annotator/predictions-setup-provider.c
 
 export const useNextPredictionPrefetch = (nextMediaItem: Media) => {
     const projectId = useProjectIdentifier();
-    const { selectedModel, selectedDevice } = usePredictionSetup();
+    const { selectedModel, selectedDevice, confidenceThreshold } = usePredictionSetup();
 
     const range = isVideoFrame(nextMediaItem)
         ? {
@@ -27,6 +27,7 @@ export const useNextPredictionPrefetch = (nextMediaItem: Media) => {
             selectedModel,
             mediaId: nextMediaItem.id,
             device: selectedDevice,
+            confidenceThreshold,
             range,
         })
     );

--- a/application/ui/src/features/inference/aside/pipeline-configuration.component.tsx
+++ b/application/ui/src/features/inference/aside/pipeline-configuration.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { ReactNode, Suspense } from 'react';
+import { ReactNode, Suspense, useState } from 'react';
 
 import { Flex, Item, Loading, TabList, TabPanels, Tabs, Text, View } from '@geti-ui/ui';
 
@@ -19,6 +19,16 @@ const ConfigurationItem = ({ children }: { children: ReactNode }) => {
     );
 };
 
+// TODO: read the value from `inference.confidence_threshold` and persist it through `PATCH /pipeline`
+const PipelineConfidenceThreshold = () => {
+    const FALLBACK_CONFIDENCE_THRESHOLD = 0.3;
+    const [threshold, setThreshold] = useState(FALLBACK_CONFIDENCE_THRESHOLD);
+
+    return (
+        <ConfidenceThreshold value={threshold} defaultValue={FALLBACK_CONFIDENCE_THRESHOLD} onChange={setThreshold} />
+    );
+};
+
 export const PipelineConfiguration = () => {
     return (
         <Flex direction={'column'} gap={'size-150'} minHeight={0}>
@@ -26,7 +36,7 @@ export const PipelineConfiguration = () => {
                 <StreamInferenceDevices />
             </Suspense>
 
-            {FEATURE_FLAGS.CONFIDENCE_THRESHOLD && <ConfidenceThreshold />}
+            {FEATURE_FLAGS.CONFIDENCE_THRESHOLD && <PipelineConfidenceThreshold />}
 
             <Tabs
                 aria-label={'Pipeline configuration tabs'}

--- a/application/ui/src/features/models/model-listing/model-training-datasets/subset-media-dialog.component.test.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/subset-media-dialog.component.test.tsx
@@ -43,6 +43,7 @@ const selectableModel: SelectableModel = {
     modelId: 'model-1',
     modelVariantId: 'variant-1',
     name: 'Model [FP16]',
+    optimalConfidenceThreshold: 0.65,
 };
 
 const PREDICTION_DELAY_MS = 500;

--- a/application/ui/src/features/models/model-listing/model-training-datasets/subset-media-dialog.component.tsx
+++ b/application/ui/src/features/models/model-listing/model-training-datasets/subset-media-dialog.component.tsx
@@ -52,6 +52,7 @@ const SubsetMediaDialogContent = ({
         mediaId: mediaItem.id,
         selectedModel,
         device: pipeline.device,
+        confidenceThreshold: selectedModel?.optimalConfidenceThreshold ?? null,
         range: null,
     });
 
@@ -59,6 +60,7 @@ const SubsetMediaDialogContent = ({
         mediaId: mediaItem.id,
         selectedModel,
         device: pipeline.device,
+        confidenceThreshold: selectedModel?.optimalConfidenceThreshold ?? null,
         range: null,
     });
 

--- a/application/ui/src/features/models/utils.test.ts
+++ b/application/ui/src/features/models/utils.test.ts
@@ -84,7 +84,7 @@ describe('getAllModelsWithOpenVINOVariants', () => {
         });
 
         expect(getAllModelsWithOpenVINOVariants([model])).toEqual([
-            { modelVariantId: 'v-ov', name: 'My Model [FP16]', modelId: 'model-1' },
+            { modelVariantId: 'v-ov', name: 'My Model [FP16]', modelId: 'model-1', optimalConfidenceThreshold: 0.65 },
         ]);
     });
 
@@ -100,9 +100,9 @@ describe('getAllModelsWithOpenVINOVariants', () => {
         });
 
         expect(getAllModelsWithOpenVINOVariants([model])).toEqual([
-            { modelVariantId: 'v-fp16', name: 'My Model [FP16]', modelId: 'model-1' },
-            { modelVariantId: 'v-fp32', name: 'My Model [FP32]', modelId: 'model-1' },
-            { modelVariantId: 'v-int8', name: 'My Model [INT8]', modelId: 'model-1' },
+            { modelVariantId: 'v-fp16', name: 'My Model [FP16]', modelId: 'model-1', optimalConfidenceThreshold: 0.65 },
+            { modelVariantId: 'v-fp32', name: 'My Model [FP32]', modelId: 'model-1', optimalConfidenceThreshold: 0.65 },
+            { modelVariantId: 'v-int8', name: 'My Model [INT8]', modelId: 'model-1', optimalConfidenceThreshold: 0.65 },
         ]);
     });
 
@@ -117,7 +117,7 @@ describe('getAllModelsWithOpenVINOVariants', () => {
         });
 
         expect(getAllModelsWithOpenVINOVariants([model])).toEqual([
-            { modelVariantId: 'v-ov', name: 'My Model [FP16]', modelId: 'model-1' },
+            { modelVariantId: 'v-ov', name: 'My Model [FP16]', modelId: 'model-1', optimalConfidenceThreshold: 0.65 },
         ]);
     });
 
@@ -138,16 +138,31 @@ describe('getAllModelsWithOpenVINOVariants', () => {
         });
 
         expect(getAllModelsWithOpenVINOVariants([modelA, modelB, modelC])).toEqual([
-            { modelVariantId: 'v-a-ov', name: 'Model A [FP16]', modelId: 'model-a' },
-            { modelVariantId: 'v-c-fp32', name: 'Model C [FP32]', modelId: 'model-c' },
-            { modelVariantId: 'v-c-int8', name: 'Model C [INT8]', modelId: 'model-c' },
+            { modelVariantId: 'v-a-ov', name: 'Model A [FP16]', modelId: 'model-a', optimalConfidenceThreshold: 0.65 },
+            {
+                modelVariantId: 'v-c-fp32',
+                name: 'Model C [FP32]',
+                modelId: 'model-c',
+                optimalConfidenceThreshold: 0.65,
+            },
+            {
+                modelVariantId: 'v-c-int8',
+                name: 'Model C [INT8]',
+                modelId: 'model-c',
+                optimalConfidenceThreshold: 0.65,
+            },
         ]);
     });
 });
 
 describe('getModelIdentifierPayload', () => {
     it('returns both model_id (parent) and model_variant_id', () => {
-        const model: SelectableModel = { modelVariantId: 'v-ov', name: 'My Model [FP16]', modelId: 'model-1' };
+        const model: SelectableModel = {
+            modelVariantId: 'v-ov',
+            name: 'My Model [FP16]',
+            modelId: 'model-1',
+            optimalConfidenceThreshold: 0.65,
+        };
 
         expect(getModelIdentifierPayload(model)).toEqual({ model_id: 'model-1', model_variant_id: 'v-ov' });
     });

--- a/application/ui/src/features/models/utils.ts
+++ b/application/ui/src/features/models/utils.ts
@@ -3,7 +3,12 @@
 
 import type { Model } from '@/api/types';
 
-export type SelectableModel = { modelVariantId: string; name: string; modelId: string };
+export type SelectableModel = {
+    modelVariantId: string;
+    name: string;
+    modelId: string;
+    optimalConfidenceThreshold: number | null;
+};
 
 export const getModelIdentifierPayload = (model: SelectableModel): { model_id: string; model_variant_id: string } => ({
     model_id: model.modelId,
@@ -43,6 +48,7 @@ export const getAllModelsWithOpenVINOVariants = (models: Model[]): SelectableMod
                 modelVariantId: variant.id,
                 modelId: model.id,
                 name: `${model.name} [${variant.precision.toUpperCase()}]`,
+                optimalConfidenceThreshold: variant.optimal_confidence_threshold ?? null,
             }))
     );
 };


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Update hooks/ui/mocks with new parameter
* Add new PredictionConfidenceThreshold (we hide the slider if the model has no optimal confidence threshold)
* Add tests
* Closes https://github.com/open-edge-platform/geti/issues/7122

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
