### PR TITLE
Confidence threshold integration part 2 (pipeline)

### DIFF
--- a/application/backend/app/services/pipeline_service.py
+++ b/application/backend/app/services/pipeline_service.py
@@ -300,11 +300,17 @@ class PipelineService(BaseSessionManagedService):
         The stored value is kept in sync with the model by :meth:`update_pipeline`, so this fallback only
         applies to pipelines configured before the threshold became part of the pipeline configuration.
         """
-        if pipeline.inference.confidence_threshold is not None:
-            return pipeline
-        pipeline.inference.confidence_threshold = self._get_model_confidence_threshold(
-            project_id=pipeline.project_id, model_id=pipeline.model_id, model_variant_id=pipeline.model_variant_id
-        )
+        model_confidence_threshold = None
+        if pipeline.model_variant is not None or pipeline.inference.confidence_threshold is None:
+            model_confidence_threshold = self._get_model_confidence_threshold(
+                project_id=pipeline.project_id, model_id=pipeline.model_id, model_variant_id=pipeline.model_variant_id
+            )
+        if pipeline.model_variant is not None:
+            # optimal_confidence_threshold is a runtime-only field: it is never populated by the ORM mapping,
+            # so it must be read explicitly from the model file, same as ModelService.get_model_variants does.
+            pipeline.model_variant.optimal_confidence_threshold = model_confidence_threshold
+        if pipeline.inference.confidence_threshold is None:
+            pipeline.inference.confidence_threshold = model_confidence_threshold
         return pipeline
 
     @staticmethod

--- a/application/backend/tests/integration/services/test_pipeline_service.py
+++ b/application/backend/tests/integration/services/test_pipeline_service.py
@@ -687,6 +687,33 @@ class TestPipelineConfidenceThreshold:
 
         assert pipeline.inference.confidence_threshold is None
 
+    @pytest.mark.parametrize("embedded_threshold", [0.35, None], ids=["with_threshold", "without_threshold"])
+    def test_get_pipeline_reports_model_variant_confidence_threshold(
+        self, embedded_threshold, fxt_pipeline_with_models, fxt_pipeline_service, fxt_project_id
+    ):
+        """The embedded model variant returned by the pipeline also reports the confidence threshold."""
+        fxt_pipeline_with_models([embedded_threshold, None], is_running=False)
+
+        pipeline = fxt_pipeline_service.get_pipeline_by_id(fxt_project_id)
+
+        assert pipeline.model_variant is not None
+        assert pipeline.model_variant.optimal_confidence_threshold == pytest.approx(embedded_threshold)
+
+    def test_get_pipeline_model_variant_threshold_independent_of_custom_override(
+        self, fxt_pipeline_with_models, fxt_pipeline_service, fxt_project_id
+    ):
+        """The model variant's threshold always reflects the model file, not a custom pipeline override."""
+        fxt_pipeline_with_models([0.35, None], is_running=False)
+        fxt_pipeline_service.update_pipeline(
+            str(fxt_project_id), {"inference": InferenceConfig(confidence_threshold=0.7)}
+        )
+
+        pipeline = fxt_pipeline_service.get_pipeline_by_id(fxt_project_id)
+
+        assert pipeline.inference.confidence_threshold == pytest.approx(0.7)
+        assert pipeline.model_variant is not None
+        assert pipeline.model_variant.optimal_confidence_threshold == pytest.approx(0.35)
+
     def test_set_custom_confidence_threshold(
         self, fxt_pipeline_with_models, fxt_pipeline_service, fxt_project_id, fxt_event_bus, db_session
     ):

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/prediction-confidence-threshold/prediction-confidence-threshold.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/prediction-confidence-threshold/prediction-confidence-threshold.component.tsx
@@ -4,11 +4,7 @@
 import { ConfidenceThreshold } from '../../../../../components/confidence-threshold/confidence-threshold.component';
 import { usePredictionSetup } from '../../../../annotator/predictions-setup-provider.component';
 
