### PR TITLE
Add useful scripts for library

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -655,7 +655,7 @@ python scripts/test.py \
 #   MULTI_CLASS_CLS:        accuracy, f1-score
 #   MULTI_LABEL_CLS:        accuracy, f1-score, map
 #   DETECTION:              f1-score, map
-#   INSTANCE_SEGMENTATION:  f1-score, map, dice
+#   INSTANCE_SEGMENTATION:  f1-score, map
 #   SEMANTIC_SEGMENTATION:  dice, miou
 #   KEYPOINT_DETECTION:     pck, pck-score
 ```

--- a/library/README.md
+++ b/library/README.md
@@ -10,6 +10,7 @@
 [Supported Tasks & Models](#supported-tasks--models) •
 [Installation](#installation) •
 [Usage](#usage) •
+[Command-Line Scripts](#command-line-scripts) •
 [Docs](https://docs.geti.intel.com/docs/user-guide/library/get-started/intro) •
 [License](#license)
 
@@ -608,6 +609,115 @@ Available model classes:
 - **Keypoint:** `RTMPose`
 
 </details>
+
+---
+
+## Command-Line Scripts
+
+The `scripts/` directory ships ready-to-use command-line entry points that wrap the `getitune` API for common workflows (training, evaluation, export, benchmarking, and prediction). They are plain Python scripts — run them directly with your `getitune` environment active.
+
+### `train.py`
+
+Train, test, and optionally export/quantize a `getitune` model from the CLI. Accepts a model name or recipe, dataset root, device, epochs, batch size, and precision, with flags to disable early stopping and to export (`--export`) to OpenVINO/ONNX and quantize (`--quantize`) to INT8.
+
+```bash
+# Train, test, and export to OpenVINO FP16
+python scripts/train.py \
+    --model src/getitune/recipe/detection/yolox_s.yaml \
+    --data-root /path/to/dataset \
+    --epochs 50 \
+    --export --export-format openvino --export-precision fp16
+
+# Train and quantize the exported model to INT8
+python scripts/train.py \
+    --model yolox_s \
+    --data-root /path/to/dataset \
+    --export --quantize
+```
+
+### `test.py`
+
+Evaluate a trained model (torch `.ckpt`/`.pt`/`.pth`, or exported OV/ONNX) on a dataset and print the resulting metrics. Supports a task-aware `--metric` override (e.g. `f1-score`, `map`, `dice`, `miou`, `pck`) mapped per task, so invalid combinations like `map` for multiclass classification are rejected.
+
+```bash
+# Evaluate an exported OpenVINO model with the default recipe metrics
+python scripts/test.py \
+    --model /path/to/exported_model.xml \
+    --data-root /path/to/dataset
+
+# Evaluate a torch checkpoint with explicit metrics (DETECTION task)
+python scripts/test.py \
+    --model ckpt.ckpt --recipe yolox_s --task DETECTION \
+    --data-root /path/to/dataset \
+    --metric f1-score map
+
+# Supported metrics per task:
+#   MULTI_CLASS_CLS:        accuracy, f1-score
+#   MULTI_LABEL_CLS:        accuracy, f1-score, map
+#   DETECTION:              f1-score, map
+#   INSTANCE_SEGMENTATION:  f1-score, map, dice
+#   SEMANTIC_SEGMENTATION:  dice, miou
+#   KEYPOINT_DETECTION:     pck, pck-score
+```
+
+### `export.py`
+
+Export a `getitune` model to OpenVINO or ONNX at FP32/FP16, or to INT8 via post-training quantization. Defaults to OpenVINO FP16; INT8 requires a dataset root for the calibration step.
+
+```bash
+# Export to OpenVINO FP16 (default)
+python scripts/export.py \
+    --model yolox_s --checkpoint /path/to/ckpt.ckpt \
+    --data-root /path/to/dataset
+
+# Export to ONNX FP32
+python scripts/export.py \
+    --model /path/to/exported_model.xml \
+    --data-root /path/to/dataset \
+    --format onnx --precision fp32
+
+# Export to OpenVINO INT8 (quantized)
+python scripts/export.py \
+    --model yolox_s --checkpoint /path/to/ckpt.ckpt \
+    --data-root /path/to/dataset \
+    --precision int8
+```
+
+### `predict.py`
+
+Run inference with an OV/ONNX/torch model on a dataset or images folder and write the predictions to a COCO-format JSON file (bounding boxes, RLE masks for segmentation, and keypoints). Uses `coco_utils.py` for the conversion.
+
+```bash
+# Predict with an exported OpenVINO model on an images folder
+python scripts/predict.py \
+    --model /path/to/exported_model.xml \
+    --input /path/to/images \
+    --output predictions.json
+
+# Predict with a torch checkpoint
+python scripts/predict.py \
+    --model ckpt.ckpt --recipe yolox_s --task DETECTION \
+    --input /path/to/dataset \
+    --output predictions.json
+```
+
+### `benchmark.py`
+
+Prepare a model (export a recipe or quantize to INT8 as needed) and run OpenVINO `benchmark_app` against it, forwarding device, batch, input shape, hint, and iteration/time options for latency/throughput measurement.
+
+```bash
+# Benchmark an exported OpenVINO model on CPU
+python scripts/benchmark.py \
+    --model /path/to/exported_model.xml \
+    --data-root /path/to/dataset \
+    --device CPU
+
+# Export + quantize a recipe to INT8, then benchmark
+python scripts/benchmark.py \
+    --model yolox_s --checkpoint /path/to/ckpt.ckpt \
+    --data-root /path/to/dataset \
+    --precision int8 --device CPU
+```
 
 ---
 

--- a/library/README.md
+++ b/library/README.md
@@ -670,9 +670,9 @@ python scripts/export.py \
     --model yolox_s --checkpoint /path/to/ckpt.ckpt \
     --data-root /path/to/dataset
 
-# Export to ONNX FP32
+# Export to ONNX FP32 from a recipe/model and checkpoint
 python scripts/export.py \
-    --model /path/to/exported_model.xml \
+    --model yolox_s --checkpoint /path/to/ckpt.ckpt \
     --data-root /path/to/dataset \
     --format onnx --precision fp32
 

--- a/library/scripts/benchmark.py
+++ b/library/scripts/benchmark.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import argparse
-import subprocess
+import subprocess  # nosec B404
 from pathlib import Path
 
 from getitune.engine import create_engine
@@ -31,6 +31,7 @@ def _input_shape(value: str) -> str:
 
 
 def _benchmark_command(args: argparse.Namespace, model: Path, shape: str | None) -> list[str]:
+    # benchmark_app receives a constructed argv list and does not use shell interpolation.
     command = [args.benchmark_app, "-m", str(model), "-d", args.device]
     if args.batch is not None:
         command.extend(["-b", str(args.batch)])

--- a/library/scripts/benchmark.py
+++ b/library/scripts/benchmark.py
@@ -1,0 +1,148 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark an existing model or export one from a getitune recipe first."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from getitune.engine import create_engine
+from getitune.types.export import ExportFormat
+from getitune.types.precision import Precision
+
+
+def _input_shape(value: str) -> str:
+    parts = value.lower().replace("x", ",").split(",")
+    if len(parts) != 2:
+        message = "input size must be written as HxW, for example 224x224"
+        raise argparse.ArgumentTypeError(message)
+    try:
+        height, width = (int(part.strip()) for part in parts)
+    except ValueError as error:
+        message = "input size must contain two integers"
+        raise argparse.ArgumentTypeError(message) from error
+    if height <= 0 or width <= 0:
+        message = "input size must be greater than zero"
+        raise argparse.ArgumentTypeError(message)
+    return f"[1,3,{height},{width}]"
+
+
+def _benchmark_command(args: argparse.Namespace, model: Path, shape: str | None) -> list[str]:
+    command = [args.benchmark_app, "-m", str(model), "-d", args.device]
+    if args.batch is not None:
+        command.extend(["-b", str(args.batch)])
+    if shape is not None:
+        command.extend(["-shape", shape])
+    if args.precision != "int8":
+        command.extend(["-infer_precision", "f16" if args.precision == "fp16" else "f32"])
+    else:
+        command.extend(["-infer_precision", "i8"])
+    if args.hint is not None:
+        command.extend(["-hint", args.hint])
+    if args.iterations is not None:
+        command.extend(["-niter", str(args.iterations)])
+    if args.time is not None:
+        command.extend(["-t", str(args.time)])
+    if args.infer_requests is not None:
+        command.extend(["-nireq", str(args.infer_requests)])
+    return command
+
+
+def _quantize(model: Path, args: argparse.Namespace, data: str) -> Path:
+    quantize_engine = create_engine(model=str(model), data=data, work_dir=str(args.work_dir))
+    return quantize_engine.optimize()
+
+
+def _prepare_model(args: argparse.Namespace) -> Path:
+    model = Path(args.model)
+    if model.suffix.lower() in {".xml", ".onnx"}:
+        if not model.exists():
+            message = f"model file not found: {model}"
+            raise FileNotFoundError(message)
+        if args.precision == "int8":
+            if model.suffix.lower() == ".onnx":
+                message = "INT8 quantization requires an OpenVINO XML model, not ONNX"
+                raise ValueError(message)
+            if args.data_root is None:
+                message = "--data-root is required to quantize an existing model"
+                raise ValueError(message)
+            return _quantize(model, args, str(args.data_root))
+        return model
+
+    if args.data_root is None:
+        message = "--data-root is required when --model is a model name or recipe path"
+        raise ValueError(message)
+
+    engine = create_engine(
+        model=args.model,
+        data=str(args.data_root),
+        work_dir=str(args.work_dir),
+        device=args.device,
+        checkpoint=str(args.checkpoint) if args.checkpoint else None,
+        task=args.task,
+    )
+    if args.precision == "int8":
+        exported = engine.export(export_format=ExportFormat.OPENVINO, export_precision=Precision.FP32)
+        return _quantize(Path(exported), args, str(args.data_root))
+
+    export_format = ExportFormat.ONNX if args.format == "onnx" else ExportFormat.OPENVINO
+    export_precision = Precision.FP16 if args.precision == "fp16" else Precision.FP32
+    return Path(engine.export(export_format=export_format, export_precision=export_precision))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the benchmark command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, help="Existing .xml/.onnx model, model name, or recipe path")
+    parser.add_argument("--data-root", type=Path, help="Dataset root, required for recipe export and quantization")
+    parser.add_argument("--checkpoint", type=Path, help="Optional checkpoint used when exporting a recipe model")
+    parser.add_argument("--task", help="Optional task used to disambiguate a model name")
+    parser.add_argument("--work-dir", type=Path, default=Path("./getitune-workspace"))
+    parser.add_argument("--format", choices=("openvino", "onnx"), default="openvino")
+    parser.add_argument("--precision", choices=("fp32", "fp16", "int8"), default="fp32")
+    parser.add_argument("--device", default="CPU", help="OpenVINO device, for example CPU, GPU, or NPU")
+    parser.add_argument("--batch", type=int)
+    shape = parser.add_mutually_exclusive_group()
+    shape.add_argument(
+        "--input-size",
+        type=_input_shape,
+        default=None,
+        help="Optional input image size, for example 224x224 (default: model shape)",
+    )
+    shape.add_argument(
+        "--shape",
+        default=None,
+        help="Optional benchmark_app input shape, for example [1,3,224,224] (default: model shape)",
+    )
+    parser.add_argument("--hint", choices=("latency", "throughput", "none"))
+    parser.add_argument("--iterations", type=int)
+    parser.add_argument("--time", type=int)
+    parser.add_argument("--infer-requests", type=int)
+    parser.add_argument(
+        "--benchmark-app",
+        default="benchmark_app",
+        help="Path to the OpenVINO benchmark_app executable",
+    )
+    return parser
+
+
+def main() -> None:
+    """Prepare a model and run OpenVINO benchmark_app."""
+    args = build_parser().parse_args()
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        model = _prepare_model(args)
+        shape = args.shape or args.input_size
+        command = _benchmark_command(args, model, shape)
+        print("Running:", " ".join(command))
+        subprocess.run(command, check=True)  # noqa: S603
+    except (FileNotFoundError, RuntimeError, TypeError, ValueError) as error:
+        message = f"error: {error}"
+        raise SystemExit(message) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/library/scripts/coco_utils.py
+++ b/library/scripts/coco_utils.py
@@ -1,0 +1,139 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Convert getitune prediction entities to COCO prediction JSON."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pycocotools.mask as mask_utils  # type: ignore[import-untyped]
+from torchvision import tv_tensors
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import torch
+
+    from getitune.types.label import LabelInfo
+
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
+
+
+def iter_image_files(input_path: Path) -> list[Path]:
+    """Return image files under ``input_path`` (recursively) in sorted order."""
+    if input_path.is_file():
+        return [input_path]
+    files = [p for p in input_path.rglob("*") if p.suffix.lower() in IMAGE_EXTENSIONS]
+    return sorted(files)
+
+
+def _xyxy_to_xywh(box: np.ndarray) -> list[float]:
+    x1, y1, x2, y2 = (float(v) for v in box)
+    return [x1, y1, max(x2 - x1, 0.0), max(y2 - y1, 0.0)]
+
+
+def _encode_mask(mask: torch.Tensor) -> dict:
+    if mask.ndim == 3:
+        mask = mask[0]
+    mask_np = (mask.detach().cpu().numpy() > 0).astype(np.uint8)
+    rle = mask_utils.encode(np.asfortranarray(mask_np))
+    rle["counts"] = rle["counts"].decode("utf-8") if isinstance(rle["counts"], bytes) else rle["counts"]
+    return rle
+
+
+def _build_categories(label_info: LabelInfo) -> list[dict]:
+    names = getattr(label_info, "label_names", None) or []
+    return [{"id": idx + 1, "name": name, "supercategory": "none"} for idx, name in enumerate(names)]
+
+
+def predictions_to_coco(predictions: list, label_info: LabelInfo, image_files: list[Path] | None = None) -> dict:
+    """Convert a list of ``PredictionBatch`` objects to a COCO prediction dict.
+
+    Args:
+        predictions: Output of ``engine.predict()`` (list of ``PredictionBatch``).
+        label_info: Model ``label_info`` used to build the categories section.
+        image_files: Optional list of image paths aligned with the prediction order.
+            When omitted, images are referenced by a generated index.
+
+    Returns:
+        A dict in COCO result format with ``images``, ``categories`` and ``annotations``.
+    """
+    images: list[dict] = []
+    annotations: list[dict] = []
+    ann_id = 1
+    image_id = 1
+
+    for batch in predictions:
+        batch_labels = getattr(batch, "labels", None)
+        batch_scores = getattr(batch, "scores", None)
+        batch_boxes = getattr(batch, "bboxes", None)
+        batch_masks = getattr(batch, "masks", None)
+        batch_keypoints = getattr(batch, "keypoints", None)
+        imgs_info = getattr(batch, "imgs_info", None) or []
+
+        for i in range(len(imgs_info)):
+            info = imgs_info[i]
+            height, width = info.ori_shape[:2] if info is not None else (None, None)
+            file_name = str(image_files[len(images)]) if image_files else f"image_{image_id:06d}"
+            images.append(
+                {
+                    "id": image_id,
+                    "file_name": file_name,
+                    **({"height": int(height), "width": int(width)} if height is not None else {}),
+                }
+            )
+
+            labels = batch_labels[i] if batch_labels is not None else None
+            scores = batch_scores[i] if batch_scores is not None else None
+            boxes = batch_boxes[i] if batch_boxes is not None else None
+            masks = batch_masks[i] if batch_masks is not None else None
+            keypoints = batch_keypoints[i] if batch_keypoints is not None else None
+
+            if labels is None:
+                image_id += 1
+                continue
+
+            labels_list = labels.detach().cpu().numpy().tolist()
+            scores_list = scores.detach().cpu().numpy().tolist() if scores is not None else [None] * len(labels_list)
+
+            for j, (label, score) in enumerate(zip(labels_list, scores_list)):
+                ann: dict = {
+                    "id": ann_id,
+                    "image_id": image_id,
+                    "category_id": int(label) + 1,
+                    "score": float(score) if score is not None else None,
+                }
+                if boxes is not None and j < len(boxes):
+                    box = boxes[j]
+                    if isinstance(box, tv_tensors.BoundingBoxes):
+                        box = box.tensor
+                    ann["bbox"] = _xyxy_to_xywh(np.asarray(box.detach().cpu().numpy()).reshape(-1))
+                if masks is not None and j < len(masks):
+                    ann["segmentation"] = _encode_mask(masks[j])
+                if keypoints is not None and j < len(keypoints):
+                    ann["keypoints"] = keypoints[j].detach().cpu().numpy().reshape(-1).tolist()
+                annotations.append(ann)
+                ann_id += 1
+
+            image_id += 1
+
+    return {
+        "images": images,
+        "categories": _build_categories(label_info),
+        "annotations": annotations,
+    }
+
+
+def write_coco(
+    predictions: list,
+    output: Path,
+    label_info: LabelInfo,
+    image_files: list[Path] | None = None,
+) -> None:
+    """Convert predictions to COCO and write them to ``output`` as JSON."""
+    coco = predictions_to_coco(predictions, label_info, image_files)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(coco, indent=2))

--- a/library/scripts/export.py
+++ b/library/scripts/export.py
@@ -1,0 +1,106 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Export a getitune model to ONNX or OpenVINO with the requested precision."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from getitune.engine import create_engine
+from getitune.types.export import ExportFormat
+from getitune.types.precision import Precision
+
+
+def _task(value: str) -> str:
+    value = value.strip().upper().replace("-", "_").replace(" ", "_")
+    from getitune.types import TaskType
+
+    aliases = {
+        "DETECTION": TaskType.DETECTION.value,
+        "INSTANCE_SEGMENTATION": TaskType.INSTANCE_SEGMENTATION.value,
+        "SEMANTIC_SEGMENTATION": TaskType.SEMANTIC_SEGMENTATION.value,
+        "KEYPOINT_DETECTION": TaskType.KEYPOINT_DETECTION.value,
+        "MULTI_CLASS_CLS": TaskType.MULTI_CLASS_CLS.value,
+        "MULTI_LABEL_CLS": TaskType.MULTI_LABEL_CLS.value,
+    }
+    value = aliases.get(value, value)
+    try:
+        return TaskType(value).value
+    except ValueError as error:
+        choices = ", ".join(task.value for task in TaskType)
+        message = f"unknown task {value!r}; choose from {choices}"
+        raise argparse.ArgumentTypeError(message) from error
+
+
+def _quantize(model: Path, args: argparse.Namespace) -> Path:
+    quantize_engine = create_engine(
+        model=str(model),
+        data=str(args.data_root),
+        work_dir=str(args.work_dir),
+    )
+    return Path(quantize_engine.optimize())
+
+
+def run(args: argparse.Namespace) -> Path:
+    """Export a model to the requested format and precision."""
+    if args.precision == "int8" and args.format != "openvino":
+        message = "INT8 quantization requires --format openvino"
+        raise ValueError(message)
+
+    if args.precision == "int8" and args.data_root is None:
+        message = "--data-root is required to quantize a model to INT8"
+        raise ValueError(message)
+
+    engine = create_engine(
+        model=args.model,
+        data=str(args.data_root),
+        work_dir=str(args.work_dir),
+        device=args.device,
+        checkpoint=str(args.checkpoint) if args.checkpoint else None,
+        task=args.task,
+    )
+
+    export_format = ExportFormat.ONNX if args.format == "onnx" else ExportFormat.OPENVINO
+    export_precision = Precision.FP16 if args.precision == "fp16" else Precision.FP32
+    exported = engine.export(export_format=export_format, export_precision=export_precision)
+    print(f"Exported {export_format.value} {export_precision.value}: {exported}")
+
+    if args.precision == "int8":
+        quantized = _quantize(Path(exported), args)
+        print(f"Quantized OpenVINO INT8: {quantized}")
+        return Path(quantized)
+
+    return Path(exported)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, help="Model name, recipe YAML path, or .xml/.onnx model")
+    parser.add_argument("--task", type=_task, help="Task type, for example DETECTION or OBJECT DETECTION")
+    parser.add_argument(
+        "--data-root", required=True, type=Path, help="Dataset root, required for recipe export and INT8 quantization"
+    )
+    parser.add_argument("--checkpoint", type=Path, help="Trained model checkpoint to export")
+    parser.add_argument("--work-dir", type=Path, default=Path("./getitune-workspace"))
+    parser.add_argument("--format", choices=("openvino", "onnx"), default="openvino")
+    parser.add_argument("--precision", choices=("fp32", "fp16", "int8"), default="fp16")
+    parser.add_argument("--device", default="auto", help="Device, for example auto, cpu, gpu, or xpu")
+    return parser
+
+
+def main() -> None:
+    """Parse arguments and export the model."""
+    args = build_parser().parse_args()
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        run(args)
+    except (FileNotFoundError, RuntimeError, TypeError, ValueError) as error:
+        message = f"error: {error}"
+        raise SystemExit(message) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/library/scripts/export.py
+++ b/library/scripts/export.py
@@ -45,6 +45,13 @@ def _quantize(model: Path, args: argparse.Namespace) -> Path:
 
 def run(args: argparse.Namespace) -> Path:
     """Export a model to the requested format and precision."""
+    if Path(str(args.model)).suffix.lower() in {".xml", ".onnx"}:
+        message = (
+            "--model must be a model name or recipe YAML when using export.py; "
+            "exporting from an already-exported .xml/.onnx model is not supported."
+        )
+        raise ValueError(message)
+
     if args.precision == "int8" and args.format != "openvino":
         message = "INT8 quantization requires --format openvino"
         raise ValueError(message)
@@ -78,8 +85,8 @@ def run(args: argparse.Namespace) -> Path:
 def build_parser() -> argparse.ArgumentParser:
     """Build the command-line argument parser."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--model", required=True, help="Model name, recipe YAML path, or .xml/.onnx model")
-    parser.add_argument("--task", type=_task, help="Task type, for example DETECTION or OBJECT DETECTION")
+    parser.add_argument("--model", required=True, help="Model name or recipe YAML path")
+    parser.add_argument("--task", type=_task, help="Task type, for example DETECTION or INSTANCE_SEGMENTATION")
     parser.add_argument(
         "--data-root", required=True, type=Path, help="Dataset root, required for recipe export and INT8 quantization"
     )

--- a/library/scripts/predict.py
+++ b/library/scripts/predict.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from getitune.engine import create_engine
+from coco_utils import iter_image_files, write_coco
 
-from .coco_utils import iter_image_files, write_coco
+from getitune.engine import create_engine
 
 
 def _task(value: str) -> str:

--- a/library/scripts/predict.py
+++ b/library/scripts/predict.py
@@ -1,0 +1,118 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Predict with an OV / ONNX / torch model and save predictions in COCO format."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from getitune.engine import create_engine
+
+from .coco_utils import iter_image_files, write_coco
+
+
+def _task(value: str) -> str:
+    value = value.strip().upper().replace("-", "_").replace(" ", "_")
+    from getitune.types import TaskType
+
+    aliases = {
+        "DETECTION": TaskType.DETECTION.value,
+        "INSTANCE_SEGMENTATION": TaskType.INSTANCE_SEGMENTATION.value,
+        "SEMANTIC_SEGMENTATION": TaskType.SEMANTIC_SEGMENTATION.value,
+        "KEYPOINT_DETECTION": TaskType.KEYPOINT_DETECTION.value,
+        "MULTI_CLASS_CLS": TaskType.MULTI_CLASS_CLS.value,
+        "MULTI_LABEL_CLS": TaskType.MULTI_LABEL_CLS.value,
+    }
+    value = aliases.get(value, value)
+    try:
+        return TaskType(value).value
+    except ValueError as error:
+        choices = ", ".join(task.value for task in TaskType)
+        message = f"unknown task {value!r}; choose from {choices}"
+        raise argparse.ArgumentTypeError(message) from error
+
+
+def run(args: argparse.Namespace) -> None:
+    """Run prediction and write COCO predictions to disk."""
+    model_path = Path(args.model)
+    is_torch = model_path.suffix.lower() in {".ckpt", ".pt", ".pth"}
+    if is_torch and args.checkpoint is None:
+        args.checkpoint = model_path
+        args.model = args.recipe
+
+    if is_torch:
+        if not args.recipe:
+            message = "--recipe (model name or recipe path) is required for a torch checkpoint"
+            raise ValueError(message)
+        if not args.task:
+            message = "--task is required for a torch checkpoint"
+            raise ValueError(message)
+
+    create_kwargs: dict = {
+        "model": args.recipe if is_torch else str(model_path),
+        "data": str(args.input),
+        "work_dir": str(args.work_dir),
+        "device": args.device,
+    }
+    if is_torch:
+        create_kwargs["checkpoint"] = str(args.checkpoint)
+        create_kwargs["task"] = args.task
+
+    engine = create_engine(**create_kwargs)
+
+    image_files = iter_image_files(Path(args.input))
+    predictions = engine.predict(data=str(args.input))
+
+    write_coco(predictions, Path(args.output), engine.model.label_info, image_files)
+    print(f"Wrote COCO predictions for {len(predictions)} batch(es) to {args.output}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="Trained model: .xml/.onnx file, or a .ckpt/.pt/.pth torch checkpoint",
+    )
+    parser.add_argument(
+        "--recipe",
+        help="Model name or recipe YAML path (required when --model is a torch checkpoint)",
+    )
+    parser.add_argument(
+        "--task",
+        type=_task,
+        help="Task type, for example DETECTION (required for torch checkpoints)",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        help="Torch checkpoint path (defaults to --model when it is a checkpoint)",
+    )
+    parser.add_argument(
+        "--input",
+        required=True,
+        type=Path,
+        help="Dataset root or images folder to run predictions on",
+    )
+    parser.add_argument("--work-dir", type=Path, default=Path("./getitune-workspace"))
+    parser.add_argument("--device", default="auto", help="Device, for example auto, cpu, gpu, or xpu")
+    parser.add_argument("--output", type=Path, default=Path("predictions.json"), help="Output COCO JSON path")
+    return parser
+
+
+def main() -> None:
+    """Parse arguments and run prediction."""
+    args = build_parser().parse_args()
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        run(args)
+    except (FileNotFoundError, RuntimeError, TypeError, ValueError) as error:
+        message = f"error: {error}"
+        raise SystemExit(message) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/library/scripts/test.py
+++ b/library/scripts/test.py
@@ -83,18 +83,18 @@ def _resolve_metric(
         message = f"unsupported metric(s) {unknown} for task {task}; supported: {supported}"
         raise ValueError(message)
 
-    metrics: dict[str, Metric] = {}
-    for name in metric_names:
-        result = available[name](label_info)
-        if isinstance(result, MetricCollection):
-            for key, metric in result.items():
-                metrics[f"{name}/{key}"] = metric
-        else:
-            metrics[name] = result
-    collection = MetricCollection(metrics)
+    def _callable(current_label_info: LabelInfo) -> MetricCollection:
+        metrics: dict[str, Metric] = {}
+        for name in metric_names:
+            result = available[name](current_label_info)
+            if isinstance(result, MetricCollection):
+                for key, metric in result.items():
+                    metrics[f"{name}/{key}"] = metric
+            else:
+                metrics[name] = result
+        return MetricCollection(metrics)
 
-    def _callable(_: LabelInfo) -> MetricCollection:
-        return collection
+    _callable(label_info)
 
     return _callable
 

--- a/library/scripts/test.py
+++ b/library/scripts/test.py
@@ -60,7 +60,6 @@ METRIC_REGISTRY: dict[str, dict[str, MetricFactory]] = {
     TaskType.INSTANCE_SEGMENTATION.value: {
         "f1-score": _f_measure_callable,
         "map": _mask_rle_mean_ap_callable,
-        "dice": _segm_callable,
     },
     TaskType.SEMANTIC_SEGMENTATION.value: {
         "dice": _segm_callable,
@@ -176,7 +175,7 @@ def build_parser() -> argparse.ArgumentParser:
             "One or more metrics to evaluate (overrides recipe defaults). "
             "Supported per task: MULTI_CLASS_CLS=accuracy,f1-score; "
             "MULTI_LABEL_CLS=accuracy,f1-score,map; "
-            "DETECTION=f1-score,map; INSTANCE_SEGMENTATION=f1-score,map,dice; "
+            "DETECTION=f1-score,map; INSTANCE_SEGMENTATION=f1-score,map; "
             "SEMANTIC_SEGMENTATION=dice,miou; KEYPOINT_DETECTION=pck,pck-score"
         ),
     )

--- a/library/scripts/test.py
+++ b/library/scripts/test.py
@@ -1,0 +1,198 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Evaluate a getitune model on a dataset and print the computed metrics."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Callable
+
+from torchmetrics import Metric, MetricCollection
+
+from getitune.engine import create_engine
+from getitune.metrics.accuracy import MultiClassClsMetricCallable, MultiLabelClsMetricCallable
+from getitune.metrics.dice import _segm_callable
+from getitune.metrics.fmeasure import _f_measure_callable
+from getitune.metrics.mean_ap import _mask_rle_mean_ap_callable, _mean_ap_callable
+from getitune.metrics.mlc_map import MultilabelmAP
+from getitune.metrics.pck import _pck_measure_callable
+from getitune.types.label import LabelInfo
+from getitune.types.task import TaskType
+
+MetricFactory = Callable[[LabelInfo], Metric | MetricCollection]
+
+
+def _task(value: str) -> str:
+    value = value.strip().upper().replace("-", "_").replace(" ", "_")
+    aliases = {
+        "DETECTION": TaskType.DETECTION.value,
+        "INSTANCE_SEGMENTATION": TaskType.INSTANCE_SEGMENTATION.value,
+        "SEMANTIC_SEGMENTATION": TaskType.SEMANTIC_SEGMENTATION.value,
+        "KEYPOINT_DETECTION": TaskType.KEYPOINT_DETECTION.value,
+        "MULTI_CLASS_CLS": TaskType.MULTI_CLASS_CLS.value,
+        "MULTI_LABEL_CLS": TaskType.MULTI_LABEL_CLS.value,
+    }
+    value = aliases.get(value, value)
+    try:
+        return TaskType(value).value
+    except ValueError as error:
+        choices = ", ".join(task.value for task in TaskType)
+        message = f"unknown task {value!r}; choose from {choices}"
+        raise argparse.ArgumentTypeError(message) from error
+
+
+METRIC_REGISTRY: dict[str, dict[str, MetricFactory]] = {
+    TaskType.MULTI_CLASS_CLS.value: {
+        "accuracy": MultiClassClsMetricCallable,
+        "f1-score": MultiClassClsMetricCallable,
+    },
+    TaskType.MULTI_LABEL_CLS.value: {
+        "accuracy": MultiLabelClsMetricCallable,
+        "f1-score": MultiLabelClsMetricCallable,
+        "map": lambda label_info: MultilabelmAP(label_info),
+    },
+    TaskType.DETECTION.value: {
+        "f1-score": _f_measure_callable,
+        "map": _mean_ap_callable,
+    },
+    TaskType.INSTANCE_SEGMENTATION.value: {
+        "f1-score": _f_measure_callable,
+        "map": _mask_rle_mean_ap_callable,
+        "dice": _segm_callable,
+    },
+    TaskType.SEMANTIC_SEGMENTATION.value: {
+        "dice": _segm_callable,
+        "miou": _segm_callable,
+    },
+    TaskType.KEYPOINT_DETECTION.value: {
+        "pck": _pck_measure_callable,
+        "pck-score": _pck_measure_callable,
+    },
+}
+
+
+def _resolve_metric(
+    task: str, metric_names: list[str], label_info: LabelInfo
+) -> Callable[[LabelInfo], Metric | MetricCollection]:
+    available = METRIC_REGISTRY.get(task, {})
+    unknown = [name for name in metric_names if name not in available]
+    if unknown:
+        supported = ", ".join(sorted(available)) or "none"
+        message = f"unsupported metric(s) {unknown} for task {task}; supported: {supported}"
+        raise ValueError(message)
+
+    metrics: dict[str, Metric] = {}
+    for name in metric_names:
+        result = available[name](label_info)
+        if isinstance(result, MetricCollection):
+            for key, metric in result.items():
+                metrics[f"{name}/{key}"] = metric
+        else:
+            metrics[name] = result
+    collection = MetricCollection(metrics)
+
+    def _callable(_: LabelInfo) -> MetricCollection:
+        return collection
+
+    return _callable
+
+
+def run(args: argparse.Namespace) -> None:
+    """Evaluate the model and print the test metrics."""
+    model_path = Path(args.model)
+    is_torch = model_path.suffix.lower() in {".ckpt", ".pt", ".pth"}
+    if is_torch and args.checkpoint is None:
+        args.checkpoint = model_path
+        args.model = args.recipe
+
+    if is_torch:
+        if not args.recipe:
+            message = "--recipe (model name or recipe path) is required for a torch checkpoint"
+            raise ValueError(message)
+        if not args.task:
+            message = "--task is required for a torch checkpoint"
+            raise ValueError(message)
+
+    create_kwargs: dict = {
+        "model": args.recipe if is_torch else str(model_path),
+        "data": str(args.data_root),
+        "work_dir": str(args.work_dir),
+        "device": args.device,
+    }
+    if is_torch:
+        create_kwargs["checkpoint"] = str(args.checkpoint)
+        create_kwargs["task"] = args.task
+
+    engine = create_engine(**create_kwargs)
+
+    metric = None
+    if args.metric:
+        metric = _resolve_metric(engine.task, args.metric, engine.model.label_info)
+
+    print(f"Evaluating {args.model} on {args.data_root} (task={engine.task})")
+    metrics = engine.test(metric=metric)
+    print("Test metrics:")
+    for key, value in metrics.items():
+        print(f"  {key}: {value}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model",
+        required=True,
+        help="Trained model: .xml/.onnx file, or a .ckpt/.pt/.pth torch checkpoint",
+    )
+    parser.add_argument(
+        "--recipe",
+        help="Model name or recipe YAML path (required when --model is a torch checkpoint)",
+    )
+    parser.add_argument(
+        "--task",
+        type=_task,
+        help="Task type, for example DETECTION (required for torch checkpoints)",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        help="Torch checkpoint path (defaults to --model when it is a checkpoint)",
+    )
+    parser.add_argument(
+        "--data-root",
+        required=True,
+        type=Path,
+        help="Path to the dataset root used for evaluation",
+    )
+    parser.add_argument("--work-dir", type=Path, default=Path("./getitune-workspace"))
+    parser.add_argument("--device", default="auto", help="Device, for example auto, cpu, gpu, or xpu")
+    parser.add_argument(
+        "--metric",
+        nargs="+",
+        metavar="NAME",
+        help=(
+            "One or more metrics to evaluate (overrides recipe defaults). "
+            "Supported per task: MULTI_CLASS_CLS=accuracy,f1-score; "
+            "MULTI_LABEL_CLS=accuracy,f1-score,map; "
+            "DETECTION=f1-score,map; INSTANCE_SEGMENTATION=f1-score,map,dice; "
+            "SEMANTIC_SEGMENTATION=dice,miou; KEYPOINT_DETECTION=pck,pck-score"
+        ),
+    )
+    return parser
+
+
+def main() -> None:
+    """Parse arguments and evaluate the model."""
+    args = build_parser().parse_args()
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        run(args)
+    except (FileNotFoundError, RuntimeError, TypeError, ValueError) as error:
+        message = f"error: {error}"
+        raise SystemExit(message) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/library/scripts/train.py
+++ b/library/scripts/train.py
@@ -1,0 +1,136 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Train, test, export, and optionally quantize a getitune model."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from getitune.backend.lightning.engine import LightningEngine
+from getitune.engine import create_engine
+from getitune.types import TaskType
+from getitune.types.export import ExportFormat
+from getitune.types.precision import Precision
+
+
+def _task(value: str) -> str:
+    value = value.strip().upper().replace("-", "_").replace(" ", "_")
+    aliases = {
+        "DETECTION": TaskType.DETECTION.value,
+        "INSTANCE_SEGMENTATION": TaskType.INSTANCE_SEGMENTATION.value,
+        "SEMANTIC_SEGMENTATION": TaskType.SEMANTIC_SEGMENTATION.value,
+        "KEYPOINT_DETECTION": TaskType.KEYPOINT_DETECTION.value,
+        "MULTI_CLASS_CLS": TaskType.MULTI_CLASS_CLS.value,
+        "MULTI_LABEL_CLS": TaskType.MULTI_LABEL_CLS.value,
+    }
+    value = aliases.get(value, value)
+    try:
+        return TaskType(value).value
+    except ValueError as error:
+        choices = ", ".join(task.value for task in TaskType)
+        message = f"unknown task {value!r}; choose from {choices}"
+        raise argparse.ArgumentTypeError(message) from error
+
+
+def _disable_early_stopping(engine: LightningEngine) -> None:
+    if not isinstance(engine, LightningEngine):
+        return
+
+    from lightning.pytorch.callbacks import EarlyStopping
+
+    callbacks = engine._cache.args.get("callbacks", [])  # noqa: SLF001
+    callbacks = [callback for callback in callbacks if not isinstance(callback, EarlyStopping)]
+    engine._cache.args["callbacks"] = callbacks  # noqa: SLF001
+
+
+def run(args: argparse.Namespace) -> None:
+    """Run the requested training workflow."""
+    task = args.task
+    export_format_name = "openvino" if args.export_format == "ov" else args.export_format
+    if args.quantize and export_format_name != "openvino":
+        message = "quantization requires --export-format openvino"
+        raise ValueError(message)
+
+    engine = create_engine(
+        model=args.model,
+        data=str(args.data_root),
+        work_dir=str(args.work_dir),
+        device=args.device,
+        checkpoint=str(args.checkpoint) if args.checkpoint else None,
+        task=task,
+    )
+
+    if args.no_early_stopping:
+        _disable_early_stopping(engine)
+
+    train_args = {"max_epochs": args.epochs, "precision": args.precision}
+    if args.batch is not None and not isinstance(engine, LightningEngine):
+        train_args["batch"] = args.batch
+    if args.no_early_stopping and not isinstance(engine, LightningEngine):
+        if hasattr(engine, "_training_defaults"):
+            engine._training_defaults["patience"] = None  # noqa: SLF001
+        else:
+            train_args["patience"] = 0
+
+    print(f"Training {args.model} for {args.epochs} epoch(s) on {args.device}")
+    print(f"Train metrics: {engine.train(**train_args)}")
+    print(f"Test metrics: {engine.test()}")
+
+    if not (args.export or args.quantize):
+        return
+
+    export_format = ExportFormat.OPENVINO if export_format_name == "openvino" else ExportFormat.ONNX
+    export_precision = Precision.FP16 if args.export_precision == "fp16" else Precision.FP32
+    exported = engine.export(export_format=export_format, export_precision=export_precision)
+    print(f"Exported {export_format.value}: {exported}")
+
+    if args.quantize:
+        quantized_engine = create_engine(
+            model=exported,
+            data=engine.datamodule,
+            work_dir=str(args.work_dir),
+        )
+        quantized = quantized_engine.optimize()
+        print(f"Quantized OpenVINO model: {quantized}")
+        print(f"Quantized test metrics: {quantized_engine.test()}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line argument parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", required=True, help="Model name or recipe YAML path")
+    parser.add_argument("--task", type=_task, help="Task type, for example DETECTION or OBJECT DETECTION")
+    parser.add_argument("--data-root", required=True, type=Path, help="Dataset root or supported dataset file")
+    parser.add_argument("--work-dir", type=Path, default=Path("./getitune-workspace"))
+    parser.add_argument("--checkpoint", type=Path, help="Optional checkpoint for warm-start training")
+    parser.add_argument("--epochs", type=int, default=100)
+    parser.add_argument("--batch", type=int, help="Optional batch-size override")
+    parser.add_argument("--precision", default="16-mixed", help="Training precision, for example 32 or bf16")
+    parser.add_argument("--device", default="auto", help="Device, for example auto, cpu, gpu, or xpu")
+    parser.add_argument(
+        "--no-early-stopping",
+        action="store_true",
+        help="Disable early stopping configured by the recipe",
+    )
+    parser.add_argument("--export", action="store_true", help="Export the trained model")
+    parser.add_argument("--export-format", choices=("openvino", "ov", "onnx"), default="openvino")
+    parser.add_argument("--export-precision", choices=("fp32", "fp16"), default="fp32")
+    parser.add_argument("--quantize", action="store_true", help="Quantize the exported OpenVINO model to INT8")
+    return parser
+
+
+def main() -> None:
+    """Parse arguments and run training."""
+    args = build_parser().parse_args()
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        run(args)
+    except (FileNotFoundError, RuntimeError, TypeError, ValueError) as error:
+        message = f"error: {error}"
+        raise SystemExit(message) from error
+
+
+if __name__ == "__main__":
+    main()

--- a/library/scripts/train.py
+++ b/library/scripts/train.py
@@ -101,7 +101,7 @@ def build_parser() -> argparse.ArgumentParser:
     """Build the command-line argument parser."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model", required=True, help="Model name or recipe YAML path")
-    parser.add_argument("--task", type=_task, help="Task type, for example DETECTION or OBJECT DETECTION")
+    parser.add_argument("--task", type=_task, help="Task type, for example DETECTION or INSTANCE_SEGMENTATION")
     parser.add_argument("--data-root", required=True, type=Path, help="Dataset root or supported dataset file")
     parser.add_argument("--work-dir", type=Path, default=Path("./getitune-workspace"))
     parser.add_argument("--checkpoint", type=Path, help="Optional checkpoint for warm-start training")


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

For now CLI support in Library is outdated, this PR temporary substitute necessary functionality to run getitune using prepared python scripts. It is also very useful for quick experiments and debugging.

1. **train.py:** e2e training with possible export and quantization. Accepts a model name or recipe, dataset root, device, epochs, batch size, and precision, with flags to disable early stopping and to export (--export) to OpenVINO/ONNX and quantize (--quantize) to INT8.
2. **test.py:** Evaluate a trained model (torch .ckpt/.pt/.pth, or exported OV/ONNX) on a dataset and print the resulting metrics. Supports a task-aware --metric override (e.g. f1-score, map, dice, miou, pck) mapped per task, so invalid combinations like map for multiclass classification are rejected.
3. **export.py:**  Export a getitune model to OpenVINO or ONNX at FP32/FP16, or to INT8 via post-training quantization. Defaults to OpenVINO FP16; INT8 requires a dataset root for the calibration step.
4. **benchmark.py:** Prepare a model (export a recipe or quantize to INT8 as needed) and run OpenVINO benchmark_app against it, forwarding device, batch, input shape, hint, and iteration/time options for latency/throughput measurement.
5. **predict.py:** Run inference with an OV/ONNX/torch model on a dataset or images folder and write the predictions to a COCO-format JSON file (bounding boxes, RLE masks for segmentation, and keypoints), using coco_utils.py for the conversion. NOTE: I plan to add visualization option in that script in the next PR.

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
