### PR TITLE
Remove model size cache

### DIFF
--- a/application/backend/app/services/model_service.py
+++ b/application/backend/app/services/model_service.py
@@ -95,11 +95,6 @@ CONFIDENCE_THRESHOLD_IR_PATH = "rt_info/model_info/confidence_threshold"
 CONFIDENCE_THRESHOLD_ONNX_KEY = "model_info confidence_threshold"
 
 
-@lru_cache
-def _cached_model_size_in_bytes(model_path: Path) -> int:
-    return sum(f.stat().st_size for f in model_path.glob("**/*") if f.is_file())
-
-
 def _read_ir_confidence_threshold(model_xml: Path) -> float | None:
     """Read the confidence threshold from the ``rt_info`` section of an OpenVINO IR XML file."""
     # The IR topology is parsed directly rather than through openvino.Core.read_model, which would also
@@ -267,7 +262,8 @@ class ModelService(BaseSessionManagedService):
             return 0
 
         model_path = self._projects_dir / str(project_id) / "models" / str(model_id)
-        return _cached_model_size_in_bytes(model_path)
+
+        return sum(f.stat().st_size for f in model_path.glob("**/*") if f.is_file())
 
     def rename_model(self, project_id: UUID, model_id: UUID, model_metadata: dict[str, str]) -> ModelRevision:
         """


### PR DESCRIPTION
### Summary

This PR removes the cache introduced in `ModelService` as a performance optimization for the /models endpoint. The cache was added under the assumption that the total model size would remain constant over time, but it turns out that the situation is more complex:
- During training, the folder size changes as model binaries and logs are written
- After quantization, the size changes again because of the new variant

Overall, the small performance gain is not worth adding bugs and inconsistencies.

Fixes #7400 

### How to test

- [x] Train a model and verify that the reported size is correct
- [x] Quantize the model and verify that the size increases as expected

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
