### PR TITLE
Improve annotator close transition

### DIFF
--- a/application/ui/src/features/annotator/api/use-media-predictions.ts
+++ b/application/ui/src/features/annotator/api/use-media-predictions.ts
@@ -15,6 +15,9 @@ import { PREDICTION_CHUNK_SIZE, PREDICTION_FRAME_SKIP } from '../video-player/ap
 import { getVideoFrameRangeIndexes } from '../video-player/api/utils';
 import { useVideoPlayerContext } from '../video-player/video-player-provider.component';
 
+// Prefix matching every prediction query of a project, so callers can cancel them all at once.
+export const getMediaPredictionsQueryKeyPrefix = (projectId: string) => [projectId, 'media-predictions'];
+
 export const mediaPredictionsQueryOptions = ({
     projectId,
     selectedModel,

--- a/application/ui/src/features/annotator/api/use-media-predictions.ts
+++ b/application/ui/src/features/annotator/api/use-media-predictions.ts
@@ -35,8 +35,7 @@ export const mediaPredictionsQueryOptions = ({
 }) =>
     queryOptions({
         queryKey: [
-            projectId,
-            'media-predictions',
+            ...getMediaPredictionsQueryKeyPrefix(projectId),
             mediaId,
             device,
             selectedModel?.modelId,

--- a/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
+++ b/application/ui/src/features/annotator/tools/segment-anything-tool/use-segment-anything.hook.ts
@@ -92,6 +92,12 @@ const segmentAnythingWorkerQueryOptions = (enabled = true) =>
 const getEncodingQueryParams = (mediaItem: Media) =>
     isVideoFrame(mediaItem) ? { frame_index: mediaItem.frame_number } : undefined;
 
+// Prefix matching every media's encoding query, so callers can cancel them all at once.
+export const SEGMENT_ANYTHING_ENCODING_QUERY_KEY_PREFIX: QueryKey = [
+    'get',
+    '/api/projects/{project_id}/dataset/media/{media_id}/embeddings',
+];
+
 const getSegmentAnythingEncodingQueryKey = (projectId: string, mediaItem: Media): QueryKey =>
     getQueryKey([
         'get',

--- a/application/ui/src/features/dataset/gallery/gallery.component.tsx
+++ b/application/ui/src/features/dataset/gallery/gallery.component.tsx
@@ -175,7 +175,6 @@ export const Gallery = ({
                 <DialogContainer type={'fullscreenTakeover'} onDismiss={() => onSelectedMediaItemChange(null)}>
                     {selectedMediaItem !== null && (
                         <MediaPreview
-                            mediaItem={selectedMediaItem}
                             close={() => onSelectedMediaItemChange(null)}
                             onSelectedMediaItem={onSelectedMediaItemChange}
                         />

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -97,9 +97,9 @@ const MediaPreviewPanels = ({
 };
 
 /**
- * Aborts inference and embedding requests the user walked away from.
- * `media:predict` is a synchronous backend endpoint holding a process-wide model lock, so an
- * abandoned request keeps every later request (thumbnails, dataset items) queued behind it.
+ * Aborts inference and embedding requests if the user closes the annotator dialog.
+ *
+ * It won't stop the server side processing but it will prevent the client from waiting for the results.
  */
 const useCancelInferenceOnUnmount = () => {
     const queryClient = useQueryClient();
@@ -179,8 +179,7 @@ const MediaPreviewContent = ({
 export const MediaPreview = ({ close, onSelectedMediaItem }: MediaPreviewProps) => {
     const { items, isFetchingNextPage, fetchNextPage, isMediaItemReviewedById } = useDatasetMediaWithReviewStatus();
 
-    // Read rather than receive the selection: Spectrum keeps this dialog's last child mounted for its
-    // 350ms exit animation, so props are frozen but the cleared selection still reaches us.
+    // Reading the route param unmounts the content on close, without waiting for the dialog's exit animation.
     const { selectedMediaItem } = useSelectDatasetItem();
 
     return (

--- a/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
+++ b/application/ui/src/features/dataset/media-preview/media-preview.component.tsx
@@ -1,21 +1,25 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import type { DatasetSubset, Media } from '@/api/types';
 import { Content, Dialog, Grid, View } from '@geti-ui/ui';
+import { useQueryClient } from '@tanstack/react-query';
 import { useDatasetMediaWithReviewStatus } from 'hooks/use-dataset-media-with-review-status.hook';
+import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 import type { AnnotatorMode } from '../../../shared/annotator/annotator-mode';
 import { ToolProvider } from '../../../shared/annotator/tool-provider.component';
 import { isVideoFrame } from '../../../shared/media-item-utils';
-import { useMediaPredictions } from '../../annotator/api/use-media-predictions';
+import { getMediaPredictionsQueryKeyPrefix, useMediaPredictions } from '../../annotator/api/use-media-predictions';
 import { PredictionsSetupProvider, usePredictionSetup } from '../../annotator/predictions-setup-provider.component';
 import {
     SelectedMediaItemProvider,
     useSelectedMediaItem,
 } from '../../annotator/selected-media-item-provider.component';
+import { SEGMENT_ANYTHING_ENCODING_QUERY_KEY_PREFIX } from '../../annotator/tools/segment-anything-tool/use-segment-anything.hook';
+import { useSelectDatasetItem } from '../gallery/hooks/use-select-dataset-item.hook';
 import { AnnotatorProviders } from './annotator-providers.component';
 import { AnnotatorContainer } from './annotator.component';
 import { useAnnotationsQuery } from './api/use-annotations-query';
@@ -25,7 +29,6 @@ import { useAnnotatorMediaTransition } from './use-annotator-media-transition.ho
 import { getInitialAnnotations, useAnnotatorMode } from './utils';
 
 type MediaPreviewProps = {
-    mediaItem: Media;
     close: () => void;
     onSelectedMediaItem: (item: Media) => void;
 };
@@ -93,6 +96,23 @@ const MediaPreviewPanels = ({
     );
 };
 
+/**
+ * Aborts inference and embedding requests the user walked away from.
+ * `media:predict` is a synchronous backend endpoint holding a process-wide model lock, so an
+ * abandoned request keeps every later request (thumbnails, dataset items) queued behind it.
+ */
+const useCancelInferenceOnUnmount = () => {
+    const queryClient = useQueryClient();
+    const projectId = useProjectIdentifier();
+
+    useEffect(() => {
+        return () => {
+            void queryClient.cancelQueries({ queryKey: getMediaPredictionsQueryKeyPrefix(projectId) });
+            void queryClient.cancelQueries({ queryKey: SEGMENT_ANYTHING_ENCODING_QUERY_KEY_PREFIX });
+        };
+    }, [queryClient, projectId]);
+};
+
 const MediaPreviewContent = ({
     items,
     onSelectedMediaItem,
@@ -103,6 +123,8 @@ const MediaPreviewContent = ({
 }: MediaPreviewContentProps) => {
     const { mediaItem } = useSelectedMediaItem();
     const { selectedModel, selectedDevice, confidenceThreshold } = usePredictionSetup();
+
+    useCancelInferenceOnUnmount();
 
     const { data: annotationsData } = useAnnotationsQuery(mediaItem);
     const { data: predictionsData } = useMediaPredictions({
@@ -154,8 +176,12 @@ const MediaPreviewContent = ({
     );
 };
 
-export const MediaPreview = ({ mediaItem, close, onSelectedMediaItem }: MediaPreviewProps) => {
+export const MediaPreview = ({ close, onSelectedMediaItem }: MediaPreviewProps) => {
     const { items, isFetchingNextPage, fetchNextPage, isMediaItemReviewedById } = useDatasetMediaWithReviewStatus();
+
+    // Read rather than receive the selection: Spectrum keeps this dialog's last child mounted for its
+    // 350ms exit animation, so props are frozen but the cleared selection still reaches us.
+    const { selectedMediaItem } = useSelectDatasetItem();
 
     return (
         <Dialog
@@ -179,18 +205,20 @@ export const MediaPreview = ({ mediaItem, close, onSelectedMediaItem }: MediaPre
                         'toolbar bottom aside',
                     ]}
                 >
-                    <SelectedMediaItemProvider mediaItem={mediaItem}>
-                        <PredictionsSetupProvider>
-                            <MediaPreviewContent
-                                items={items}
-                                onClose={close}
-                                onSelectedMediaItem={onSelectedMediaItem}
-                                isFetchingNextPage={isFetchingNextPage}
-                                fetchNextPage={fetchNextPage}
-                                isMediaItemReviewedById={isMediaItemReviewedById}
-                            />
-                        </PredictionsSetupProvider>
-                    </SelectedMediaItemProvider>
+                    {selectedMediaItem !== null && (
+                        <SelectedMediaItemProvider mediaItem={selectedMediaItem}>
+                            <PredictionsSetupProvider>
+                                <MediaPreviewContent
+                                    items={items}
+                                    onClose={close}
+                                    onSelectedMediaItem={onSelectedMediaItem}
+                                    isFetchingNextPage={isFetchingNextPage}
+                                    fetchNextPage={fetchNextPage}
+                                    isMediaItemReviewedById={isMediaItemReviewedById}
+                                />
+                            </PredictionsSetupProvider>
+                        </SelectedMediaItemProvider>
+                    )}
                 </Grid>
             </Content>
         </Dialog>


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* At the moment, closing the annotator can take up to several seconds, because we're waiting on all pending processes
* This PR cancels all current requests and immediately unmounts the dialog. The backend will still process these but the experience is now smooth instead of very sluggish

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
