### PR TITLE
SAM tool encoder: use F32 precision only for ARM64

### DIFF
--- a/application/backend/app/services/sam/media_segment_service.py
+++ b/application/backend/app/services/sam/media_segment_service.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+import platform
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -44,11 +45,14 @@ SAM_ENCODER_CONFIGURATION = {
     "pad_value": 0,
 }
 
-# The mobile_sam encoder IR is numerically unstable in f16: the graph emits the same
-# embedding for every input, so the client decodes an empty mask with no error anywhere.
-# f16 is the CPU plugin default on Apple Silicon (x86 defaults to bf16/f32), so this only
-# reproduces on macOS ARM. Pin f32 explicitly on every platform.
-SAM_ENCODER_PLUGIN_CONFIG = {"INFERENCE_PRECISION_HINT": "f32"}
+
+# The mobile_sam encoder IR is numerically unstable in f16 on Apple Silicon (ARM):
+# the graph emits the same embedding for every input, so the client decodes an empty
+# mask with no error anywhere. As a workaround, we pin the inference precision to f32
+# on arm64 (a.k.a. aarch64), meanwhile other platforms can use the plugin default.
+def _get_encoder_plugin_config() -> dict[str, str]:
+    is_apple_silicon = platform.system() == "Darwin" and platform.machine() in {"arm64", "aarch64"}
+    return {"INFERENCE_PRECISION_HINT": "f32"} if is_apple_silicon else {}
 
 
 class MediaSegmentService(BaseSessionManagedService):
@@ -80,7 +84,7 @@ class MediaSegmentService(BaseSessionManagedService):
             core,
             str(self.model_xml_path),
             device=device,
-            plugin_config=SAM_ENCODER_PLUGIN_CONFIG,
+            plugin_config=_get_encoder_plugin_config(),
             max_num_requests=1,
         )
         return Model.create_model(adapter, configuration=SAM_ENCODER_CONFIGURATION)

--- a/application/backend/app/services/sam/media_segment_service.py
+++ b/application/backend/app/services/sam/media_segment_service.py
@@ -51,8 +51,8 @@ SAM_ENCODER_CONFIGURATION = {
 # mask with no error anywhere. As a workaround, we pin the inference precision to f32
 # on arm64 (a.k.a. aarch64), meanwhile other platforms can use the plugin default.
 def _get_encoder_plugin_config() -> dict[str, str]:
-    is_apple_silicon = platform.system() == "Darwin" and platform.machine() in {"arm64", "aarch64"}
-    return {"INFERENCE_PRECISION_HINT": "f32"} if is_apple_silicon else {}
+    is_arm = platform.machine() in {"arm64", "aarch64"}
+    return {"INFERENCE_PRECISION_HINT": "f32"} if is_arm else {}
 
 
 class MediaSegmentService(BaseSessionManagedService):

--- a/application/backend/tests/unit/services/test_media_segment_service.py
+++ b/application/backend/tests/unit/services/test_media_segment_service.py
@@ -18,8 +18,8 @@ from app.services.media_numpy_loader import MediaNumpyLoader
 from app.services.media_service import MediaService
 from app.services.sam.media_segment_service import (
     SAM_EMBEDDING_MODEL_VERSION,
-    SAM_ENCODER_PLUGIN_CONFIG,
     MediaSegmentService,
+    _get_encoder_plugin_config,
 )
 
 
@@ -105,7 +105,7 @@ class TestMediaSegmentService:
         tensors = safetensors_load(blob)
         np.testing.assert_array_equal(tensors["image_embeddings"], embeddings)
 
-    def test_load_model_pins_f32_precision(self, fxt_media_service, fxt_media_numpy_loader, tmp_path):
+    def test_load_model_pins_precision_per_platform(self, fxt_media_service, fxt_media_numpy_loader, tmp_path):
         service = MediaSegmentService(
             media_service=fxt_media_service,
             media_numpy_loader=fxt_media_numpy_loader,
@@ -123,7 +123,25 @@ class TestMediaSegmentService:
             service._load_model(device="CPU")
 
         core.set_property.assert_any_call({"CACHE_DIR": str(tmp_path)})
-        assert mock_adapter.call_args.kwargs["plugin_config"] == SAM_ENCODER_PLUGIN_CONFIG
+        assert mock_adapter.call_args.kwargs["plugin_config"] == _get_encoder_plugin_config()
+
+    @pytest.mark.parametrize(
+        "system, machine, expected_config",
+        [
+            ("Darwin", "arm64", {"INFERENCE_PRECISION_HINT": "f32"}),
+            ("Darwin", "aarch64", {"INFERENCE_PRECISION_HINT": "f32"}),
+            ("Darwin", "x86_64", {}),
+            ("Linux", "arm64", {}),
+            ("Linux", "x86_64", {}),
+            ("Windows", "x86_64", {}),
+        ],
+    )
+    def test_get_encoder_plugin_config(self, system, machine, expected_config):
+        with (
+            patch("app.services.sam.media_segment_service.platform.system", return_value=system),
+            patch("app.services.sam.media_segment_service.platform.machine", return_value=machine),
+        ):
+            assert _get_encoder_plugin_config() == expected_config
 
     def test_encode_media_image(self, fxt_media_segment_service, fxt_media_numpy_loader):
         project = MagicMock(spec=Project, id=uuid4())

--- a/application/backend/tests/unit/services/test_media_segment_service.py
+++ b/application/backend/tests/unit/services/test_media_segment_service.py
@@ -126,19 +126,15 @@ class TestMediaSegmentService:
         assert mock_adapter.call_args.kwargs["plugin_config"] == _get_encoder_plugin_config()
 
     @pytest.mark.parametrize(
-        "system, machine, expected_config",
+        "machine, expected_config",
         [
-            ("Darwin", "arm64", {"INFERENCE_PRECISION_HINT": "f32"}),
-            ("Darwin", "aarch64", {"INFERENCE_PRECISION_HINT": "f32"}),
-            ("Darwin", "x86_64", {}),
-            ("Linux", "arm64", {}),
-            ("Linux", "x86_64", {}),
-            ("Windows", "x86_64", {}),
+            ("arm64", {"INFERENCE_PRECISION_HINT": "f32"}),
+            ("aarch64", {"INFERENCE_PRECISION_HINT": "f32"}),
+            ("x86_64", {}),
         ],
     )
-    def test_get_encoder_plugin_config(self, system, machine, expected_config):
+    def test_get_encoder_plugin_config(self, machine, expected_config):
         with (
-            patch("app.services.sam.media_segment_service.platform.system", return_value=system),
             patch("app.services.sam.media_segment_service.platform.machine", return_value=machine),
         ):
             assert _get_encoder_plugin_config() == expected_config


### PR DESCRIPTION
### Summary

This PR refines the workaround introduced in #7354 (a fix for an issue with the SAM encoder returning bad embeddings on ARM64), limiting the scope of the original fix to ARM64 platforms only. Conversely, x86_64 can still run inference in F16/BF16 which is faster than F32.

### How to test

Check that the SAM tool returns good results on:
- [x] x86_64
- [x] arm64

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
