### PR TITLE
Show media skeleton while scrolling

### DIFF
--- a/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
@@ -43,7 +43,7 @@ const VideoIndicator = ({ duration }: VideoIndicatorProps) => {
 export const MediaThumbnail = ({ onDoubleClick, onClick, url, alt, item }: MediaThumbnailProps) => {
     const imgRef = useRef<HTMLImageElement>(null);
     const isScrolling = useIsScrolling();
-    const [isLoading, setIsLoading] = useState(true);
+    const [status, setStatus] = useState<'loading' | 'loaded' | 'error'>('loading');
 
     // Tiles that fly past during a fast scroll would otherwise start a request and immediately
     // cancel it; enough of those wedge the connection and leave the gallery blank.
@@ -58,6 +58,7 @@ export const MediaThumbnail = ({ onDoubleClick, onClick, url, alt, item }: Media
             return;
         }
 
+        setStatus('loading');
         imgRef.current.src = url;
     }, [url, isScrolling]);
 
@@ -77,13 +78,18 @@ export const MediaThumbnail = ({ onDoubleClick, onClick, url, alt, item }: Media
                 ref={imgRef}
                 alt={alt}
                 className={clsx(classes.img, {
-                    [classes.imgHidden]: isLoading,
+                    [classes.imgHidden]: status !== 'loaded',
                 })}
                 draggable={false}
                 decoding={'async'}
-                onLoad={() => setIsLoading(false)}
+                onLoad={() => setStatus('loaded')}
+                onError={() => {
+                    if (imgRef.current?.complete === true) {
+                        setStatus('error');
+                    }
+                }}
             />
-            {isLoading && <Skeleton width={'100%'} height={'100%'} className={classes.skeleton} />}
+            {status === 'loading' && <Skeleton width={'100%'} height={'100%'} className={classes.skeleton} />}
             {isVideo(item) && <VideoIndicator duration={item.duration} />}
         </div>
     );

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.component.tsx
@@ -52,6 +52,12 @@ export const MediaThumbnail = ({ onDoubleClick, onClick, url, alt, item }: Media
             return;
         }
 
+        // Re-assigning the same value restarts the fetch, so every scroll stop would abort and
+        // re-request the thumbnails that are already loading.
+        if (imgRef.current.getAttribute('src') === url) {
+            return;
+        }
+
         imgRef.current.src = url;
     }, [url, isScrolling]);
 
@@ -76,11 +82,6 @@ export const MediaThumbnail = ({ onDoubleClick, onClick, url, alt, item }: Media
                 draggable={false}
                 decoding={'async'}
                 onLoad={() => setIsLoading(false)}
-                onError={() => {
-                    if (imgRef.current?.complete === true) {
-                        setIsLoading(false);
-                    }
-                }}
             />
             {isLoading && <Skeleton width={'100%'} height={'100%'} className={classes.skeleton} />}
             {isVideo(item) && <VideoIndicator duration={item.duration} />}

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.test.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'test-utils/render';
 
@@ -64,5 +64,17 @@ describe('MediaThumbnail', () => {
         render(<MediaThumbnail url='test-image.jpg' alt='Test Image' item={{ type: 'image' }} />);
 
         expect(screen.getByRole('img', { name: 'Test Image' })).toHaveAttribute('src', 'test-image.jpg');
+    });
+
+    it('keeps the skeleton and hides the image when the thumbnail fails to load', () => {
+        vi.mocked(useIsScrolling).mockReturnValue(false);
+
+        render(<MediaThumbnail url='test-image.jpg' alt='Test Image' item={{ type: 'image' }} />);
+
+        fireEvent.error(screen.getByRole('img', { name: 'Test Image' }));
+
+        // CSS modules are not applied in jsdom, so assert on the class that hides the image.
+        expect(screen.getByRole('img', { name: 'Test Image' }).className).toContain('imgHidden');
+        expect(screen.getByRole('img', { name: 'Loading…' })).toBeVisible();
     });
 });

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.test.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.test.tsx
@@ -10,14 +10,13 @@ import { render } from 'test-utils/render';
 import { useIsScrolling } from '../../hooks/use-is-scrolling.hook';
 import { MediaThumbnail } from './media-thumbnail.component';
 
-import classes from './media-thumbnail.module.scss';
-
 vi.mock('../../hooks/use-is-scrolling.hook', () => ({
     useIsScrolling: vi.fn(),
 }));
 
 const getImage = () => screen.getByRole('img', { name: 'Test Image' });
