### PR TITLE
Zoom & label improvements

### DIFF
--- a/application/ui/src/components/zoom/zoom-gestures.test.tsx
+++ b/application/ui/src/components/zoom/zoom-gestures.test.tsx
@@ -1,0 +1,101 @@
+// Copyright (C) 2025 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { act, fireEvent, screen } from '@testing-library/react';
+import { render } from 'test-utils/render';
+
+import { useContainerSize } from './use-container-size';
+import { ZoomTransform } from './zoom-transform';
+import { ZoomProvider } from './zoom.provider';
+
+vi.mock('./use-container-size', () => ({
+    useContainerSize: vi.fn(),
+}));
+
+const INITIAL_SCALE = 0.9;
+const MAX_SCALE = INITIAL_SCALE * 10;
+const WHEEL_STEP = Math.exp(0.2);
+
+// Stable references, otherwise useSyncZoom re-runs setZoom on every render and loops
+const SCREEN_SIZE = { width: 500, height: 500 };
+const CONTENT_SIZE = { width: 500, height: 500 };
+
+const setupZoom = () => {
+    vi.mocked(useContainerSize).mockImplementation(() => SCREEN_SIZE);
+
+    render(
+        <ZoomProvider>
+            <ZoomTransform target={CONTENT_SIZE}>Content</ZoomTransform>
+        </ZoomProvider>
+    );
+
+    const container = screen.getByTestId('zoom-transform').parentElement as HTMLElement;
+    const getScale = () => Number(container.style.getPropertyValue('--zoom-scale'));
+
+    return { container, getScale };
+};
+
+const wheel = (container: HTMLElement, deltaY: number, ctrlKey = false) =>
+    fireEvent.wheel(container, { deltaY, ctrlKey, clientX: 250, clientY: 250 });
+
+describe('Zoom gestures', () => {
+    it('zooms in on wheel up and out on wheel down', () => {
+        const { container, getScale } = setupZoom();
+
+        wheel(container, -100);
+        const zoomedIn = getScale();
+        expect(zoomedIn).toBeGreaterThan(INITIAL_SCALE);
+
+        wheel(container, 100);
+        expect(getScale()).toBeLessThan(zoomedIn);
+    });
+
+    it('accumulates every wheel event when several arrive before a re-render', () => {
+        const { container, getScale } = setupZoom();
+
+        // One act, so React commits once for all five, the way a trackpad's stream outpaces rendering
+        act(() => {
+            for (let index = 0; index < 5; index++) {
+                wheel(container, -100);
+            }
+        });
+
+        // Reading a stale scale instead of the previous one would leave this at a single step
+        expect(getScale()).toBeCloseTo(INITIAL_SCALE * WHEEL_STEP ** 5, 5);
+    });
+
+    it('keeps zooming in on a large delta instead of collapsing to fit-to-screen', () => {
+        const { container, getScale } = setupZoom();
+
+        // A factor of 1 - deltaY / 500 would turn negative here and clamp back to the initial scale
+        wheel(container, -2000);
+
+        expect(getScale()).toBeGreaterThan(INITIAL_SCALE);
+    });
+
+    it('never zooms outside the fit-to-screen and max bounds', () => {
+        const { container, getScale } = setupZoom();
+
+        act(() => {
+            for (let index = 0; index < 20; index++) {
+                wheel(container, -1000);
+            }
+        });
+        expect(getScale()).toBeLessThanOrEqual(MAX_SCALE);
+
+        act(() => {
+            for (let index = 0; index < 20; index++) {
+                wheel(container, 1000);
+            }
+        });
+        expect(getScale()).toBeCloseTo(INITIAL_SCALE, 5);
+    });
+
+    it('does not apply the wheel factor to ctrl+wheel, which the pinch handler owns', () => {
+        const { container, getScale } = setupZoom();
+
+        wheel(container, -100, true);
+
+        expect(getScale()).not.toBeCloseTo(INITIAL_SCALE * WHEEL_STEP, 5);
+    });
+});

