### PR TITLE
Update license of EdgeCrafter models

### DIFF
--- a/application/README.md
+++ b/application/README.md
@@ -7,8 +7,8 @@
 **Full-stack web application to build and deploy computer vision AI models, powered by the [getitune](../library) library.**
 
 [![python](https://img.shields.io/badge/python-3.13-green)]()
-[![pytorch](https://img.shields.io/badge/pytorch-2.10-orange)]()
-[![openvino](https://img.shields.io/badge/openvino-2026.2-purple)]()
+[![pytorch](https://img.shields.io/badge/pytorch-2.12-orange)]()
+[![openvino](https://img.shields.io/badge/openvino-2026.3-purple)]()
 
 [Application](#geti-application) •
 [Docs](#documentation) •

--- a/application/backend/app/supported_models/manifests/detection/edgecrafter_l.yaml
+++ b/application/backend/app/supported_models/manifests/detection/edgecrafter_l.yaml
@@ -1,5 +1,6 @@
 id: object-detection-edgecrafter-l
 name: ECDet-L
+license: EdgeCrafter
 
 pretrained_weights:
   source: direct_link

--- a/application/backend/app/supported_models/manifests/detection/edgecrafter_m.yaml
+++ b/application/backend/app/supported_models/manifests/detection/edgecrafter_m.yaml
@@ -1,5 +1,6 @@
 id: object-detection-edgecrafter-m
 name: ECDet-M
+license: EdgeCrafter
 
 pretrained_weights:
   source: direct_link

--- a/application/backend/app/supported_models/manifests/detection/edgecrafter_s.yaml
+++ b/application/backend/app/supported_models/manifests/detection/edgecrafter_s.yaml
@@ -1,5 +1,6 @@
 id: object-detection-edgecrafter-s
 name: ECDet-S
+license: EdgeCrafter
 
 pretrained_weights:
   source: direct_link

--- a/application/backend/app/supported_models/manifests/detection/edgecrafter_x.yaml
+++ b/application/backend/app/supported_models/manifests/detection/edgecrafter_x.yaml
@@ -1,5 +1,6 @@
 id: object-detection-edgecrafter-x
 name: ECDet-X
+license: EdgeCrafter
 
 pretrained_weights:
   source: direct_link

--- a/application/ui/src/features/models/components/edgecrafter-license.component.tsx
+++ b/application/ui/src/features/models/components/edgecrafter-license.component.tsx
@@ -1,0 +1,17 @@
+// Copyright (C) 2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Link } from '../../../platform/components/link.component';
+
+const EDGECRAFTER_LICENSE_URL = 'https://github.com/Intellindust-AI-Lab/EdgeCrafter/blob/main/LICENSE.md';
+
+export const EdgeCrafterLicense = () => {
+    return (
+        <>
+            {'License: '}
+            <Link href={EDGECRAFTER_LICENSE_URL} target={'_blank'} rel={'noopener noreferrer'}>
+                EdgeCrafter
+            </Link>
+        </>
+    );
+};

--- a/application/ui/src/features/models/train-model/model-architectures-list/model-architecture-card/model-architecture-card.component.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/model-architecture-card/model-architecture-card.component.tsx
@@ -7,8 +7,9 @@ import type { ModelArchitecture as ModelArchitectureType, ModelArchitectureWithP
 import { Content, ContextualHelp, Divider, Flex, Heading, Radio, Text } from '@geti-ui/ui';
 import { clsx } from 'clsx';
 
+import { EdgeCrafterLicense } from '../../../components/edgecrafter-license.component';
 import { UltralyticsLicense } from '../../../components/ultralytics-license.component';
-import { isUltralyticsModel } from '../../../utils';
+import { isEdgeCrafterModel, isUltralyticsModel } from '../../../utils';
 import { getAccuracyMetric } from '../utils';
 
 import classes from './model-architecture-card.module.scss';
@@ -37,6 +38,8 @@ const License = () => {
         <li>
             {isUltralyticsModel(modelArchitecture.id) ? (
                 <UltralyticsLicense />
+            ) : isEdgeCrafterModel(modelArchitecture.id) ? (
+                <EdgeCrafterLicense />
             ) : (
                 `License: ${modelArchitecture.license}`
             )}

--- a/application/ui/src/features/models/utils.test.ts
+++ b/application/ui/src/features/models/utils.test.ts
@@ -8,6 +8,7 @@ import {
     distributeByLargestRemainder,
     getAllModelsWithOpenVINOVariants,
     getModelIdentifierPayload,
+    isEdgeCrafterModel,
     isUltralyticsModel,
     SelectableModel,
 } from './utils';
@@ -189,5 +190,26 @@ describe('isUltralyticsModel', () => {
     it('returns false for non ultralytics model identifier', () => {
         expect(isUltralyticsModel('object-detection-yolox-l')).toBe(false);
         expect(isUltralyticsModel('OBJECT-DETECTION-YOLOX-L')).toBe(false);
+    });
+});
+
+describe('isEdgeCrafterModel', () => {
+    it('returns true for edgecrafter model identifier', () => {
+        const models = [
+            'object-detection-edgecrafter-l',
+            'OBJECT-DETECTION-EDGECRAFTER-L',
+            'object-detection-edgecrafter-m',
+            'object-detection-edgecrafter-s',
+            'object-detection-edgecrafter-x',
+        ];
+
+        models.forEach((model) => {
+            expect(isEdgeCrafterModel(model)).toBe(true);
+        });
+    });
+
+    it('returns false for non edgecrafter model identifier', () => {
+        expect(isEdgeCrafterModel('object-detection-yolox-l')).toBe(false);
+        expect(isEdgeCrafterModel('OBJECT-DETECTION-YOLOX-L')).toBe(false);
     });
 });

--- a/application/ui/src/features/models/utils.ts
+++ b/application/ui/src/features/models/utils.ts
@@ -56,3 +56,7 @@ export const getAllModelsWithOpenVINOVariants = (models: Model[]): SelectableMod
 export const isUltralyticsModel = (identifier: string): boolean => {
     return /yolo\d+-/.test(identifier.toLocaleLowerCase());
 };
+
+export const isEdgeCrafterModel = (identifier: string): boolean => {
+    return /edgecrafter-/.test(identifier.toLocaleLowerCase());
+};


### PR DESCRIPTION
### Summary

The [EdgeCrafter](https://github.com/Intellindust-AI-Lab/EdgeCrafter) repo recently modified its license from Apache 2.0 to a custom EdgeCrafter license. This PR updates the model manifests accordingly, so that the new license is displayed to the user.

Resolves #7450

### How to test

Open the model selection tab, view EdgeCrafter models and follow the license URL.

<img width="976" height="839" alt="image" src="https://github.com/user-attachments/assets/a9c49423-df96-42d9-accc-946b6385ca69" />

### Checklist

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
