### PR TITLE
feat(ui, dataset views): Minor UX improvements

### DIFF
--- a/application/ui/src/features/dataset/gallery/empty-dataset.component.tsx
+++ b/application/ui/src/features/dataset/gallery/empty-dataset.component.tsx
@@ -1,10 +1,14 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { ReactNode } from 'react';
+
 import { Button, Flex, Heading } from '@geti-ui/ui';
+import { ENTIRE_DATASET_VIEW_ID, useDatasetViewId } from 'hooks/use-dataset-view-id.hook';
 
 import { ReactComponent as EmptyDatasetImage } from '../../../assets/empty-dataset.svg';
 import { useImportDatasetDialogState } from '../providers/export-import-dataset-dialog-provider.component';
+import { ENTIRE_DATASET_NAME } from './toolbar/dataset-view-selector/util';
 import { MediaUpload } from './toolbar/media-upload.component';
 
 const ImportDatasetButton = () => {
@@ -17,34 +21,80 @@ const ImportDatasetButton = () => {
     );
 };
 
+const EmptyMessage = ({ children }: { children: ReactNode }) => {
+    return (
+        <Heading level={2} UNSAFE_style={{ textAlign: 'center' }}>
+            {children}
+        </Heading>
+    );
+};
+
+const NoMatchingMediaItems = () => {
+    return (
+        <EmptyMessage>
+            No media items match your filter.
+            <br />
+            Remove or select a new filter.
+        </EmptyMessage>
+    );
+};
+
+const EmptyDatasetView = () => {
+    const [, setDatasetViewId] = useDatasetViewId();
+
+    return (
+        <>
+            <EmptyMessage>
+                This view has no media items.
+                <br />
+                Assign media items to it, or go back to the entire dataset.
+            </EmptyMessage>
+            <Button variant={'secondary'} onPress={() => setDatasetViewId(ENTIRE_DATASET_VIEW_ID)}>
+                {`Go to ${ENTIRE_DATASET_NAME}`}
+            </Button>
+        </>
+    );
+};
+
+const EmptyEntireDataset = () => {
+    return (
+        <>
+            <EmptyMessage>
+                Your dataset is empty.
+                <br />
+                Upload your first media item to get started.
+            </EmptyMessage>
+            <Flex gap={'size-100'}>
+                <MediaUpload />
+                <ImportDatasetButton />
+            </Flex>
+        </>
+    );
+};
+
 type EmptyDatasetProps = {
     hasActiveFilter: boolean;
 };
+
+const EmptyDatasetContent = ({ hasActiveFilter }: EmptyDatasetProps) => {
+    const [datasetViewId] = useDatasetViewId();
+
+    if (hasActiveFilter) {
+        return <NoMatchingMediaItems />;
+    }
+
+    if (datasetViewId !== ENTIRE_DATASET_VIEW_ID) {
+        return <EmptyDatasetView />;
+    }
+
+    return <EmptyEntireDataset />;
+};
+
 export const EmptyDataset = ({ hasActiveFilter }: EmptyDatasetProps) => {
     return (
         <Flex direction={'column'} gap={'size-200'} alignItems={'center'} justifyContent={'center'} height={'100%'}>
             <EmptyDatasetImage />
-            <Heading level={2} UNSAFE_style={{ textAlign: 'center' }}>
-                {hasActiveFilter ? (
-                    <>
-                        No media items match your filter.
-                        <br />
-                        Remove or select a new filter.
-                    </>
-                ) : (
-                    <>
-                        Your dataset is empty.
-                        <br />
-                        Upload your first media item to get started.
-                    </>
-                )}
-            </Heading>
-            {!hasActiveFilter && (
-                <Flex gap={'size-100'}>
-                    <MediaUpload />
-                    <ImportDatasetButton />
-                </Flex>
-            )}
+            <EmptyDatasetContent hasActiveFilter={hasActiveFilter} />
         </Flex>
     );
 };

--- a/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/dataset-view-selector.component.test.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/dataset-view-selector.component.test.tsx
@@ -95,6 +95,32 @@ describe('DatasetViewSelector', () => {
         await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
     });
 
