### PR TITLE
Bugfix: model size cache returned stale value computed before training

### DIFF
--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -95,9 +95,13 @@ CONFIDENCE_THRESHOLD_IR_PATH = "rt_info/model_info/confidence_threshold"
 CONFIDENCE_THRESHOLD_ONNX_KEY = "model_info confidence_threshold"
 
 
+def _model_size_in_bytes(model_path: Path) -> int:
+    return sum(f.stat().st_size for f in model_path.glob("**/*") if f.is_file())
+
+
 @lru_cache
 def _cached_model_size_in_bytes(model_path: Path) -> int:
-    return sum(f.stat().st_size for f in model_path.glob("**/*") if f.is_file())
+    return _model_size_in_bytes(model_path)
 
 
 def _read_ir_confidence_threshold(model_xml: Path) -> float | None:
@@ -267,7 +271,11 @@ class ModelService(BaseSessionManagedService):
             return 0
 
         model_path = self._projects_dir / str(project_id) / "models" / str(model_id)
-        return _cached_model_size_in_bytes(model_path)
+        training_info = model_revision.training_info
+        # The folder is only guaranteed stable once training has finished; cache the size only then.
+        if training_info and training_info.status in (TrainingStatus.SUCCESSFUL, TrainingStatus.FAILED):
+            return _cached_model_size_in_bytes(model_path)
+        return _model_size_in_bytes(model_path)
 
     def rename_model(self, project_id: UUID, model_id: UUID, model_metadata: dict[str, str]) -> ModelRevision:
         """

--- a/application/backend/tests/integration/services/test_model_service.py
+++ b/application/backend/tests/integration/services/test_model_service.py
@@ -372,6 +372,63 @@ class TestModelServiceIntegration:
 
         assert total_size == 100 + 200 + 300 + 400
 
+    @pytest.mark.parametrize("training_status", [TrainingStatus.NOT_STARTED, TrainingStatus.IN_PROGRESS])
+    def test_get_model_size_in_bytes_recomputes_while_training_not_finished(
+        self,
+        training_status: TrainingStatus,
+        tmp_path: Path,
+        fxt_project_id: UUID,
+        fxt_model_id: UUID,
+        fxt_model_service: ModelService,
+        db_session: Session,
+    ):
+        """Size must reflect the current filesystem state while the model folder can still change."""
+        model_rev_db = db_session.get(ModelRevisionDB, str(fxt_model_id))
+        assert model_rev_db
+        model_rev_db.training_status = training_status
+        db_session.add(model_rev_db)
+        db_session.flush()
+
+        model_base_path = tmp_path / "projects" / str(fxt_project_id) / "models" / str(fxt_model_id)
+        variant_dir = model_base_path / "variants" / str(uuid4())
+        variant_dir.mkdir(parents=True, exist_ok=True)
+        (variant_dir / "model.pt").write_bytes(b"x" * 100)
+
+        assert fxt_model_service.get_model_size_in_bytes(fxt_project_id, fxt_model_id) == 100
+
+        (variant_dir / "extra.ckpt").write_bytes(b"x" * 50)
+
+        assert fxt_model_service.get_model_size_in_bytes(fxt_project_id, fxt_model_id) == 150
+
+    @pytest.mark.parametrize("training_status", [TrainingStatus.SUCCESSFUL, TrainingStatus.FAILED])
+    def test_get_model_size_in_bytes_uses_cache_after_training_finishes(
+        self,
+        training_status: TrainingStatus,
+        tmp_path: Path,
+        fxt_project_id: UUID,
+        fxt_model_id: UUID,
+        fxt_model_service: ModelService,
+        db_session: Session,
+    ):
+        """Once training has finished the folder is stable, so the cached value is returned."""
+        model_rev_db = db_session.get(ModelRevisionDB, str(fxt_model_id))
+        assert model_rev_db
+        model_rev_db.training_status = training_status
+        db_session.add(model_rev_db)
+        db_session.flush()
+
+        model_base_path = tmp_path / "projects" / str(fxt_project_id) / "models" / str(fxt_model_id)
+        variant_dir = model_base_path / "variants" / str(uuid4())
+        variant_dir.mkdir(parents=True, exist_ok=True)
+        (variant_dir / "model.pt").write_bytes(b"x" * 100)
+
+        assert fxt_model_service.get_model_size_in_bytes(fxt_project_id, fxt_model_id) == 100
+
+        (variant_dir / "extra.ckpt").write_bytes(b"x" * 50)
+
+        # Stale cached value is returned, since the model path is assumed immutable after training finishes
+        assert fxt_model_service.get_model_size_in_bytes(fxt_project_id, fxt_model_id) == 100
+
     def test_rename_model(self, fxt_project_id: UUID, fxt_model_id: UUID, fxt_model_service: ModelService):
         """Test updating name of a model by ID."""
         new_model_name = "This is a new model name"


### PR DESCRIPTION
### Summary

The size of a model folder can be assumed constant only after the corresponding training job has finished. This PR solves an issue where the model folder size would be computed and cached shortly after the begin of the training job (as a result of calling the /models endpoint), when the folder is still small and incomplete; the cache is now used only for models that finished training.

Fixes #7400 

### How to test

Train a new model and verify that the size reported after training is accurate.

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