--- a/application/ui/src/components/zoom/zoom-transform.tsx
+++ b/application/ui/src/components/zoom/zoom-transform.tsx
@@ -39,42 +39,42 @@ export const ZoomTransform = ({ children, target, zoomInMultiplier = 10, zoomOut
 
     useGesture(
         {
-            onPinch: ({ origin, offset: [deltaDistance] }) => {
+            onPinch: ({ origin, offset: [pinchScale] }) => {
                 const rect = containerRef.current?.getBoundingClientRect();
                 if (!rect) return;
 
-                const factor = 1 + deltaDistance / 200;
-                const newScale = clampBetween(
-                    zoom.initialCoordinates.scale,
-                    zoom.initialCoordinates.scale * factor,
-                    zoom.maxZoomIn
-                );
-                const relativeCursor = { x: origin[0] - rect.left, y: origin[1] - rect.top };
+                const cursorX = origin[0] - rect.left;
+                const cursorY = origin[1] - rect.top;
 
-                setZoom(
+                setZoom((prev) =>
                     getZoomState({
-                        newScale,
-                        cursorX: relativeCursor.x,
-                        cursorY: relativeCursor.y,
-                        initialCoordinates: zoom.initialCoordinates,
-                    })
+                        newScale: pinchScale,
+                        cursorX,
+                        cursorY,
+                        initialCoordinates: prev.initialCoordinates,
+                    })(prev)
                 );
             },
             onWheel: ({ event, delta: [, verticalScrollDelta] }) => {
+                // A trackpad pinch arrives as ctrl+wheel, which onPinch already handles
+                if (event.ctrlKey) return;
+
                 const rect = containerRef.current?.getBoundingClientRect();
                 if (!rect) return;
 
-                const factor = 1 - verticalScrollDelta / 500;
-                const newScale = clampBetween(zoom.initialCoordinates.scale, zoom.scale * factor, zoom.maxZoomIn);
-                const relativeCursor = { x: event.clientX - rect.left, y: event.clientY - rect.top };
+                // Exponential so the step stays proportional and never flips sign on large deltas
+                const factor = Math.exp(-verticalScrollDelta / 500);
+                const cursorX = event.clientX - rect.left;
+                const cursorY = event.clientY - rect.top;
 
-                setZoom(
+                // Scaled off prev, since React batches the many events a trackpad emits per frame
+                setZoom((prev) =>
                     getZoomState({
-                        newScale,
-                        cursorX: relativeCursor.x,
-                        cursorY: relativeCursor.y,
-                        initialCoordinates: zoom.initialCoordinates,
-                    })
+                        newScale: clampBetween(prev.initialCoordinates.scale, prev.scale * factor, prev.maxZoomIn),
+                        cursorX,
+                        cursorY,
+                        initialCoordinates: prev.initialCoordinates,
+                    })(prev)
                 );
             },
             onDrag: ({ delta: [x, y] }) => handleTranslateUpdate({ x, y }),
@@ -83,7 +83,12 @@ export const ZoomTransform = ({ children, target, zoomInMultiplier = 10, zoomOut
             target: containerRef,
             eventOptions: { passive: false },
             wheel: { preventDefault: true },
-            pinch: { preventDefault: true },
+            pinch: {
+                preventDefault: true,
+                // Makes offset[0] an absolute scale that resumes from the current zoom
+                from: () => [zoom.scale, 0],
+                scaleBounds: () => ({ min: zoom.initialCoordinates.scale, max: zoom.maxZoomIn }),
+            },
             drag: { enabled: isPanning },
         }
     );

--- a/application/ui/src/features/annotator/annotations/annotation-labels/annotation-labels.component.test.tsx
+++ b/application/ui/src/features/annotator/annotations/annotation-labels/annotation-labels.component.test.tsx
@@ -108,7 +108,8 @@ describe('AnnotationLabels', () => {
         );
 
         const foreignObject = document.querySelector('foreignObject');
-        expect(foreignObject).toHaveAttribute('height', '25');
+        expect(foreignObject).toHaveAttribute('height', '24');
+        expect(foreignObject).toHaveAttribute('y', '-24');
     });
 
     it('prevents event propagation on close button click', () => {

--- a/application/ui/src/features/annotator/annotations/annotation-labels/annotation-labels.component.tsx
+++ b/application/ui/src/features/annotator/annotations/annotation-labels/annotation-labels.component.tsx
@@ -5,7 +5,6 @@ import { PointerEvent, useCallback } from 'react';
 
 import { v4 as uuid } from 'uuid';
 
-import { useZoom } from '../../../../components/zoom/zoom.provider';
 import { useLabelResolver } from '../../../../shared/annotator/labels';
 import type { AnnotationLabel, AnnotationLabelRef } from '../../../../shared/types';
 import { isPrediction } from '../utils';
@@ -39,7 +38,6 @@ export const AnnotationLabels = ({
     useBottomCorners = false,
     isRemovable = true,
 }: AnnotationLabelsProps) => {
-    const { scale } = useZoom();
     const { resolveAnnotationLabel } = useLabelResolver();
 
     const onDeleteLabel = useCallback(
@@ -54,17 +52,14 @@ export const AnnotationLabels = ({
     const resolvedLabels = labels.map(resolveAnnotationLabel).filter((label) => label !== undefined);
     const displayLabels = resolvedLabels.length ? resolvedLabels : [placeholderLabel];
 
-    // Need to round up to preveent sub-pixel render issues when zoomed in
-    const foreignObjectHeight = Math.ceil(LABEL_HEIGHT_PX / scale) + 1;
-    const foreignObjectWidth = Math.ceil(LABEL_MAX_WIDTH_PX / scale) + 1;
-
     return (
         <foreignObject
             x={0}
-            y={useBottomCorners ? 0 : -foreignObjectHeight}
-            width={foreignObjectWidth}
-            height={foreignObjectHeight}
+            y={useBottomCorners ? 0 : -LABEL_HEIGHT_PX}
+            width={LABEL_MAX_WIDTH_PX}
+            height={LABEL_HEIGHT_PX}
             overflow='visible'
+            className={useBottomCorners ? classes.labelsScalePolygon : classes.labelsScaleRect}
             aria-label={`Annotation labels`}
         >
             <div className={useBottomCorners ? classes.labelsContainerPolygon : classes.labelsContainerRect}>

--- a/application/ui/src/features/annotator/annotations/annotation-labels/annotation-labels.module.scss
+++ b/application/ui/src/features/annotator/annotations/annotation-labels/annotation-labels.module.scss
@@ -1,28 +1,39 @@
 .labelsContainerRect,
 .labelsContainerPolygon {
     display: flex;
-    align-items: start;
     flex-direction: row;
     height: 100%;
     width: max-content;
     pointer-events: auto;
 }
 
-/* Rectangle shape labels: positioned at bottom of foreignObject, scale from bottom-left */
+/* Counter-scaling lives on the foreignObject so the chip keeps a constant screen size
+   without React having to recompute its geometry on every zoom step. */
+.labelsScaleRect,
+.labelsScalePolygon {
+    transform-box: fill-box;
+    transform: scale(calc(1 / var(--zoom-scale, 1)));
+}
+
+/* Rectangle labels: the chip's bottom-left sits on the annotation's top-left corner */
+.labelsScaleRect {
+    transform-origin: left bottom;
+}
+
+/* Polygon labels: the box origin is the centroid, so the chip pivots there */
+.labelsScalePolygon {
+    transform-origin: left top;
+}
+
 /* translate offset accounts for stroke width (half of the 3px) and small adjustment to prevent antialiasing issues */
 .labelsContainerRect {
     align-items: flex-end;
-    transform: scale(calc(1 / var(--zoom-scale, 1))) translate(-1.5px, -1.3px);
-    transform-origin: bottom left;
+    transform: translate(-1.5px, -1.3px);
 }
 
-/* Polygon labels: center on the centroid, scale from center */
-/* The foreignObject is inflated by 1/zoom, so the chip must be centered in it for the
-   center-origin scale to pivot on the chip rather than on the (much taller) box. */
 .labelsContainerPolygon {
     align-items: center;
-    transform: translate(-50%, -50%) scale(calc(1 / var(--zoom-scale, 1)));
-    transform-origin: center center;
+    transform: translate(-50%, -50%);
 }
 
 .label {


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Remove zoom provider's subscription from annotation labels. Now the foreignObject has fixed geometry and we control the positions through css only. This fix came because i am improving the annotator performance. And in this case, the issue was that, for each zoom change, ALL the labels were rerendering, and when you have 400-500 labels, this becomes a bottleneck
* Fix delta/scale calculating of zoom (used opus to research) . This fixes a long time issue with zoom on trackpads. Tested on macOS trackpad, works perfectly. The gist is that on trackpad, zooming in means CTRL + mouseWheel , and both events were conflicting with each other

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
