### PR TITLE
Add Deep OC-SORT tracker

### DIFF
--- a/libraries/getitrack/src/getitrack/algorithms/__init__.py
+++ b/libraries/getitrack/src/getitrack/algorithms/__init__.py
@@ -9,7 +9,8 @@ Importing this package registers every algorithm into
 
 from getitrack.algorithms.botsort import BotSortTracker
 from getitrack.algorithms.bytetrack import ByteTrackTracker
+from getitrack.algorithms.deepocsort import DeepOcSortTracker
 from getitrack.algorithms.ocsort import OCSortTracker
 from getitrack.algorithms.sort import SortTracker
 
-__all__ = ["BotSortTracker", "ByteTrackTracker", "OCSortTracker", "SortTracker"]
+__all__ = ["BotSortTracker", "ByteTrackTracker", "DeepOcSortTracker", "OCSortTracker", "SortTracker"]

--- a/libraries/getitrack/src/getitrack/algorithms/configs/deepocsort.py
+++ b/libraries/getitrack/src/getitrack/algorithms/configs/deepocsort.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Configuration model for the Deep OC-SORT tracker."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import Field
+
+from getitrack.algorithms.configs.ocsort import OCSortConfig
+from getitrack.config import AlgorithmType, ReIDConfig
+
+
+class DeepOcSortConfig(OCSortConfig):
+    """Deep OC-SORT configuration.
+
+    Extends the OC-SORT parameter set with an appearance (ReID) stage: a bounded
+    per-track gallery, a cosine appearance cost fused with IoU under an IoU
+    proximity gate in the first (OCM) association, and an optional
+    confidence-scaled EMA feature.
+    """
+
+    algorithm: Literal[AlgorithmType.DEEPOCSORT] = AlgorithmType.DEEPOCSORT  # pyrefly: ignore[bad-override]
+    """Algorithm identifier; fixed to ``deepocsort``."""
+
+    appearance_weight: Annotated[float, Field(ge=0.0, le=1.0)] = 0.25
+    """Weight of the appearance term when fusing appearance and IoU costs.
+    0 disables appearance influence; 1 matches on appearance alone (still
+    subject to the IoU proximity gate)."""
+
+    appearance_iou_floor: Annotated[float, Field(ge=0.0, le=1.0)] = 0.5
+    """Minimum IoU a track/detection pair must reach for appearance fusion to
+    apply. Pairs below it fall back to the plain IoU (plus OCM) cost."""
+
+    gallery_size: Annotated[int, Field(ge=1)] = 50
+    """Maximum descriptors retained in each track's FIFO appearance gallery."""
+
+    appearance_threshold: Annotated[float, Field(ge=0.0, le=2.0)] = 0.25
+    """Maximum cosine distance for a descriptor to be admitted into a track's
+    gallery. Descriptors above it are rejected."""
+
+    use_ema: bool = True
+    """Query appearance against a running EMA descriptor rather than the raw
+    FIFO gallery entries."""
+
+    ema_alpha: Annotated[float, Field(gt=0.0, lt=1.0)] = 0.9
+    """EMA retention factor. Higher keeps more appearance history. The update is
+    confidence-scaled by the detection score."""
+
+    reid: ReIDConfig = Field(default_factory=ReIDConfig)
+    """ReID model enablement and path used to embed detections."""

