### PR TITLE
Remove onnx encoder file from the build

### DIFF
--- a/application/ui/rsbuild.config.ts
+++ b/application/ui/rsbuild.config.ts
@@ -177,8 +177,22 @@ export default defineConfig({
             // `exports` map is keyed on `browser`.
             const conditionNames = ['onnxruntime-web-use-extern-wasm', '...'];
 
+            // `@geti-ui/smart-tools` still builds both model URLs eagerly at module scope
+            // (`new URL('./mobile_sam.encoder.onnx', import.meta.url)`), which makes rspack
+            // emit the 27 MB encoder regardless. `emit: false` keeps the reference
+            // resolvable while dropping the binary from the output.
+            const rules = [
+                ...(config.module?.rules ?? []),
+                {
+                    test: /[\\/]@geti-ui[\\/]smart-tools[\\/].*mobile_sam\.encoder\.onnx$/,
+                    type: 'asset/resource' as const,
+                    generator: { emit: false },
+                },
+            ];
+
             return {
                 ...config,
+                module: { ...config.module, rules },
                 resolve: { ...config.resolve, extensions, conditionNames },
                 watchOptions: { ...config.watchOptions, ignored: ['**/src-tauri/**'] },
             };


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Slashed 27mb from the build. Now that we have SAM encoding on the server side, we dont need this. Ty Leonardo for the catch!

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