-type PredictionConfidenceThresholdProps = {
-    isDisabled?: boolean;
-};
-
-export const PredictionConfidenceThreshold = ({ isDisabled }: PredictionConfidenceThresholdProps) => {
+export const PredictionConfidenceThreshold = () => {
     const { selectedModel, confidenceThreshold, changeConfidenceThreshold } = usePredictionSetup();
 
     const defaultValue = selectedModel?.optimalConfidenceThreshold ?? null;
@@ -23,7 +19,6 @@ export const PredictionConfidenceThreshold = ({ isDisabled }: PredictionConfiden
             value={confidenceThreshold}
             defaultValue={defaultValue}
             onChange={changeConfidenceThreshold}
-            isDisabled={isDisabled}
         />
     );
 };

--- a/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/secondary-toolbar/secondary-toolbar.component.tsx
@@ -100,9 +100,7 @@ const PredictionActions = ({ isDisabled }: { isDisabled: boolean }) => {
                     <Flex gap={'size-300'} direction={'column'}>
                         <PredictionModelSelector isDisabled={isDisabled} />
                         <PredictionInferenceDevices isDisabled={isDisabled} />
-                        {FEATURE_FLAGS.CONFIDENCE_THRESHOLD && (
-                            <PredictionConfidenceThreshold isDisabled={isDisabled} />
-                        )}
+                        {FEATURE_FLAGS.CONFIDENCE_THRESHOLD && <PredictionConfidenceThreshold />}
                     </Flex>
                 </Content>
             </Dialog>

--- a/application/ui/src/features/inference/aside/pipeline-confidence-threshold.component.tsx
+++ b/application/ui/src/features/inference/aside/pipeline-confidence-threshold.component.tsx
@@ -1,0 +1,29 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { usePatchPipeline, usePipeline } from 'hooks/api/pipeline.hook';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
+
+import { ConfidenceThreshold } from '../../../components/confidence-threshold/confidence-threshold.component';
+
+export const PipelineConfidenceThreshold = () => {
+    const projectId = useProjectIdentifier();
+    const { data: pipeline } = usePipeline();
+    const updatePipeline = usePatchPipeline();
+
+    const confidenceThreshold = pipeline.inference?.confidence_threshold ?? null;
+    const defaultValue = pipeline.model_variant?.optimal_confidence_threshold ?? null;
+
+    if (confidenceThreshold === null || defaultValue === null) {
+        return null;
+    }
+
+    const handleChange = (value: number) => {
+        updatePipeline.mutate({
+            params: { path: { project_id: projectId } },
+            body: { inference: { confidence_threshold: value } },
+        });
+    };
+
+    return <ConfidenceThreshold value={confidenceThreshold} defaultValue={defaultValue} onChange={handleChange} />;
+};

--- a/application/ui/src/features/inference/aside/pipeline-confidence-threshold.component.tsx
+++ b/application/ui/src/features/inference/aside/pipeline-confidence-threshold.component.tsx
@@ -1,6 +1,8 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { useState } from 'react';
+
 import { usePatchPipeline, usePipeline } from 'hooks/api/pipeline.hook';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
@@ -10,6 +12,7 @@ export const PipelineConfidenceThreshold = () => {
     const projectId = useProjectIdentifier();
     const { data: pipeline } = usePipeline();
     const updatePipeline = usePatchPipeline();
+    const [pendingValue, setPendingValue] = useState<number | null>(null);
 
     const confidenceThreshold = pipeline.inference?.confidence_threshold ?? null;
     const defaultValue = pipeline.model_variant?.optimal_confidence_threshold ?? null;
@@ -19,11 +22,23 @@ export const PipelineConfidenceThreshold = () => {
     }
 
     const handleChange = (value: number) => {
-        updatePipeline.mutate({
-            params: { path: { project_id: projectId } },
-            body: { inference: { confidence_threshold: value } },
-        });
+        setPendingValue(value);
+
+        updatePipeline.mutate(
+            {
+                params: { path: { project_id: projectId } },
+                body: { inference: { confidence_threshold: value } },
+            },
+            // Patching the pipeline refetches it, so by now the query holds either the new or the rejected value
+            { onSettled: () => setPendingValue(null) }
+        );
     };
 
-    return <ConfidenceThreshold value={confidenceThreshold} defaultValue={defaultValue} onChange={handleChange} />;
+    return (
+        <ConfidenceThreshold
+            value={pendingValue ?? confidenceThreshold}
+            defaultValue={defaultValue}
+            onChange={handleChange}
+        />
+    );
 };

--- a/application/ui/src/features/inference/aside/pipeline-confidence-threshold.test.tsx
+++ b/application/ui/src/features/inference/aside/pipeline-confidence-threshold.test.tsx
@@ -84,4 +84,20 @@ describe('PipelineConfidenceThreshold', () => {
             expect(pipelinePatchSpy).toHaveBeenCalledWith({ inference: { confidence_threshold: 0.65 } });
         });
     });