--- a/libraries/getitrack/src/getitrack/algorithms/deepocsort.py
+++ b/libraries/getitrack/src/getitrack/algorithms/deepocsort.py
@@ -1,0 +1,197 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Deep OC-SORT: OC-SORT association augmented with appearance (ReID).
+
+Extends OC-SORT's observation-centric association with an appearance stage. Each
+track keeps a bounded appearance gallery
+(`getitrack.reid.gallery.AppearanceGallery`), and the first (OCM) association
+fuses a cosine appearance cost with the IoU cost under an IoU proximity gate
+before the momentum term is applied.
+
+Each matched high-confidence detection feeds its descriptor into the track's
+gallery with the detection score as the confidence; the gallery's EMA descriptor
+is confidence-scaled by that score.
+
+The first-pass validity gate uses the pure IoU cost. `fuse_appearance_cost`
+falls back to the plain IoU cost below the IoU floor or for tracks without
+appearance features, so Deep OC-SORT reduces to OC-SORT when ReID is disabled or
+no embeddings are supplied.
+
+Appearance features come from ``Detections.embeddings``, populated by the caller
+or by the ReID provider exposed as `DeepOcSortTracker.reid_provider` when
+``reid`` is configured.
+
+Reference: Maggiolino et al., "Deep OC-SORT: Multi-Pedestrian Tracking by
+Adaptive Re-Identification" (2023).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar, cast
+
+import numpy as np
+
+from getitrack.algorithms.configs.deepocsort import DeepOcSortConfig
+from getitrack.algorithms.ocsort import OCSortTracker, _direction_cost
+from getitrack.core.registry import register_algorithm
+from getitrack.matching import fuse_appearance_cost, linear_assignment
+from getitrack.reid.gallery import AppearanceGallery
+
+if TYPE_CHECKING:
+    from getitrack.config import LifecycleConfig
+    from getitrack.core.detection import Detections
+    from getitrack.reid.base import ReIDProvider
+
+
+@register_algorithm("deepocsort", config=DeepOcSortConfig)
+class DeepOcSortTracker(OCSortTracker):
+    """Deep OC-SORT multi-object tracker (OC-SORT + appearance gallery).
+
+    Maintains OC-SORT's Kalman + observation-centric state and, in parallel, one
+    `AppearanceGallery` per track keyed by track id. Matched high-confidence
+    detections feed their descriptor into the gallery; the first (OCM)
+    association fuses the resulting appearance cost with IoU before the momentum
+    term is applied.
+    """
+
+    algorithm_name: ClassVar[str] = "deepocsort"
+
+    def __init__(self, config: DeepOcSortConfig) -> None:
+        super().__init__(config)
+        self._appearance: dict[int, AppearanceGallery] = {}
+        self._reid_provider: ReIDProvider | None = None
+
+    @property
+    def _cfg(self) -> DeepOcSortConfig:
+        """Return ``config`` narrowed to the Deep OC-SORT type."""
+        return cast("DeepOcSortConfig", self.config)
+
+    def reset(self) -> None:  # noqa: D102
+        super().reset()
+        self._appearance.clear()
+
+    @property
+    def reid_provider(self) -> ReIDProvider | None:
+        """Lazily-built ReID provider from ``config.reid``, or None if disabled.
+
+        Fills ``Detections.embeddings`` before `update`::
+
+            dets = replace(dets, embeddings=tracker.reid_provider.extract(frame, dets.bboxes))
+
+        The backend (torch / OpenVINO / torchreid) is imported on first access.
+        """
+        if self._reid_provider is None and self._cfg.reid.enabled:
+            from getitrack.reid.factory import build_reid_provider
+
+            self._reid_provider = build_reid_provider(self._cfg.reid)
+        return self._reid_provider
+
+    def _associate_first(self, track_ids: list[int], dets: Detections) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """First pass: IoU fused with appearance, minus the OCM momentum, gated on IoU.
+
+        Blends a cosine appearance cost into the IoU cost via
+        `fuse_appearance_cost` before subtracting the momentum bonus. The
+        validity gate uses the pure IoU cost. Appearance applies only when
+        detection embeddings and at least one non-empty gallery are present.
+        """
+        if not track_ids or len(dets) == 0:
+            return self._empty_association(len(track_ids), len(dets))
+        track_boxes = np.stack([self._tracks[track_id].bbox for track_id in track_ids], axis=0)
+        # Association distance selected by config (defaults to IoU).
+        iou_cost = self._distance(track_boxes, dets.bboxes)
+
+        fused_cost = iou_cost
+        if dets.embeddings is not None:
+            appearance_cost = self._appearance_cost(track_ids, dets.embeddings)
+            if appearance_cost is not None:
+                fused_cost = fuse_appearance_cost(
+                    iou_cost,
+                    appearance_cost,
+                    appearance_weight=self._cfg.appearance_weight,
+                    iou_floor=self._cfg.appearance_iou_floor,
+                )
+
+        prev_boxes = np.stack([self._previous_observation(track_id) for track_id in track_ids], axis=0)
+        velocities = np.stack(
+            [v if (v := self._obs[track_id].velocity) is not None else np.zeros(2) for track_id in track_ids],
+            axis=0,
+        )
+        valid = np.array([self._obs[track_id].velocity is not None for track_id in track_ids])
+        momentum_bonus = _direction_cost(dets.bboxes, prev_boxes, velocities, valid, dets.scores, self.config.inertia)
+
+        cost = fused_cost - momentum_bonus
+        # Gate on the pure IoU cost.
+        invalid = iou_cost > self.config.match_threshold
+        class_mismatch = self._class_mismatch(track_ids, dets)
+        if class_mismatch is not None:
+            invalid = invalid | class_mismatch
+        cost[invalid] = self._INVALID_COST
+        return linear_assignment(cost, self._MATCH_COST_CEILING)
+
+    def _appearance_cost(self, track_ids: list[int], det_embeddings: np.ndarray) -> np.ndarray | None:
+        """Build the ``(T, N)`` appearance cost, or None if no gallery is usable.
+
+        Tracks without a usable gallery get an all-``NaN`` row, which
+        `fuse_appearance_cost` treats as absent appearance information.
+        """
+        n = det_embeddings.shape[0]
+        rows: list[np.ndarray] = []
+        usable = False
+        for track_id in track_ids:
+            gallery = self._appearance.get(track_id)
+            if gallery is None or gallery.is_empty:
+                rows.append(np.full((n,), np.nan, dtype=np.float32))
+            else:
+                rows.append(gallery.distance(det_embeddings))
+                usable = True
+        if not usable:
+            return None
+        return np.stack(rows, axis=0).astype(np.float32)
+
+    def _apply_hit(
+        self,
+        track_id: int,
+        dets: Detections,
+        det_idx: int,
+        lifecycle: LifecycleConfig,
+        *,
+        src_index: int,
+    ) -> None:
+        super()._apply_hit(track_id, dets, det_idx, lifecycle, src_index=src_index)
+        if dets.embeddings is None:
+            return
+        score = float(dets.scores[det_idx])
+        # Only high-confidence detections (> det_threshold) feed the gallery.
+        if score > self.config.det_threshold:
+            self._admit(track_id, dets.embeddings[det_idx], score)
+
+    def _spawn_track(self, dets: Detections, det_idx: int, *, src_index: int) -> None:
+        # super() assigns the id from _allocate_id(), i.e. the current _next_id;
+        # capture it here before the increment.
+        new_id = self._next_id
+        super()._spawn_track(dets, det_idx, src_index=src_index)
+        if dets.embeddings is not None:
+            score = float(dets.scores[det_idx])
+            if score > self.config.det_threshold:
+                self._admit(new_id, dets.embeddings[det_idx], score)
+
+    def _remove_track(self, track_id: int) -> None:
+        super()._remove_track(track_id)
+        self._appearance.pop(track_id, None)
+
+    def _admit(self, track_id: int, feature: np.ndarray, score: float) -> None:
+        """Feed a matched detection's descriptor into the track's gallery.
+
+        The detection score is passed as the gallery's confidence for the EMA
+        update.
+        """
+        gallery = self._appearance.get(track_id)
+        if gallery is None:
+            gallery = AppearanceGallery(
+                gallery_size=self._cfg.gallery_size,
+                use_ema=self._cfg.use_ema,
+                ema_alpha=self._cfg.ema_alpha,
+                admission_threshold=self._cfg.appearance_threshold,
+            )
+            self._appearance[track_id] = gallery
+        gallery.update(feature, confidence=score)