-const getSkeleton = (container: HTMLElement) => container.querySelector(`.${classes.skeleton}`);
+const getSkeleton = () => screen.getByRole('img', { name: 'Loading…' });
+const querySkeleton = () => screen.queryByRole('img', { name: 'Loading…' });
 
 describe('MediaThumbnail', () => {
     beforeEach(() => {
@@ -87,34 +86,34 @@ describe('MediaThumbnail', () => {
             );
         };
 
-        const { container } = render(<Thumbnail />);
+        render(<Thumbnail />);
         fireEvent.load(getImage());
 
         await userEvent.click(screen.getByRole('button'));
 
         // CSS modules keep the local name, so assert on the class that hides the image.
         expect(getImage().className).toContain('imgHidden');
-        expect(getSkeleton(container)).toBeInTheDocument();
+        expect(getSkeleton()).toBeInTheDocument();
     });
 
     it('stops the skeleton but keeps the image hidden when the thumbnail fails to load', () => {
-        const { container } = render(<MediaThumbnail url='test-image.jpg' alt='Test Image' item={{ type: 'image' }} />);
+        render(<MediaThumbnail url='test-image.jpg' alt='Test Image' item={{ type: 'image' }} />);
 
         // jsdom never loads the image, so mark it as settled the way a broken image is.
         Object.defineProperty(getImage(), 'complete', { value: true });
         fireEvent.error(getImage());
 
         expect(getImage().className).toContain('imgHidden');
-        expect(getSkeleton(container)).not.toBeInTheDocument();
+        expect(querySkeleton()).not.toBeInTheDocument();
     });
 
     it('ignores the error fired while the image is still loading', () => {
-        const { container } = render(<MediaThumbnail url='test-image.jpg' alt='Test Image' item={{ type: 'image' }} />);
+        render(<MediaThumbnail url='test-image.jpg' alt='Test Image' item={{ type: 'image' }} />);
 
         expect(getImage()).toHaveProperty('complete', false);
 
         fireEvent.error(getImage());
 
-        expect(getSkeleton(container)).toBeInTheDocument();
+        expect(getSkeleton()).toBeInTheDocument();
     });
 });

--- a/application/ui/src/components/media-thumbnail/media-thumbnail.test.tsx
+++ b/application/ui/src/components/media-thumbnail/media-thumbnail.test.tsx
@@ -1,24 +1,36 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+
+import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'test-utils/render';
 
 import { useIsScrolling } from '../../hooks/use-is-scrolling.hook';
 import { MediaThumbnail } from './media-thumbnail.component';
 
+import classes from './media-thumbnail.module.scss';
+
 vi.mock('../../hooks/use-is-scrolling.hook', () => ({
-    useIsScrolling: vi.fn(() => false),
+    useIsScrolling: vi.fn(),
 }));
 