+    it('closes the popover when the user selects the already selected view', async () => {
+        const user = userEvent.setup();
+        renderDatasetViewSelector(`/projects/123?${DATASET_VIEW_ID_PARAM}=collection-one`);
+
+        await openDatasetViewSelector(user);
+        await user.click(screen.getByRole('listitem', { name: 'Collection One' }));
+
+        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+        expect(screen.getByTestId('search-params-spy')).toHaveTextContent(`${DATASET_VIEW_ID_PARAM}=collection-one`);
+    });
+
+    it('keeps the selected view when the user cancels the delete confirmation', async () => {
+        const user = userEvent.setup();
+        renderDatasetViewSelector(`/projects/123?${DATASET_VIEW_ID_PARAM}=collection-one`);
+
+        await openDatasetViewSelector(user);
+        await user.click(screen.getByRole('button', { name: 'Dataset view actions for Collection One' }));
+        await user.click(screen.getByRole('menuitem', { name: 'Delete' }));
+
+        await user.click(await screen.findByRole('button', { name: 'Close' }));
+
+        await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument());
+        expect(screen.getByTestId('search-params-spy')).toHaveTextContent(`${DATASET_VIEW_ID_PARAM}=collection-one`);
+        expect(screen.getByRole('button', { name: 'Select dataset view' })).toHaveTextContent('Collection One');
+    });
+
     it('falls back to "Entire dataset" and strips an unknown datasetViewId param', async () => {
         renderDatasetViewSelector(`/projects/123?${DATASET_VIEW_ID_PARAM}=unknown-view-id`);
 

--- a/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/dataset-view-selector.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/dataset-view-selector.component.tsx
@@ -75,10 +75,14 @@ export const DatasetViewSelector = ({ datasetViews, resetSelectedMediaIds }: Dat
         setDatasetViewToBeRenamed(datasetView);
     };
 
-    const handleCloseDeleteDialog = () => {
+    const handleDeleteSuccess = () => {
         if (datasetViewToBeDeleted?.id === datasetViewId) {
             setDatasetViewId(ENTIRE_DATASET_VIEW_ID);
         }
+        setDatasetViewToBeDeleted(null);
+    };
+
+    const handleCancelDelete = () => {
         setDatasetViewToBeDeleted(null);
     };
 
@@ -96,10 +100,11 @@ export const DatasetViewSelector = ({ datasetViews, resetSelectedMediaIds }: Dat
     }, [datasetViewId, datasetViews, setDatasetViewId]);
 
     const selectDatasetView = (id: string | null) => {
+        setIsDatasetViewSelectorOpen(false);
+
         if (id === datasetViewId) return;
 
         setDatasetViewId(id);
-        setIsDatasetViewSelectorOpen(false);
         resetSelectedMediaIds();
     };
 
@@ -131,9 +136,13 @@ export const DatasetViewSelector = ({ datasetViews, resetSelectedMediaIds }: Dat
                 </Dialog>
             </DialogTrigger>
 
-            <DialogContainer onDismiss={handleCloseDeleteDialog}>
+            <DialogContainer onDismiss={handleCancelDelete}>
                 {datasetViewToBeDeleted !== null && (
-                    <DeleteDatasetViewDialog datasetView={datasetViewToBeDeleted} onClose={handleCloseDeleteDialog} />
+                    <DeleteDatasetViewDialog
+                        datasetView={datasetViewToBeDeleted}
+                        onSuccess={handleDeleteSuccess}
+                        onCancel={handleCancelDelete}
+                    />
                 )}
             </DialogContainer>
             <DialogContainer onDismiss={handleCloseRenameDialog}>

--- a/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/dataset-view-selector.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/dataset-view-selector.component.tsx
@@ -75,7 +75,7 @@ export const DatasetViewSelector = ({ datasetViews, resetSelectedMediaIds }: Dat
         setDatasetViewToBeRenamed(datasetView);
     };
 
-    const handleDeleteSuccess = () => {
+    const handleDelete = () => {
         if (datasetViewToBeDeleted?.id === datasetViewId) {
             setDatasetViewId(ENTIRE_DATASET_VIEW_ID);
         }
@@ -140,7 +140,7 @@ export const DatasetViewSelector = ({ datasetViews, resetSelectedMediaIds }: Dat
                 {datasetViewToBeDeleted !== null && (
                     <DeleteDatasetViewDialog
                         datasetView={datasetViewToBeDeleted}
-                        onSuccess={handleDeleteSuccess}
+                        onSuccess={handleDelete}
                         onCancel={handleCancelDelete}
                     />
                 )}

--- a/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/delete-dataset-view.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/delete-dataset-view.component.tsx
@@ -11,7 +11,8 @@ import { DatasetView } from './type';
 
 type DeleteDatasetViewDialogProps = {
     datasetView: DatasetView;
-    onClose: () => void;
+    onSuccess: () => void;
+    onCancel: () => void;
 };
 
 const useDeleteDatasetView = () => {
@@ -44,11 +45,11 @@ const useDeleteDatasetView = () => {
     };
 };
 
-export const DeleteDatasetViewDialog = ({ datasetView, onClose }: DeleteDatasetViewDialogProps) => {
+export const DeleteDatasetViewDialog = ({ datasetView, onSuccess, onCancel }: DeleteDatasetViewDialogProps) => {
     const { deleteDatasetView, isPending } = useDeleteDatasetView();
 
     const deleteView = () => {
-        deleteDatasetView({ datasetViewId: datasetView.id, onSuccess: onClose });
+        deleteDatasetView({ datasetViewId: datasetView.id, onSuccess });
     };
 
     return (
@@ -57,7 +58,7 @@ export const DeleteDatasetViewDialog = ({ datasetView, onClose }: DeleteDatasetV
             primaryActionLabel={'Delete'}
             variant={'destructive'}
             onPrimaryAction={deleteView}
-            onCancel={onClose}
+            onCancel={onCancel}
             secondaryActionLabel={'Close'}
             isPrimaryActionDisabled={isPending}
         >

--- a/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/rename-dataset-view.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/rename-dataset-view.component.tsx
@@ -9,6 +9,7 @@ import { isEmpty } from 'lodash-es';
 
 import { useRenameDatasetViewMutation } from './api/use-rename-dataset-view-mutation';
 import { DatasetView } from './type';
+import { DUPLICATE_DATASET_VIEW_NAME_ERROR } from './util';
 
 type RenameDatasetViewProps = {
     datasetView: DatasetView;
@@ -58,7 +59,7 @@ export const RenameDatasetView = ({ datasetView, onClose, datasetViews }: Rename
                         onChange={setNewName}
                         label={'View name'}
                         validationState={isDuplicateName ? 'invalid' : undefined}
-                        errorMessage={isDuplicateName ? 'A dataset view with this name already exists' : undefined}
+                        errorMessage={isDuplicateName ? DUPLICATE_DATASET_VIEW_NAME_ERROR : undefined}
                     />
                 </Form>
             </Content>

--- a/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/save-dataset-view/save-dataset-view.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/save-dataset-view/save-dataset-view.component.tsx
@@ -11,6 +11,7 @@ import { isEmpty } from 'lodash-es';
 import { useCreateDatasetViewMutation } from '../api/use-create-dataset-view';
 import { SelectedMediaCount } from '../selected-media-count/selected-media-count.component';
 import { DatasetView } from '../type';
+import { DUPLICATE_DATASET_VIEW_NAME_ERROR } from '../util';
 
 type SaveDatasetViewDialogProps = {
     onClose: (datasetViewId?: string) => void;
@@ -63,7 +64,7 @@ const SaveDatasetViewDialog = ({ onClose, selectedMediaIds, datasetViews }: Save
                         value={viewName}
                         onChange={setViewName}
                         validationState={isDuplicatedName ? 'invalid' : undefined}
-                        errorMessage={isDuplicatedName ? 'A view with this name already exists.' : undefined}
+                        errorMessage={isDuplicatedName ? DUPLICATE_DATASET_VIEW_NAME_ERROR : undefined}
                     />
                 </Form>
             </Content>

--- a/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/util.ts
+++ b/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/util.ts
@@ -2,3 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export const ENTIRE_DATASET_NAME = 'Entire dataset';
+
+export const DUPLICATE_DATASET_VIEW_NAME_ERROR = 'A view with this name already exists.';


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

1. Cancelling delete no longer navigates away.
2. Empty view shows view-specific copy.
3. Re-selecting the current view closes the popover. selectDatasetView closes first, then early-returns for the state changes.
4. One duplicate-name error string.

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
