### PR TITLE
Avoid double suspense

### DIFF
--- a/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/api/use-dataset-views.ts
+++ b/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/api/use-dataset-views.ts
@@ -6,13 +6,18 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 
 export const datasetViewsQueryOptions = (projectId: string) =>
-    $api.queryOptions('get', '/api/projects/{project_id}/dataset/views', {
-        params: {
-            path: {
-                project_id: projectId,
+    $api.queryOptions(
+        'get',
+        '/api/projects/{project_id}/dataset/views',
+        {
+            params: {
+                path: {
+                    project_id: projectId,
+                },
             },
         },
-    });
+        { staleTime: 1000 * 60 }
+    );
 
 export const useDatasetViewsQuery = () => {
     const projectId = useProjectIdentifier();

--- a/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.test.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.test.tsx
@@ -3,7 +3,7 @@
 
 import type { Media } from '@/api/types';
 import { ViewModes } from '@geti-ui/ui';
-import { fireEvent, screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { getMockedDatasetStatistics } from 'mocks/mock-dataset-item';
 import { getMockedDatasetView } from 'mocks/mock-dataset-view';
 import { getMockedMediaImage } from 'mocks/mock-media';
@@ -105,7 +105,7 @@ describe('Toolbar', () => {
             path: '/projects/:projectId',
         });
 
-        await waitForElementToBeRemoved(screen.getByRole('progressbar'));
+        await screen.findByRole('button', { name: 'Select dataset view' });
 
         return result;
     };

--- a/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Dispatch, SetStateAction, useMemo } from 'react';
+import { Dispatch, SetStateAction, Suspense, useMemo } from 'react';
 
 import type { Media } from '@/api/types';
 import {
@@ -58,6 +58,46 @@ const AnnotateButton = ({ isDisabled, onClick }: AnnotateButtonProps) => {
     );
 };
 
+type DatasetViewsProps = {
+    resetSelectedMediaIds: () => void;
+};
+
+// Owns the dataset views query so the rest of the toolbar renders without waiting on it
+const DatasetViews = ({ resetSelectedMediaIds }: DatasetViewsProps) => {
+    const { data: datasetViews } = useDatasetViewsQuery();
+
+    return (
+        <>
+            <Divider orientation={'vertical'} size={'S'} />
+            <DatasetViewSelector datasetViews={datasetViews} resetSelectedMediaIds={resetSelectedMediaIds} />
+        </>
+    );
+};
+
+type DatasetViewActionsProps = {
+    selectedMediaIds: string[];
+    resetSelectedMediaIds: () => void;
+};
+
+const DatasetViewActions = ({ selectedMediaIds, resetSelectedMediaIds }: DatasetViewActionsProps) => {
+    const { data: datasetViews } = useDatasetViewsQuery();
+
+    return (
+        <>
+            <SaveDatasetView
+                selectedMediaIds={selectedMediaIds}
+                datasetViews={datasetViews}
+                resetSelectedMediaIds={resetSelectedMediaIds}
+            />
+            <AssignToExistingView
+                datasetViews={datasetViews}
+                selectedMediaIds={selectedMediaIds}
+                resetSelectedMediaIds={resetSelectedMediaIds}
+            />
+        </>
+    );
+};
+
 const SortMediaByUploadDate = () => {
     const { sortDirection, setSortDirection } = useDatasetFiltersSearchParams();
 
@@ -79,7 +119,6 @@ const SortMediaByUploadDate = () => {
 export const Toolbar = ({ items, viewMode, setViewMode }: ToolbarProps) => {
     const { onSelectedMediaItemChange } = useSelectDatasetItem();
     const { selectedKeys, setSelectedKeys, toggleSelectedKeys } = useSelectedData();
-    const { data: datasetViews } = useDatasetViewsQuery();
 
     const selectedMediaItems = selectedKeys instanceof Set ? selectedKeys : null;
 
@@ -113,13 +152,9 @@ export const Toolbar = ({ items, viewMode, setViewMode }: ToolbarProps) => {
                     <Heading margin={0}>Dataset</Heading>
 
                     {FEATURE_FLAGS.DATASET_VIEWS && (
-                        <>
-                            <Divider orientation={'vertical'} size={'S'} />
-                            <DatasetViewSelector
-                                datasetViews={datasetViews}
-                                resetSelectedMediaIds={resetSelectedMediaIds}
-                            />
-                        </>
+                        <Suspense fallback={null}>
+                            <DatasetViews resetSelectedMediaIds={resetSelectedMediaIds} />
+                        </Suspense>
                     )}
                 </Flex>
 
@@ -166,16 +201,12 @@ export const Toolbar = ({ items, viewMode, setViewMode }: ToolbarProps) => {
                             />
                             {FEATURE_FLAGS.DATASET_VIEWS && (
                                 <>
-                                    <SaveDatasetView
-                                        selectedMediaIds={selectedMediaItemsIds}
-                                        datasetViews={datasetViews}
-                                        resetSelectedMediaIds={resetSelectedMediaIds}
-                                    />
-                                    <AssignToExistingView
-                                        datasetViews={datasetViews}
-                                        selectedMediaIds={selectedMediaItemsIds}
-                                        resetSelectedMediaIds={resetSelectedMediaIds}
-                                    />
+                                    <Suspense fallback={null}>
+                                        <DatasetViewActions
+                                            selectedMediaIds={selectedMediaItemsIds}
+                                            resetSelectedMediaIds={resetSelectedMediaIds}
+                                        />
+                                    </Suspense>
                                     <UnassignMediaFromView
                                         selectedMediaIds={selectedMediaItemsIds}
                                         resetSelectedMediaIds={resetSelectedMediaIds}

--- a/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/toolbar.component.tsx
@@ -62,7 +62,6 @@ type DatasetViewsProps = {
     resetSelectedMediaIds: () => void;
 };
 
-// Owns the dataset views query so the rest of the toolbar renders without waiting on it
 const DatasetViews = ({ resetSelectedMediaIds }: DatasetViewsProps) => {
     const { data: datasetViews } = useDatasetViewsQuery();
 

--- a/application/ui/src/routes/dataset/dataset.component.tsx
+++ b/application/ui/src/routes/dataset/dataset.component.tsx
@@ -1,9 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Suspense } from 'react';
-
-import { dimensionValue, Grid, Loading, View } from '@geti-ui/ui';
+import { dimensionValue, Grid, View } from '@geti-ui/ui';
 import { useDatasetMediaWithReviewStatus } from 'hooks/use-dataset-media-with-review-status.hook';
 import { useViewMode } from 'hooks/use-view-mode.hook';
 
@@ -40,9 +38,7 @@ export const Dataset = () => {
                 </View>
 
                 <View gridRow='2 / 3'>
-                    <Suspense fallback={<Loading mode={'inline'} />}>
-                        <Toolbar items={items} viewMode={viewMode} setViewMode={setViewMode} />
-                    </Suspense>
+                    <Toolbar items={items} viewMode={viewMode} setViewMode={setViewMode} />
                 </View>
 
                 <View gridRow='3 / 4' marginBottom={hasActiveFilter ? 'size-200' : undefined}>


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Move suspense query to DatasetViews component instead of parent

issue:
<img width="1125" height="892" alt="image (12)" src="https://github.com/user-attachments/assets/cfabc106-8f9a-447a-91d8-6c1d544be5b6" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