+const getImage = () => screen.getByRole('img', { name: 'Test Image' });
+const getSkeleton = (container: HTMLElement) => container.querySelector(`.${classes.skeleton}`);
+
 describe('MediaThumbnail', () => {
+    beforeEach(() => {
+        vi.mocked(useIsScrolling).mockReturnValue(false);
+    });
+
     it('calls onClick when image is clicked', async () => {
         const mockedClick = vi.fn();
         render(<MediaThumbnail url='test-image.jpg' alt='Test Image' onClick={mockedClick} item={{ type: 'image' }} />);
 
-        await userEvent.click(screen.getByRole('img', { name: 'Test Image' }));
-        await waitFor(() => expect(mockedClick).toHaveBeenCalled());
+        await userEvent.click(getImage());
+
+        expect(mockedClick).toHaveBeenCalled();
     });
 
     it('calls onDoubleClick when image is double-clicked', async () => {
@@ -32,17 +44,16 @@ describe('MediaThumbnail', () => {
             />
         );
 
-        await userEvent.dblClick(screen.getByRole('img', { name: 'Test Image' }));
-        await waitFor(() => expect(mockedDblClick).toHaveBeenCalled());
+        await userEvent.dblClick(getImage());
+
+        expect(mockedDblClick).toHaveBeenCalled();
     });
 
-    it('displays frames count when item is a video', async () => {
-        const mockedClick = vi.fn();
+    it('displays frames count when item is a video', () => {
         render(
             <MediaThumbnail
                 url='test-video.mp4'
                 alt='Test Image'
-                onClick={mockedClick}
                 item={{ type: 'video', frame_count: 3600, annotated_frame_count: 10, duration: 60 }}
             />
         );
@@ -55,26 +66,55 @@ describe('MediaThumbnail', () => {
 
         render(<MediaThumbnail url='test-image.jpg' alt='Test Image' item={{ type: 'image' }} />);
 
-        expect(screen.getByRole('img', { name: 'Test Image' })).not.toHaveAttribute('src');
+        expect(getImage()).not.toHaveAttribute('src');
     });
 
     it('sets the image src when not scrolling', () => {
-        vi.mocked(useIsScrolling).mockReturnValue(false);
-
         render(<MediaThumbnail url='test-image.jpg' alt='Test Image' item={{ type: 'image' }} />);
 
-        expect(screen.getByRole('img', { name: 'Test Image' })).toHaveAttribute('src', 'test-image.jpg');
+        expect(getImage()).toHaveAttribute('src', 'test-image.jpg');
     });
 
-    it('keeps the skeleton and hides the image when the thumbnail fails to load', () => {
-        vi.mocked(useIsScrolling).mockReturnValue(false);
+    it('shows the skeleton again when the url changes', async () => {
+        const Thumbnail = () => {
+            const [url, setUrl] = useState('test-image.jpg');
 
-        render(<MediaThumbnail url='test-image.jpg' alt='Test Image' item={{ type: 'image' }} />);
+            return (
+                <>
+                    <button onClick={() => setUrl('other-image.jpg')}>Next</button>
+                    <MediaThumbnail url={url} alt='Test Image' item={{ type: 'image' }} />
+                </>
+            );
+        };
 
-        fireEvent.error(screen.getByRole('img', { name: 'Test Image' }));
+        const { container } = render(<Thumbnail />);
+        fireEvent.load(getImage());
 
-        // CSS modules are not applied in jsdom, so assert on the class that hides the image.
-        expect(screen.getByRole('img', { name: 'Test Image' }).className).toContain('imgHidden');
-        expect(screen.getByRole('img', { name: 'Loading…' })).toBeVisible();
+        await userEvent.click(screen.getByRole('button'));
+
+        // CSS modules keep the local name, so assert on the class that hides the image.
+        expect(getImage().className).toContain('imgHidden');
+        expect(getSkeleton(container)).toBeInTheDocument();
+    });
+
+    it('stops the skeleton but keeps the image hidden when the thumbnail fails to load', () => {
+        const { container } = render(<MediaThumbnail url='test-image.jpg' alt='Test Image' item={{ type: 'image' }} />);
+
+        // jsdom never loads the image, so mark it as settled the way a broken image is.
+        Object.defineProperty(getImage(), 'complete', { value: true });
+        fireEvent.error(getImage());
+
+        expect(getImage().className).toContain('imgHidden');
+        expect(getSkeleton(container)).not.toBeInTheDocument();
+    });
+
+    it('ignores the error fired while the image is still loading', () => {
+        const { container } = render(<MediaThumbnail url='test-image.jpg' alt='Test Image' item={{ type: 'image' }} />);
+
+        expect(getImage()).toHaveProperty('complete', false);
+
+        fireEvent.error(getImage());
+
+        expect(getSkeleton(container)).toBeInTheDocument();
     });
 });

--- a/application/ui/src/features/inference/stream/web-rtc-connection.ts
+++ b/application/ui/src/features/inference/stream/web-rtc-connection.ts
@@ -77,7 +77,13 @@ export class WebRTCConnection {
 
             const data = await this.sendOffer();
 
-            if (!this.handleOfferResponse(data)) return;
+            if (!(await this.handleOfferResponse(data))) {
+                clearTimeout(this.timeoutId);
+                this.updateStatus('failed');
+                await this.stop();
+
+                return;
+            }
 
             await this.updateConfThreshold(0.5); // Initial confidence threshold
             this.setupConnectionStateListener();
@@ -208,6 +214,8 @@ export class WebRTCConnection {
     }
 
     public async stop(): Promise<void> {
+        clearTimeout(this.timeoutId);
+
         if (!this.peerConnection) {
             return;
         }

--- a/application/ui/src/features/models/training-logs/log-entry.component.tsx
+++ b/application/ui/src/features/models/training-logs/log-entry.component.tsx
@@ -51,6 +51,10 @@ const MessageWithPaths = ({ message }: { message: string }) => {
                     title={'Click to copy path'}
                     onClick={() => copy(part)}
                     onKeyDown={(event) => {
+                        if (event.repeat) {
+                            return;
+                        }
+
                         if (event.key === 'Enter' || event.key === ' ') {
                             event.preventDefault();
                             copy(part);

--- a/application/ui/src/features/models/training-logs/log-entry.component.tsx
+++ b/application/ui/src/features/models/training-logs/log-entry.component.tsx
@@ -50,6 +50,12 @@ const MessageWithPaths = ({ message }: { message: string }) => {
                     className={classes.path}
                     title={'Click to copy path'}
                     onClick={() => copy(part)}
+                    onKeyDown={(event) => {
+                        if (event.key === 'Enter' || event.key === ' ') {
+                            event.preventDefault();
+                            copy(part);
+                        }
+                    }}
                     role={'button'}
                     tabIndex={0}
                 >


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Show media item skeleton when loading instead of a cryptic alt
* Bonus: Correctly await for a promise on webrtc handling
* Add ENTER/SPACE key support for copying logs

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