+
+    it('restores the pipeline value when it could not be persisted', async () => {
+        renderApp(mockedPipeline);
+
+        server.use(http.patch('/api/projects/{project_id}/pipeline', () => HttpResponse.json(null, { status: 500 })));
+
+        await screen.findByRole('textbox', { name: 'Change Confidence threshold' });
+
+        await userEvent.clear(getInput());
+        await userEvent.type(getInput(), '0.8');
+        await userEvent.tab();
+
+        await waitFor(() => {
+            expect(getInput()).toHaveValue('0.35');
+        });
+    });
 });

--- a/application/ui/src/features/inference/aside/pipeline-confidence-threshold.test.tsx
+++ b/application/ui/src/features/inference/aside/pipeline-confidence-threshold.test.tsx
@@ -92,6 +92,8 @@ describe('PipelineConfidenceThreshold', () => {
 
         await screen.findByRole('textbox', { name: 'Change Confidence threshold' });
 
+        expect(getInput()).toHaveValue('0.35');
+
         await userEvent.clear(getInput());
         await userEvent.type(getInput(), '0.8');
         await userEvent.tab();

--- a/application/ui/src/features/inference/aside/pipeline-confidence-threshold.test.tsx
+++ b/application/ui/src/features/inference/aside/pipeline-confidence-threshold.test.tsx
@@ -1,0 +1,87 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Pipeline } from '@/api/types';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { getMockedPipeline } from 'mocks/mock-pipeline';
+import { HttpResponse } from 'msw';
+import { render } from 'test-utils/render';
+
+import { http } from '../../../api/utils';
+import { server } from '../../../msw-node-setup';
+import { PipelineConfidenceThreshold } from './pipeline-confidence-threshold.component';
+
+const getInput = () => screen.getByRole('textbox', { name: 'Change Confidence threshold' });
+
+const renderApp = (pipeline: Pipeline) => {
+    const pipelinePatchSpy = vi.fn();
+
+    server.use(
+        http.get('/api/projects/{project_id}/pipeline', () => HttpResponse.json(pipeline)),
+        http.patch('/api/projects/{project_id}/pipeline', async ({ request }) => {
+            pipelinePatchSpy(await request.json());
+
+            return HttpResponse.json(pipeline);
+        })
+    );
+
+    render(<PipelineConfidenceThreshold />);
+
+    return pipelinePatchSpy;
+};
+
+describe('PipelineConfidenceThreshold', () => {
+    const mockedPipeline = getMockedPipeline({
+        model_variant: {
+            id: 'variant-id',
+            model_revision_id: 'model-id',
+            format: 'openvino',
+            precision: 'fp16',
+            weights_size: 1024,
+            evaluations: [],
+            files_deleted: false,
+            optimal_confidence_threshold: 0.65,
+        },
+        inference: { confidence_threshold: 0.35 },
+    });
+
+    it("shows the pipeline's confidence threshold", async () => {
+        renderApp(mockedPipeline);
+
+        expect(await screen.findByRole('textbox', { name: 'Change Confidence threshold' })).toHaveValue('0.35');
+    });
+
+    it('is not rendered when the pipeline has no confidence threshold', async () => {
+        renderApp(getMockedPipeline({ model_variant: null, inference: { confidence_threshold: null } }));
+
+        await waitFor(() => {
+            expect(screen.queryByRole('textbox', { name: 'Change Confidence threshold' })).not.toBeInTheDocument();
+        });
+    });
+
+    it('persists a committed value through the pipeline', async () => {
+        const pipelinePatchSpy = renderApp(mockedPipeline);
+
+        await screen.findByRole('textbox', { name: 'Change Confidence threshold' });
+
+        await userEvent.clear(getInput());
+        await userEvent.type(getInput(), '0.8');
+        await userEvent.tab();
+
+        await waitFor(() => {
+            expect(pipelinePatchSpy).toHaveBeenCalledWith({ inference: { confidence_threshold: 0.8 } });
+        });
+    });
+
+    it('resets to the optimal threshold of the pipeline model variant', async () => {
+        const pipelinePatchSpy = renderApp(mockedPipeline);
+
+        await screen.findByRole('textbox', { name: 'Change Confidence threshold' });
+        await userEvent.click(screen.getByRole('button', { name: 'Reset confidence threshold' }));
+
+        await waitFor(() => {
+            expect(pipelinePatchSpy).toHaveBeenCalledWith({ inference: { confidence_threshold: 0.65 } });
+        });
+    });
+});

--- a/application/ui/src/features/inference/aside/pipeline-configuration.component.tsx
+++ b/application/ui/src/features/inference/aside/pipeline-configuration.component.tsx
@@ -1,14 +1,14 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { ReactNode, Suspense, useState } from 'react';
+import { ReactNode, Suspense } from 'react';
 
 import { Flex, Item, Loading, TabList, TabPanels, Tabs, Text, View } from '@geti-ui/ui';
 
-import { ConfidenceThreshold } from '../../../components/confidence-threshold/confidence-threshold.component';
 import { FEATURE_FLAGS } from '../../../constants/feature-flags';
 import { SinkActions } from '../sinks/sink-actions.component';
 import { SourceActions } from '../sources/source-actions.component';
+import { PipelineConfidenceThreshold } from './pipeline-confidence-threshold.component';
 import { StreamInferenceDevices } from './stream-inference-devices.component';
 
 const ConfigurationItem = ({ children }: { children: ReactNode }) => {
@@ -16,16 +16,6 @@ const ConfigurationItem = ({ children }: { children: ReactNode }) => {
         <View position={'relative'} minHeight={'size-800'}>
             <Suspense fallback={<Loading mode={'inline'} size={'M'} />}>{children}</Suspense>
         </View>
-    );
-};
-
-// TODO: read the value from `inference.confidence_threshold` and persist it through `PATCH /pipeline`
-const PipelineConfidenceThreshold = () => {
-    const FALLBACK_CONFIDENCE_THRESHOLD = 0.3;
-    const [threshold, setThreshold] = useState(FALLBACK_CONFIDENCE_THRESHOLD);
-
-    return (
-        <ConfidenceThreshold value={threshold} defaultValue={FALLBACK_CONFIDENCE_THRESHOLD} onChange={setThreshold} />
     );
 };
 

--- a/application/ui/tests/annotator/annotator.spec.ts
+++ b/application/ui/tests/annotator/annotator.spec.ts
@@ -1278,7 +1278,10 @@ test.describe('Annotator', () => {
                     return HttpResponse.json([olderModel, newerModel]);
                 }),
                 http.post('/api/projects/{project_id}/dataset/media:predict', async ({ request }) => {
-                    const body = (await request.json()) as unknown as Record<string, string & number>;
+                    const body = (await request.json()) as unknown as {
+                        model_variant_id?: string;
+                        confidence_threshold?: number;
+                    };
                     capturedModelVariantId = body.model_variant_id;
                     capturedConfidenceThreshold = body.confidence_threshold;
 

--- a/application/ui/tests/annotator/annotator.spec.ts
+++ b/application/ui/tests/annotator/annotator.spec.ts
@@ -9,6 +9,7 @@ import { getMockedVariant } from 'mocks/mock-model-variant';
 import { getMockedProject } from 'mocks/mock-project';
 import { HttpResponse } from 'msw';
 
+import { FEATURE_FLAGS } from '../../src/constants/feature-flags';
 import { Polygon } from '../../src/shared/types';
 import { http, test } from '../fixtures';
 import { blueLabel, candyBinaryHandler, redLabel } from './annotator-fixtures';
@@ -1109,7 +1110,14 @@ test.describe('Annotator', () => {
         const olderModel = getMockedModel({
             id: 'older-model-id',
             name: 'Older_Model (older)',
-            variants: [getMockedVariant({ id: 'older-variant-id', format: 'openvino', precision: 'fp32' })],
+            variants: [
+                getMockedVariant({
+                    id: 'older-variant-id',
+                    format: 'openvino',
+                    precision: 'fp32',
+                    optimal_confidence_threshold: 0.2,
+                }),
+            ],
             training_info: {
                 status: 'successful',
                 label_schema_revision: { labels: [{ id: 'label-1', name: 'cat' }] },
@@ -1122,7 +1130,14 @@ test.describe('Annotator', () => {
         const newerModel = getMockedModel({
             id: 'newer-model-id',
             name: 'Newer_Model (newer)',
-            variants: [getMockedVariant({ id: 'newer-variant-id', format: 'openvino', precision: 'fp16' })],
+            variants: [
+                getMockedVariant({
+                    id: 'newer-variant-id',
+                    format: 'openvino',
+                    precision: 'fp16',
+                    optimal_confidence_threshold: 0.65,
+                }),
+            ],
             training_info: {
                 status: 'successful',
                 label_schema_revision: { labels: [{ id: 'label-1', name: 'cat' }] },
@@ -1256,14 +1271,16 @@ test.describe('Annotator', () => {
             network,
         }) => {
             let capturedModelVariantId: string | undefined;
+            let capturedConfidenceThreshold: number | undefined;
 
             network.use(
                 http.get('/api/projects/{project_id}/models', async () => {
                     return HttpResponse.json([olderModel, newerModel]);
                 }),
                 http.post('/api/projects/{project_id}/dataset/media:predict', async ({ request }) => {
-                    const body = await request.json();
-                    capturedModelVariantId = (body as unknown as Record<string, string>).model_variant_id;
+                    const body = (await request.json()) as unknown as Record<string, string & number>;
+                    capturedModelVariantId = body.model_variant_id;
+                    capturedConfidenceThreshold = body.confidence_threshold;
 
                     return HttpResponse.json({ predictions: [{ media: { id: 'item-1' }, prediction: [] }] });
                 })
@@ -1296,6 +1313,14 @@ test.describe('Annotator', () => {
             await test.step('predictions are requested with the newly selected model variant', async () => {
                 expect(capturedModelVariantId).toBe(olderModel.variants[0].id);
             });
+
+            // TODO: drop the guard once CONFIDENCE_THRESHOLD is enabled by default
+            if (FEATURE_FLAGS.CONFIDENCE_THRESHOLD) {
+                await test.step('the confidence threshold follows the selected model', async () => {
+                    await expect(page.getByRole('textbox', { name: 'Change Confidence threshold' })).toHaveValue('0.2');
+                    expect(capturedConfidenceThreshold).toBe(0.2);
+                });
+            }
         });
 
         test('changing device selection uses the new device for predictions', async ({

--- a/application/ui/tests/inference/inference.spec.ts
+++ b/application/ui/tests/inference/inference.spec.ts
@@ -5,6 +5,7 @@ import { getMockedPipeline } from 'mocks/mock-pipeline';
 import { getMockedProject } from 'mocks/mock-project';
 import { HttpResponse } from 'msw';
 
+import { FEATURE_FLAGS } from '../../src/constants/feature-flags';
 import { expect, http, test } from '../fixtures';
 
 test.describe('Inference', () => {
@@ -281,6 +282,57 @@ test.describe('Inference', () => {
             await confidenceSlider.fill('0.7');
             await expect(confidenceSlider).toHaveValue('0.7');
         });
+
+        // TODO: drop the guard once CONFIDENCE_THRESHOLD is enabled by default
+        if (FEATURE_FLAGS.CONFIDENCE_THRESHOLD) {
+            await test.step('updates the inference confidence threshold', async () => {
+                let confidenceThreshold = 0.35;
+                const patchedBodies: unknown[] = [];
+
+                network.use(
+                    http.get('/api/projects/{project_id}/pipeline', ({ response }) => {
+                        return response(200).json(
+                            getMockedPipeline({
+                                status: 'idle',
+                                model_variant: {
+                                    id: 'variant-id',
+                                    model_revision_id: 'model-id',
+                                    format: 'openvino',
+                                    precision: 'fp16',
+                                    weights_size: 1024,
+                                    evaluations: [],
+                                    files_deleted: false,
+                                    optimal_confidence_threshold: 0.65,
+                                },
+                                inference: { confidence_threshold: confidenceThreshold },
+                            })
+                        );
+                    }),
+                    http.patch('/api/projects/{project_id}/pipeline', async ({ request }) => {
+                        const body = (await request.json()) as { inference?: { confidence_threshold: number } };
+                        patchedBodies.push(body);
+
+                        if (body.inference !== undefined) {
+                            confidenceThreshold = body.inference.confidence_threshold;
+                        }
+
+                        return HttpResponse.json(getMockedPipeline({ status: 'idle' }));
+                    })
+                );
+
+                await page.goto('/projects/id-1/inference');
+
+                const thresholdField = page.getByRole('textbox', { name: 'Change Confidence threshold' });
+
+                await expect(thresholdField).toHaveValue('0.35');
+
+                await thresholdField.fill('0.8');
+                await thresholdField.press('Enter');
+
+                await expect(thresholdField).toHaveValue('0.8');
+                await expect.poll(() => patchedBodies).toContainEqual({ inference: { confidence_threshold: 0.8 } });
+            });
+        }
 
         await test.step('updates input and output source', async () => {
             network.use(


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Closes https://github.com/open-edge-platform/geti/issues/7306
* Fix server-side issue where `GET /pipeline` would incorrectly return `"optimal_confidence_threshold": null` in all model variants

### How to test

<img width="565" height="313" alt="image" src="https://github.com/user-attachments/assets/21f80547-cdc8-4f25-9b30-e7fb6a331ef7" />

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