--- a/libraries/getitrack/src/getitrack/config.py
+++ b/libraries/getitrack/src/getitrack/config.py
@@ -29,6 +29,7 @@ class AlgorithmType(StrEnum):
     SORT = "sort"
     OCSORT = "ocsort"
     BOTSORT = "botsort"
+    DEEPOCSORT = "deepocsort"
     MEMORY = "memory"
 
 

--- a/libraries/getitrack/tests/unit/test_deepocsort.py
+++ b/libraries/getitrack/tests/unit/test_deepocsort.py
@@ -1,0 +1,259 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit + integration tests for the Deep OC-SORT tracker and its config."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import getitrack.algorithms  # noqa: F401  -> registers Deep OC-SORT
+from getitrack.algorithms import DeepOcSortTracker, OCSortTracker
+from getitrack.algorithms.configs.deepocsort import DeepOcSortConfig
+from getitrack.algorithms.configs.ocsort import OCSortConfig
+from getitrack.config import AlgorithmType, LifecycleConfig, TrackerConfig
+from getitrack.core.base import BaseTracker
+from getitrack.core.detection import Detections
+from getitrack.core.registry import resolve_tracker_config
+
+_E_A = np.array([1.0, 0.0], dtype=np.float32)
+_E_B = np.array([0.0, 1.0], dtype=np.float32)
+
+
+def _dets(
+    boxes: list[list[float]],
+    scores: list[float],
+    frame_id: int,
+    embeddings: list[np.ndarray] | None = None,
+) -> Detections:
+    n = len(boxes)
+    emb: np.ndarray | None = None
+    if embeddings is not None:
+        emb = np.asarray(embeddings, dtype=np.float32).reshape(n, -1) if n else np.empty((0, 2), dtype=np.float32)
+    return Detections(
+        bboxes=np.asarray(boxes, dtype=np.float32).reshape(n, 4),
+        scores=np.asarray(scores, dtype=np.float32),
+        class_ids=np.zeros(n, dtype=np.int64),
+        frame_id=frame_id,
+        embeddings=emb,
+    )
+
+
+def _fast() -> LifecycleConfig:
+    return LifecycleConfig(min_hits=1, tentative_max_age=1, max_age=5)
+
+
+class TestConfigRegistry:
+    def test_from_config_dispatches_to_deepocsort(self):
+        tracker = BaseTracker.from_config(DeepOcSortConfig())
+        assert isinstance(tracker, DeepOcSortTracker)
+
+    def test_resolve_dispatches_on_algorithm_key(self):
+        resolved = resolve_tracker_config({"algorithm": "deepocsort", "appearance_weight": 0.4})
+        assert isinstance(resolved, DeepOcSortConfig)
+        assert resolved.appearance_weight == pytest.approx(0.4)
+
+    def test_algorithm_is_pinned(self):
+        assert DeepOcSortConfig().algorithm == AlgorithmType.DEEPOCSORT
+
+    def test_algorithm_mismatch_is_rejected(self):
+        # The pinned ``Literal`` field rejects any other algorithm value.
+        with pytest.raises(ValueError, match="algorithm"):
+            DeepOcSortConfig(algorithm=AlgorithmType.OCSORT)
+
+    def test_yaml_round_trip(self, tmp_path):
+        cfg = DeepOcSortConfig(
+            appearance_weight=0.5,
+            gallery_size=17,
+            appearance_threshold=0.3,
+            use_ema=False,
+            delta_t=2,
+            lifecycle=LifecycleConfig(max_age=42),
+        )
+        path = tmp_path / "deepocsort.yaml"
+        cfg.to_yaml(path)
+        assert TrackerConfig.from_yaml(path) == cfg
+
+    def test_reid_section_defaults(self):
+        cfg = DeepOcSortConfig()
+        assert cfg.reid.enabled is False
+        assert cfg.reid.model_path is None
+        assert cfg.reid.input_size == (256, 128)
+
+    def test_extends_ocsort_parameters(self):
+        # Deep OC-SORT inherits the OC-SORT knobs (e.g. the momentum lookback).
+        cfg = DeepOcSortConfig()
+        assert cfg.delta_t == 3
+        assert cfg.inertia == pytest.approx(0.2)
+
+
+class TestReidProviderProperty:
+    def test_provider_is_none_when_reid_disabled(self):
+        assert DeepOcSortTracker(DeepOcSortConfig()).reid_provider is None
+
+
+class TestAppearanceRecovery:
+    """Appearance recovers an identity that OC-SORT's motion+IoU alone drops.
+
+    After a one-frame gap the track's predicted box overlaps two competing
+    detections: a distractor sitting exactly on the prediction (higher IoU,
+    wrong appearance) and the true identity nearby (lower IoU, right
+    appearance). IoU alone binds the track to the distractor; appearance fusion
+    rebinds it to the true identity.
+    """
+
+    @staticmethod
+    def _run(tracker: BaseTracker) -> int:
+        tracker.update(_dets([[50, 50, 90, 90]], [0.9], frame_id=0, embeddings=[_E_A]))
+        tracker.update(_dets([], [], frame_id=1, embeddings=[]))
+        out = tracker.update(
+            _dets(
+                [[50, 50, 90, 90], [46, 46, 86, 86]],
+                [0.9, 0.9],
+                frame_id=2,
+                embeddings=[_E_B, _E_A],
+            ),
+        )
+        det_indices = out.det_indices.tolist()
+        row = det_indices.index(1)
+        return int(out.track_ids[row])
+
+    def test_ocsort_iou_only_loses_the_identity(self):
+        cfg = OCSortConfig(lifecycle=_fast())
+        assert self._run(OCSortTracker(cfg)) != 1
+
+    def test_deepocsort_appearance_recovers_the_identity(self):
+        cfg = DeepOcSortConfig(lifecycle=_fast(), appearance_weight=0.5)
+        assert cfg.appearance_iou_floor == pytest.approx(0.5)
+        assert self._run(DeepOcSortTracker(cfg)) == 1
+
+
+_REDUCTION_SEQ: list[tuple[list[list[float]], list[float]]] = [
+    ([[10, 10, 50, 50], [200, 200, 240, 240]], [0.9, 0.9]),
+    ([[16, 10, 56, 50], [206, 200, 246, 240]], [0.9, 0.9]),
+    ([[22, 10, 62, 50]], [0.9]),
+    ([[28, 10, 68, 50], [212, 200, 252, 240]], [0.9, 0.9]),
+    ([], []),
+    ([[34, 10, 74, 50], [218, 200, 258, 240]], [0.9, 0.9]),
+]
+
+
+class TestReducesToOcSort:
+    """With ReID disabled / no embeddings, Deep OC-SORT == OC-SORT frame by frame."""
+
+    def _drive(self, tracker: BaseTracker) -> list[tuple[list[int], list[int]]]:
+        history: list[tuple[list[int], list[int]]] = []
+        for f, (boxes, scores) in enumerate(_REDUCTION_SEQ):
+            out = tracker.update(_dets(boxes, scores, frame_id=f))
+            history.append((out.track_ids.tolist(), out.det_indices.tolist()))
+        return history
+
+    def test_no_embeddings_matches_ocsort(self):
+        lifecycle = _fast()
+        deep = self._drive(DeepOcSortTracker(DeepOcSortConfig(lifecycle=lifecycle)))
+        plain = self._drive(OCSortTracker(OCSortConfig(lifecycle=lifecycle)))
+        assert deep == plain
+
+    def test_reid_disabled_and_no_gallery_is_populated(self):
+        # No embeddings ever reach the galleries, so appearance never engages.
+        tracker = DeepOcSortTracker(DeepOcSortConfig(lifecycle=_fast()))
+        self._drive(tracker)
+        assert tracker._appearance == {}
+
+
+class TestBelowFloorInvariant:
+    """Below the IoU floor, appearance is not fused and cannot reorder matches.
+
+    After a gap the track's prediction overlaps two competitors, both below the
+    appearance floor (IoU ~0.47 and ~0.32) but still IoU-matchable: a geometry
+    winner (row 0, higher IoU) carrying the wrong embedding and a geometry loser
+    (row 1, lower IoU) carrying the right one. Even at a high appearance weight,
+    the track binds to the geometry winner exactly as OC-SORT would.
+    """
+
+    @staticmethod
+    def _run(tracker: BaseTracker) -> dict[int, int]:
+        tracker.update(_dets([[50, 50, 90, 90]], [0.9], frame_id=0, embeddings=[_E_A]))
+        tracker.update(_dets([], [], frame_id=1, embeddings=[]))
+        out = tracker.update(
+            _dets(
+                [[58, 58, 98, 98], [62, 62, 102, 102]],
+                [0.9, 0.9],
+                frame_id=2,
+                embeddings=[_E_B, _E_A],
+            ),
+        )
+        return {int(t): int(d) for t, d in zip(out.track_ids, out.det_indices, strict=True)}
+
+    def test_deepocsort_does_not_reorder_below_floor(self):
+        # appearance_weight=0.9 would flip the match to the _E_A box (row 1) if
+        # appearance were (wrongly) fused below the floor; the track must stay on
+        # the geometry winner (row 0).
+        cfg = DeepOcSortConfig(lifecycle=_fast(), appearance_weight=0.9)
+        assert cfg.appearance_iou_floor == pytest.approx(0.5)
+        assert self._run(DeepOcSortTracker(cfg))[1] == 0
+
+    def test_matches_the_ocsort_baseline(self):
+        assert self._run(OCSortTracker(OCSortConfig(lifecycle=_fast())))[1] == 0
+
+
+class TestGalleryLifecycle:
+    def test_gallery_created_on_spawn_and_dropped_on_removal(self):
+        cfg = DeepOcSortConfig(lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1, max_age=1))
+        tracker = DeepOcSortTracker(cfg)
+        tracker.update(_dets([[10, 10, 50, 50]], [0.9], frame_id=0, embeddings=[_E_A]))
+        assert set(tracker._appearance) == {1}
+        for f in range(1, 4):
+            tracker.update(_dets([], [], frame_id=f, embeddings=[]))
+        assert tracker._appearance == {}
+
+    def test_reset_clears_galleries(self):
+        cfg = DeepOcSortConfig(lifecycle=LifecycleConfig(min_hits=1))
+        tracker = DeepOcSortTracker(cfg)
+        tracker.update(_dets([[10, 10, 50, 50]], [0.9], frame_id=0, embeddings=[_E_A]))
+        tracker.reset()
+        assert tracker._appearance == {}
+
+    def test_low_score_hits_do_not_pollute_gallery(self):
+        # A BYTE-stage match below det_threshold must not feed the gallery.
+        cfg = DeepOcSortConfig(lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=2), use_byte=True)
+        tracker = DeepOcSortTracker(cfg)
+        tracker.update(_dets([[10, 10, 50, 50]], [0.9], frame_id=0, embeddings=[_E_A]))
+        tracker.update(_dets([[12, 12, 52, 52]], [0.3], frame_id=1, embeddings=[_E_B]))
+        assert len(tracker._appearance[1]) == 1
+
+
+class TestMultiSpawn:
+    def test_each_gallery_is_keyed_to_the_right_detection(self):
+        cfg = DeepOcSortConfig(lifecycle=LifecycleConfig(min_hits=1))
+        tracker = DeepOcSortTracker(cfg)
+        out = tracker.update(
+            _dets(
+                [[0, 0, 20, 20], [200, 200, 240, 240]],
+                [0.9, 0.9],
+                frame_id=0,
+                embeddings=[_E_A, _E_B],
+            ),
+        )
+        assert out.track_ids.tolist() == [1, 2]
+        assert float(tracker._appearance[1].distance(_E_A[None, :])[0]) == pytest.approx(0.0, abs=1e-5)
+        assert float(tracker._appearance[1].distance(_E_B[None, :])[0]) == pytest.approx(1.0, abs=1e-5)
+        assert float(tracker._appearance[2].distance(_E_B[None, :])[0]) == pytest.approx(0.0, abs=1e-5)
+        assert float(tracker._appearance[2].distance(_E_A[None, :])[0]) == pytest.approx(1.0, abs=1e-5)
+
+
+class TestReidConfigWarning:
+    def test_deepocsort_config_with_enabled_reid_and_no_path_warns(self):
+        from getitrack.config import ReIDConfig
+
+        with pytest.warns(UserWarning, match="neither model_name nor model_path"):
+            DeepOcSortConfig(reid=ReIDConfig(enabled=True))
+
+
+class TestNoEmbeddings:
+    def test_deepocsort_falls_back_to_iou_without_embeddings(self):
+        cfg = DeepOcSortConfig(lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1))
+        tracker = DeepOcSortTracker(cfg)
+        tracker.update(_dets([[10, 10, 50, 50]], [0.9], frame_id=0))
+        out = tracker.update(_dets([[12, 12, 52, 52]], [0.9], frame_id=1))
+        assert out.track_ids.tolist() == [1]


### PR DESCRIPTION
Adds Deep OC-SORT, extending OC-SORT with an appearance (ReID) stage.

- Each track keeps a bounded appearance gallery; the OCM association fuses a cosine appearance cost with IoU under an IoU floor, before the momentum term.
- Reuses the shared ReID layer (torchreid/OpenVINO providers, factory) from BoT-SORT. Reduces to OC-SORT when no embeddings are supplied.
- Config `DeepOcSortConfig` (appearance weight, gallery size, admission threshold, ...); registered as `deepocsort`.

Unit tests cover the config, association, appearance recovery across an occlusion, and the gallery. A performance comparison on real sequences will follow.
