### PR TITLE
Add StrongSORT tracker

### DIFF
--- a/libraries/getitrack/src/getitrack/algorithms/__init__.py
+++ b/libraries/getitrack/src/getitrack/algorithms/__init__.py
@@ -11,5 +11,6 @@ from getitrack.algorithms.botsort import BotSortTracker
 from getitrack.algorithms.bytetrack import ByteTrackTracker
 from getitrack.algorithms.ocsort import OCSortTracker
 from getitrack.algorithms.sort import SortTracker
+from getitrack.algorithms.strongsort import StrongSortTracker
 
-__all__ = ["BotSortTracker", "ByteTrackTracker", "OCSortTracker", "SortTracker"]
+__all__ = ["BotSortTracker", "ByteTrackTracker", "OCSortTracker", "SortTracker", "StrongSortTracker"]

--- a/libraries/getitrack/src/getitrack/algorithms/configs/strongsort.py
+++ b/libraries/getitrack/src/getitrack/algorithms/configs/strongsort.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Configuration model for the StrongSORT tracker."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import Field
+
+from getitrack.algorithms.configs.sort import SortConfig
+from getitrack.config import AlgorithmType, ReIDConfig
+
+
+class StrongSortConfig(SortConfig):
+    """StrongSORT configuration.
+
+    Extends SORT with three components: an appearance (ReID) stage layered on the
+    IoU association, ECC-based global motion compensation (GMC), and the optional
+    NSA-Kalman confidence-scaled measurement noise. Each is individually
+    toggleable. With no detection embeddings, no supplied GMC warp, and
+    ``nsa_kalman`` off, the tracker reproduces plain SORT. ``gmc_enabled``
+    defaults on but is inert until a per-frame warp is supplied via
+    ``StrongSortTracker.set_frame_warp``.
+    """
+
+    algorithm: Literal[AlgorithmType.STRONGSORT] = AlgorithmType.STRONGSORT  # pyrefly: ignore[bad-override]
+    """Algorithm identifier; fixed to ``strongsort``."""
+
+    appearance_weight: Annotated[float, Field(ge=0.0, le=1.0)] = 0.75
+    """Weight of the appearance term when fusing appearance and IoU costs.
+
+    IoU contributes the remaining ``1 - appearance_weight``, and the IoU
+    proximity gate still guards every fused pair. 0 disables appearance
+    influence; 1 matches on appearance alone within the gate."""
+
+    appearance_iou_floor: Annotated[float, Field(ge=0.0, le=1.0)] = 0.5
+    """Minimum IoU a track/detection pair must reach for appearance fusion to
+    apply. Pairs below it fall back to the plain IoU cost."""
+
+    gallery_size: Annotated[int, Field(ge=1)] = 50
+    """Maximum descriptors retained in each track's FIFO appearance gallery."""
+
+    appearance_threshold: Annotated[float, Field(ge=0.0, le=2.0)] = 0.25
+    """Maximum cosine distance for a descriptor to be admitted into a track's
+    gallery."""
+
+    use_ema: bool = True
+    """Query appearance against a running EMA descriptor in addition to the raw
+    FIFO gallery entries."""
+
+    ema_alpha: Annotated[float, Field(gt=0.0, lt=1.0)] = 0.9
+    """EMA retention factor. Higher keeps more appearance history. The update is
+    ``ema = (1 - w) * ema + w * feature`` with ``w = (1 - ema_alpha) * score``."""
+
+    reid: ReIDConfig = Field(default_factory=ReIDConfig)
+    """ReID model enablement and path used to embed detections."""
+
+    gmc_enabled: bool = True
+    """Enable ECC global motion compensation. When on, a per-frame affine warp
+    supplied via ``StrongSortTracker.set_frame_warp`` is applied to every track's
+    Kalman-predicted box before association. Inert until a warp is supplied."""
+
+    nsa_kalman: bool = False
+    """Enable the NSA-Kalman rule: scale the Kalman measurement noise by
+    ``1 - score``."""

--- a/libraries/getitrack/src/getitrack/algorithms/sort.py
+++ b/libraries/getitrack/src/getitrack/algorithms/sort.py
@@ -144,7 +144,21 @@ class SortTracker(BaseTracker[SortConfig]):
         self._frame_det_index[track_id] = src_index
         measurement = xyxy_to_xyah(bbox[None, :])[0]
         mean, covariance = self._kalman_states[track_id]
-        self._kalman_states[track_id] = self._kalman.update(mean, covariance, measurement)
+        self._kalman_states[track_id] = self._kalman.update(
+            mean,
+            covariance,
+            measurement,
+            measurement_noise_scale=self._measurement_noise_scale(score),
+        )
+
+    def _measurement_noise_scale(self, score: float) -> float:
+        """Return the Kalman measurement-noise multiplier for a hit.
+
+        Plain SORT always returns ``1.0``. Subclasses override this hook to
+        implement confidence-aware measurement noise (e.g. StrongSORT's
+        NSA-Kalman).
+        """
+        return 1.0
 
     def _spawn_track(self, dets: Detections, det_idx: int, *, src_index: int) -> None:
         """Create a new track from an unmatched detection."""

--- a/libraries/getitrack/src/getitrack/algorithms/strongsort.py
+++ b/libraries/getitrack/src/getitrack/algorithms/strongsort.py
@@ -1,0 +1,260 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""StrongSORT: SORT with appearance (ReID), ECC GMC, and NSA-Kalman.
+
+Extends SORT's single-stage IoU association and Kalman motion model with three
+individually toggleable components:
+
+- Appearance (ReID): each track keeps a bounded appearance gallery
+  (`getitrack.reid.gallery.AppearanceGallery`); during association a cosine
+  appearance cost is fused with the IoU cost under an IoU proximity gate. Outside
+  the gate, or where a track has no appearance, the cell uses the plain IoU cost.
+
+- ECC global motion compensation (GMC): when ``gmc_enabled`` is set, a per-frame
+  2x3 affine warp supplied via `set_frame_warp` is applied to each track's
+  Kalman-predicted box before association.
+
+- NSA-Kalman: when ``nsa_kalman`` is set, the Kalman measurement noise is scaled
+  by ``1 - score``.
+
+Appearance features come from ``Detections.embeddings``, populated directly or via
+`StrongSortTracker.reid_provider`. With no embeddings, no supplied GMC warp, and
+``nsa_kalman`` off, StrongSORT reproduces plain SORT.
+
+Reference: Du et al., "StrongSORT: Make DeepSORT Great Again" (IEEE TMM 2023).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar, cast
+
+import numpy as np
+
+from getitrack.algorithms.configs.strongsort import StrongSortConfig
+from getitrack.algorithms.sort import SortTracker
+from getitrack.core.registry import register_algorithm
+from getitrack.matching import fuse_appearance_cost, linear_assignment
+from getitrack.reid.gallery import AppearanceGallery
+from getitrack.utils import xyxy_to_xyah
+
+if TYPE_CHECKING:
+    from getitrack.config import LifecycleConfig
+    from getitrack.core.detection import Detections, TrackedDetections
+    from getitrack.reid.base import ReIDProvider
+
+
+@register_algorithm("strongsort", config=StrongSortConfig)
+class StrongSortTracker(SortTracker):
+    """StrongSORT multi-object tracker (SORT + appearance + GMC + NSA-Kalman).
+
+    Maintains SORT's Kalman + lifecycle state and, in parallel, one
+    `AppearanceGallery` per track keyed by track id. Matched and newly spawned
+    detections feed their descriptor into the gallery; the IoU association fuses
+    the resulting appearance cost with IoU, an optional ECC warp compensates for
+    camera motion before association, and an optional NSA-Kalman rule scales the
+    measurement noise by detection confidence.
+    """
+
+    algorithm_name: ClassVar[str] = "strongsort"
+
+    _NSA_NOISE_FLOOR: ClassVar[float] = 0.05
+    """Lower bound on the NSA measurement-noise scale."""
+
+    def __init__(self, config: StrongSortConfig) -> None:
+        super().__init__(config)
+        self._appearance: dict[int, AppearanceGallery] = {}
+        self._reid_provider: ReIDProvider | None = None
+        self._pending_warp: np.ndarray | None = None
+        self._current_warp: np.ndarray | None = None
+
+    @property
+    def _cfg(self) -> StrongSortConfig:
+        """Return the config narrowed to its StrongSORT type."""
+        return cast("StrongSortConfig", self.config)
+
+    def reset(self) -> None:  # noqa: D102
+        super().reset()
+        self._appearance.clear()
+        self._pending_warp = None
+        self._current_warp = None
+
+    @property
+    def reid_provider(self) -> ReIDProvider | None:
+        """Lazily-built ReID provider from ``config.reid``, or None if disabled.
+
+        Fill ``Detections.embeddings`` before `update`::
+
+            dets = replace(dets, embeddings=tracker.reid_provider.extract(frame, dets.bboxes))
+        """
+        if self._reid_provider is None and self._cfg.reid.enabled:
+            from getitrack.reid.factory import build_reid_provider
+
+            self._reid_provider = build_reid_provider(self._cfg.reid)
+        return self._reid_provider
+
+    def set_frame_warp(self, warp: np.ndarray | None) -> None:
+        """Register the ``(2, 3)`` GMC affine warp to apply on the next `update`.
+
+        The warp maps previous-frame to current-frame pixel coordinates. It is
+        consumed by the next `update` and then cleared. Passing ``None`` skips
+        compensation for that frame, and the warp is ignored unless
+        ``gmc_enabled`` is set.
+
+        Args:
+            warp: ``(2, 3)`` previous-to-current affine warp, or ``None``.
+        """
+        self._pending_warp = warp
+
+    def _update_impl(self, detections: Detections) -> TrackedDetections:
+        # Consume the pending warp before association.
+        self._current_warp = self._pending_warp if self._cfg.gmc_enabled else None
+        self._pending_warp = None
+        tracked = super()._update_impl(detections)
+        for track_id in set(self._appearance) - set(self._tracks):
+            del self._appearance[track_id]
+        return tracked
+
+    def _predict_all(self) -> None:
+        """Advance the Kalman states, then warp predicted boxes for camera motion."""
+        super()._predict_all()
+        if self._current_warp is not None:
+            self._apply_gmc(self._current_warp)
+
+    def _apply_gmc(self, warp: np.ndarray) -> None:
+        """Warp every track's predicted box and Kalman mean position by ``warp``.
+
+        Applies the affine ``warp`` to each track's predicted ``xyxy`` box and
+        writes the result back onto both ``track.bbox`` and the Kalman mean's
+        position/scale. Velocity and covariance are left unchanged.
+
+        Args:
+            warp: ``(2, 3)`` affine warp mapping previous-frame to current-frame
+                coordinates.
+        """
+        for track_id, track in self._tracks.items():
+            warped = self._warp_boxes(track.bbox[None, :], warp)[0]
+            track.bbox = warped
+            mean, covariance = self._kalman_states[track_id]
+            mean = mean.copy()
+            mean[:4] = xyxy_to_xyah(warped[None, :])[0]
+            self._kalman_states[track_id] = (mean, covariance)
+
+    @staticmethod
+    def _warp_boxes(boxes: np.ndarray, warp: np.ndarray) -> np.ndarray:
+        """Apply a ``(2, 3)`` affine warp to ``xyxy`` boxes.
+
+        The box center is transformed by ``warp = [R | t]`` (a point ``p`` maps
+        to ``R @ p + t``) and the width/height are scaled by the warp's isotropic
+        scale factor ``sqrt(|det R|)``.
+
+        Args:
+            boxes: ``(N, 4)`` ``xyxy`` boxes.
+            warp: ``(2, 3)`` affine matrix.
+
+        Returns:
+            ``(N, 4)`` float32 warped, axis-aligned ``xyxy`` boxes.
+        """
+        if boxes.size == 0:
+            return boxes.astype(np.float32, copy=False)
+        rot = warp[:, :2]
+        trans = warp[:, 2]
+        centers = (boxes[:, :2] + boxes[:, 2:]) * 0.5  # (N, 2)
+        sizes = boxes[:, 2:] - boxes[:, :2]  # (N, 2) width, height
+        scale = float(np.sqrt(abs(np.linalg.det(rot))))
+        new_centers = centers @ rot.T + trans  # (N, 2)
+        half = sizes * scale * 0.5
+        return np.concatenate([new_centers - half, new_centers + half], axis=1).astype(np.float32)
+
+    def _associate(self, track_ids: list[int], dets: Detections) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Match on IoU cost with appearance fusion, gated by ``match_threshold``.
+
+        Like `SortTracker._associate` but blends a cosine appearance cost into the
+        IoU cost (under the IoU proximity gate) when detection embeddings and at
+        least one non-empty gallery are available. Outside the gate, or where a
+        track has no appearance, the cell uses the plain IoU cost.
+
+        Returns:
+            ``(matches, unmatched_track_idx, unmatched_det_idx)`` index arrays.
+        """
+        if not track_ids or len(dets) == 0:
+            return (
+                np.empty((0, 2), dtype=np.int64),
+                np.arange(len(track_ids), dtype=np.int64),
+                np.arange(len(dets), dtype=np.int64),
+            )
+        track_boxes = np.stack([self._tracks[track_id].bbox for track_id in track_ids], axis=0)
+        cost = self._distance(track_boxes, dets.bboxes)
+        if dets.embeddings is not None:
+            appearance_cost = self._appearance_cost(track_ids, dets.embeddings)
+            if appearance_cost is not None:
+                cost = fuse_appearance_cost(
+                    cost,
+                    appearance_cost,
+                    appearance_weight=self._cfg.appearance_weight,
+                    iou_floor=self._cfg.appearance_iou_floor,
+                )
+        if self.config.match_class_only:
+            track_classes = np.array([self._tracks[track_id].class_id for track_id in track_ids])
+            cost[track_classes[:, None] != dets.class_ids[None, :]] = self._UNMATCHABLE_COST
+        return linear_assignment(cost, self.config.match_threshold)
+
+    def _appearance_cost(self, track_ids: list[int], det_embeddings: np.ndarray) -> np.ndarray | None:
+        """Build the ``(T, N)`` appearance cost, or None if no gallery is usable.
+
+        Tracks without a usable gallery get an all-``NaN`` row.
+        """
+        n = det_embeddings.shape[0]
+        rows: list[np.ndarray] = []
+        usable = False
+        for track_id in track_ids:
+            gallery = self._appearance.get(track_id)
+            if gallery is None or gallery.is_empty:
+                rows.append(np.full((n,), np.nan, dtype=np.float32))
+            else:
+                rows.append(gallery.distance(det_embeddings))
+                usable = True
+        if not usable:
+            return None
+        return np.stack(rows, axis=0).astype(np.float32)
+
+    def _apply_hit(
+        self,
+        track_id: int,
+        dets: Detections,
+        det_idx: int,
+        lifecycle: LifecycleConfig,
+        *,
+        src_index: int,
+    ) -> None:
+        super()._apply_hit(track_id, dets, det_idx, lifecycle, src_index=src_index)
+        if dets.embeddings is not None:
+            self._admit(track_id, dets.embeddings[det_idx], float(dets.scores[det_idx]))
+
+    def _spawn_track(self, dets: Detections, det_idx: int, *, src_index: int) -> None:
+        new_id = self._next_id
+        super()._spawn_track(dets, det_idx, src_index=src_index)
+        if dets.embeddings is not None:
+            self._admit(new_id, dets.embeddings[det_idx], float(dets.scores[det_idx]))
+
+    def _admit(self, track_id: int, feature: np.ndarray, score: float) -> None:
+        """Feed a matched detection's descriptor into the track's gallery."""
+        gallery = self._appearance.get(track_id)
+        if gallery is None:
+            gallery = AppearanceGallery(
+                gallery_size=self._cfg.gallery_size,
+                use_ema=self._cfg.use_ema,
+                ema_alpha=self._cfg.ema_alpha,
+                admission_threshold=self._cfg.appearance_threshold,
+            )
+            self._appearance[track_id] = gallery
+        gallery.update(feature, confidence=score)
+
+    def _measurement_noise_scale(self, score: float) -> float:
+        """Return the NSA-Kalman measurement-noise multiplier for a hit.
+
+        With ``nsa_kalman`` off this is ``1.0``. When on it returns ``1 - score``
+        floored at `_NSA_NOISE_FLOOR`.
+        """
+        if not self._cfg.nsa_kalman:
+            return 1.0
+        return max(1.0 - score, self._NSA_NOISE_FLOOR)

--- a/libraries/getitrack/src/getitrack/config.py
+++ b/libraries/getitrack/src/getitrack/config.py
@@ -29,6 +29,7 @@ class AlgorithmType(StrEnum):
     SORT = "sort"
     OCSORT = "ocsort"
     BOTSORT = "botsort"
+    STRONGSORT = "strongsort"
     MEMORY = "memory"
 
 

--- a/libraries/getitrack/src/getitrack/motion/kalman.py
+++ b/libraries/getitrack/src/getitrack/motion/kalman.py
@@ -141,18 +141,26 @@ class KalmanFilter:
         new_covariances = np.einsum("nij,kj->nik", left, self._motion_mat) + motion_covs
         return new_means, new_covariances
 
-    def project(self, mean: np.ndarray, covariance: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    def project(
+        self,
+        mean: np.ndarray,
+        covariance: np.ndarray,
+        *,
+        measurement_noise_scale: float = 1.0,
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Project the state distribution into measurement space.
 
         Args:
             mean: ``(8,)`` state mean.
             covariance: ``(8, 8)`` state covariance.
+            measurement_noise_scale: Multiplier on the measurement-noise
+                covariance (R). The default ``1.0`` leaves R unchanged.
 
         Returns:
             ``(measurement_mean, measurement_covariance)`` of shapes
             ``(4,)`` and ``(4, 4)``.
         """
-        innovation_cov = self._measurement_noise_cov(mean[3])
+        innovation_cov = self._measurement_noise_cov(mean[3]) * measurement_noise_scale
         m = self._update_mat @ mean
         c = self._update_mat @ covariance @ self._update_mat.T
         return m, c + innovation_cov
@@ -162,6 +170,8 @@ class KalmanFilter:
         mean: np.ndarray,
         covariance: np.ndarray,
         measurement: np.ndarray,
+        *,
+        measurement_noise_scale: float = 1.0,
     ) -> tuple[np.ndarray, np.ndarray]:
         """Apply the Kalman correction step with a new ``xyah`` measurement.
 
@@ -169,11 +179,14 @@ class KalmanFilter:
             mean: ``(8,)`` predicted state mean.
             covariance: ``(8, 8)`` predicted state covariance.
             measurement: ``(4,)`` observed ``[x, y, a, h]``.
+            measurement_noise_scale: Multiplier on the measurement-noise
+                covariance (R) for this correction. The default ``1.0`` leaves R
+                unchanged.
 
         Returns:
             ``(mean, covariance)`` of the corrected posterior.
         """
-        projected_mean, projected_cov = self.project(mean, covariance)
+        projected_mean, projected_cov = self.project(mean, covariance, measurement_noise_scale=measurement_noise_scale)
         chol_factor, lower = scipy.linalg.cho_factor(projected_cov, lower=True, check_finite=False)
         kalman_gain_t = np.asarray(
             scipy.linalg.cho_solve(

--- a/libraries/getitrack/tests/unit/test_strongsort.py
+++ b/libraries/getitrack/tests/unit/test_strongsort.py
@@ -1,0 +1,361 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""Unit + integration tests for the StrongSORT tracker and its config."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import getitrack.algorithms  # noqa: F401  -> registers StrongSORT
+from getitrack.algorithms import SortTracker, StrongSortTracker
+from getitrack.algorithms.configs.sort import SortConfig
+from getitrack.algorithms.configs.strongsort import StrongSortConfig
+from getitrack.config import AlgorithmType, LifecycleConfig, TrackerConfig
+from getitrack.core.base import BaseTracker
+from getitrack.core.detection import Detections
+from getitrack.core.registry import resolve_tracker_config
+from getitrack.motion import KalmanFilter
+
+_E_A = np.array([1.0, 0.0], dtype=np.float32)
+_E_B = np.array([0.0, 1.0], dtype=np.float32)
+
+
+def _rotation_warp(theta: float) -> np.ndarray:
+    """Return a 2x3 pure-rotation affine warp (about the origin)."""
+    cos, sin = np.cos(theta), np.sin(theta)
+    return np.array([[cos, -sin, 0.0], [sin, cos, 0.0]], dtype=np.float32)
+
+
+def _dets(
+    boxes: list[list[float]],
+    scores: list[float],
+    frame_id: int,
+    embeddings: list[np.ndarray] | None = None,
+) -> Detections:
+    n = len(boxes)
+    emb: np.ndarray | None = None
+    if embeddings is not None:
+        emb = np.asarray(embeddings, dtype=np.float32).reshape(n, -1) if n else np.empty((0, 2), dtype=np.float32)
+    return Detections(
+        bboxes=np.asarray(boxes, dtype=np.float32).reshape(n, 4),
+        scores=np.asarray(scores, dtype=np.float32),
+        class_ids=np.zeros(n, dtype=np.int64),
+        frame_id=frame_id,
+        embeddings=emb,
+    )
+
+
+class TestConfigRegistry:
+    def test_from_config_dispatches_to_strongsort(self):
+        tracker = BaseTracker.from_config(StrongSortConfig())
+        assert isinstance(tracker, StrongSortTracker)
+
+    def test_resolve_dispatches_on_algorithm_key(self):
+        resolved = resolve_tracker_config({"algorithm": "strongsort", "appearance_weight": 0.6})
+        assert isinstance(resolved, StrongSortConfig)
+        assert resolved.appearance_weight == pytest.approx(0.6)
+
+    def test_algorithm_is_pinned(self):
+        assert StrongSortConfig().algorithm == AlgorithmType.STRONGSORT
+
+    def test_appearance_is_primary_by_default(self):
+        assert StrongSortConfig().appearance_weight == pytest.approx(0.75)
+
+    def test_gmc_enabled_by_default_nsa_off_by_default(self):
+        cfg = StrongSortConfig()
+        assert cfg.gmc_enabled is True
+        assert cfg.nsa_kalman is False
+
+    def test_yaml_round_trip(self, tmp_path):
+        cfg = StrongSortConfig(
+            appearance_weight=0.5,
+            gallery_size=17,
+            appearance_threshold=0.3,
+            use_ema=False,
+            gmc_enabled=False,
+            nsa_kalman=True,
+            lifecycle=LifecycleConfig(max_age=42),
+        )
+        path = tmp_path / "strongsort.yaml"
+        cfg.to_yaml(path)
+        assert TrackerConfig.from_yaml(path) == cfg
+
+    def test_reid_section_defaults(self):
+        cfg = StrongSortConfig()
+        assert cfg.reid.enabled is False
+        assert cfg.reid.model_path is None
+        assert cfg.reid.input_size == (256, 128)
+
+    def test_extends_sort_parameters(self):
+        # StrongSORT inherits the SORT knobs (e.g. the IoU threshold).
+        assert StrongSortConfig().iou_threshold == pytest.approx(0.3)
+
+
+class TestReidProviderProperty:
+    def test_provider_is_none_when_reid_disabled(self):
+        assert StrongSortTracker(StrongSortConfig()).reid_provider is None
+
+
+class TestReidConfigWarning:
+    def test_strongsort_config_with_enabled_reid_and_no_path_warns(self):
+        from getitrack.config import ReIDConfig
+
+        with pytest.warns(UserWarning, match="neither model_name nor model_path"):
+            StrongSortConfig(reid=ReIDConfig(enabled=True))
+
+
+class TestReducesToSort:
+    """With appearance (no embeddings), GMC, and NSA off, StrongSORT == SORT."""
+
+    @staticmethod
+    def _sequence() -> list[Detections]:
+        return [
+            _dets([[10, 10, 50, 50], [200, 200, 240, 240]], [0.9, 0.8], frame_id=0),
+            _dets([[14, 12, 54, 52], [203, 201, 243, 241]], [0.9, 0.8], frame_id=1),
+            _dets([[18, 14, 58, 54]], [0.9], frame_id=2),  # second target drops out
+            _dets([[22, 16, 62, 56], [260, 260, 300, 300]], [0.9, 0.85], frame_id=3),  # new spawn
+        ]
+
+    def test_identical_outputs_frame_by_frame(self):
+        lifecycle = LifecycleConfig(min_hits=1, tentative_max_age=1, max_age=5)
+        sort = SortTracker(SortConfig(lifecycle=lifecycle))
+        strong = StrongSortTracker(StrongSortConfig(lifecycle=lifecycle, gmc_enabled=False))
+        for dets in self._sequence():
+            out_sort = sort.update(dets)
+            out_strong = strong.update(dets)
+            np.testing.assert_array_equal(out_strong.track_ids, out_sort.track_ids)
+            np.testing.assert_array_equal(out_strong.det_indices, out_sort.det_indices)
+            np.testing.assert_allclose(out_strong.bboxes, out_sort.bboxes, rtol=1e-6, atol=1e-6)
+
+
+class TestAppearanceRecovery:
+    """Appearance recovers an identity across an occlusion that IoU alone drops."""
+
+    @staticmethod
+    def _run(tracker: BaseTracker) -> int:
+        tracker.update(_dets([[50, 50, 90, 90]], [0.9], frame_id=0, embeddings=[_E_A]))
+        tracker.update(_dets([], [], frame_id=1, embeddings=[]))
+        out = tracker.update(
+            _dets(
+                [[50, 50, 90, 90], [46, 46, 86, 86]],
+                [0.9, 0.9],
+                frame_id=2,
+                embeddings=[_E_B, _E_A],
+            ),
+        )
+        det_indices = out.det_indices.tolist()
+        row = det_indices.index(1)
+        return int(out.track_ids[row])
+
+    def test_sort_iou_only_loses_the_identity(self):
+        cfg = SortConfig(lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1, max_age=5))
+        assert self._run(SortTracker(cfg)) != 1
+
+    def test_strongsort_appearance_recovers_the_identity(self):
+        cfg = StrongSortConfig(
+            lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1, max_age=5),
+            gmc_enabled=False,
+        )
+        assert cfg.appearance_weight == pytest.approx(0.75)
+        assert self._run(StrongSortTracker(cfg)) == 1
+
+
+class TestAppearanceDiscrimination:
+    """At a high weight, a disagreeing embedding can drop a perfect-IoU match.
+
+    The convex blend raises a disagreeing pair's cost above ``match_threshold``
+    and drops it. SORT (IoU only) keeps the same pair.
+    """
+
+    @staticmethod
+    def _run(tracker: BaseTracker) -> list[int]:
+        # Frame 0 establishes track 1 with appearance E_A. Frame 1 offers a
+        # perfect-IoU detection (cost 0 on geometry) but with the opposite
+        # embedding E_B, so appearance strongly disagrees.
+        tracker.update(_dets([[50, 50, 90, 90]], [0.9], frame_id=0, embeddings=[_E_A]))
+        out = tracker.update(_dets([[50, 50, 90, 90]], [0.9], frame_id=1, embeddings=[_E_B]))
+        return out.track_ids.tolist()
+
+    def test_high_weight_appearance_drops_a_perfect_iou_match(self):
+        # fused = 0.25 * 0.0 + 0.75 * 1.0 = 0.75 > match_threshold (0.7): dropped,
+        # so the detection spawns a fresh id rather than continuing track 1.
+        cfg = StrongSortConfig(
+            lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1, max_age=5),
+            appearance_weight=0.75,
+            gmc_enabled=False,
+        )
+        assert self._run(StrongSortTracker(cfg)) == [2]
+
+    def test_sort_keeps_the_perfect_iou_match(self):
+        cfg = SortConfig(lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1, max_age=5))
+        assert self._run(SortTracker(cfg)) == [1]
+
+
+class TestNoEmbeddings:
+    def test_strongsort_falls_back_to_iou_without_embeddings(self):
+        cfg = StrongSortConfig(lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1), gmc_enabled=False)
+        tracker = StrongSortTracker(cfg)
+        tracker.update(_dets([[10, 10, 50, 50]], [0.9], frame_id=0))
+        out = tracker.update(_dets([[12, 12, 52, 52]], [0.9], frame_id=1))
+        assert out.track_ids.tolist() == [1]
+
+
+class TestGalleryLifecycle:
+    def test_gallery_created_on_spawn_and_dropped_on_removal(self):
+        cfg = StrongSortConfig(lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1, max_age=1), gmc_enabled=False)
+        tracker = StrongSortTracker(cfg)
+        tracker.update(_dets([[10, 10, 50, 50]], [0.9], frame_id=0, embeddings=[_E_A]))
+        assert set(tracker._appearance) == {1}
+        for f in range(1, 4):
+            tracker.update(_dets([], [], frame_id=f, embeddings=[]))
+        assert tracker._appearance == {}
+
+    def test_reset_clears_galleries_and_warps(self):
+        cfg = StrongSortConfig(lifecycle=LifecycleConfig(min_hits=1))
+        tracker = StrongSortTracker(cfg)
+        tracker.update(_dets([[10, 10, 50, 50]], [0.9], frame_id=0, embeddings=[_E_A]))
+        tracker.set_frame_warp(np.eye(2, 3, dtype=np.float32))
+        tracker.reset()
+        assert tracker._appearance == {}
+        assert tracker._pending_warp is None
+
+    def test_each_gallery_is_keyed_to_the_right_detection(self):
+        cfg = StrongSortConfig(lifecycle=LifecycleConfig(min_hits=1), gmc_enabled=False)
+        tracker = StrongSortTracker(cfg)
+        out = tracker.update(
+            _dets([[0, 0, 20, 20], [200, 200, 240, 240]], [0.9, 0.9], frame_id=0, embeddings=[_E_A, _E_B]),
+        )
+        assert out.track_ids.tolist() == [1, 2]
+        assert float(tracker._appearance[1].distance(_E_A[None, :])[0]) == pytest.approx(0.0, abs=1e-5)
+        assert float(tracker._appearance[1].distance(_E_B[None, :])[0]) == pytest.approx(1.0, abs=1e-5)
+        assert float(tracker._appearance[2].distance(_E_B[None, :])[0]) == pytest.approx(0.0, abs=1e-5)
+
+
+class TestWarpBoxes:
+    """The GMC warp application is a pure box transform, tested without video."""
+
+    def test_pure_translation(self):
+        warp = np.array([[1.0, 0.0, 10.0], [0.0, 1.0, -5.0]], dtype=np.float32)
+        boxes = np.array([[0.0, 0.0, 10.0, 10.0]], dtype=np.float32)
+        out = StrongSortTracker._warp_boxes(boxes, warp)
+        np.testing.assert_allclose(out, [[10.0, -5.0, 20.0, 5.0]], atol=1e-5)
+
+    def test_pure_scale_about_origin(self):
+        warp = np.array([[2.0, 0.0, 0.0], [0.0, 2.0, 0.0]], dtype=np.float32)
+        boxes = np.array([[1.0, 1.0, 3.0, 3.0]], dtype=np.float32)
+        out = StrongSortTracker._warp_boxes(boxes, warp)
+        np.testing.assert_allclose(out, [[2.0, 2.0, 6.0, 6.0]], atol=1e-5)
+
+    def test_pure_rotation_moves_center_but_preserves_size(self):
+        # 90-degree rotation about origin: center (1, 2) -> (-2, 1); w=2, h=4 unchanged.
+        warp = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float32)
+        boxes = np.array([[0.0, 0.0, 2.0, 4.0]], dtype=np.float32)
+        out = StrongSortTracker._warp_boxes(boxes, warp)
+        np.testing.assert_allclose(out, [[-3.0, -1.0, -1.0, 3.0]], atol=1e-5)
+        # Width and height are exactly preserved under pure rotation.
+        assert out[0, 2] - out[0, 0] == pytest.approx(2.0)
+        assert out[0, 3] - out[0, 1] == pytest.approx(4.0)
+
+    def test_repeated_rotation_does_not_grow_the_box(self):
+        # Regression: feeding the warped box back under sustained rotation must
+        # not inflate it.
+        warp = _rotation_warp(np.deg2rad(0.5))
+        boxes = np.array([[100.0, 100.0, 140.0, 220.0]], dtype=np.float32)  # 40 x 120
+        area0 = 40.0 * 120.0
+        for _ in range(120):
+            boxes = StrongSortTracker._warp_boxes(boxes, warp)
+        area = float((boxes[0, 2] - boxes[0, 0]) * (boxes[0, 3] - boxes[0, 1]))
+        assert area == pytest.approx(area0, rel=1e-4)
+
+    def test_empty_input(self):
+        out = StrongSortTracker._warp_boxes(np.empty((0, 4), dtype=np.float32), np.eye(2, 3, dtype=np.float32))
+        assert out.shape == (0, 4)
+
+    def test_apply_gmc_under_sustained_rotation_keeps_area_bounded(self):
+        # The reported failure path: _apply_gmc writes the warped box back onto
+        # track.bbox, so the next frame warps an already-warped box. Loop it.
+        cfg = StrongSortConfig(lifecycle=LifecycleConfig(min_hits=1), gmc_enabled=True)
+        tracker = StrongSortTracker(cfg)
+        tracker.update(_dets([[100.0, 100.0, 140.0, 220.0]], [0.9], frame_id=0))
+        box0 = tracker._tracks[1].bbox.copy()
+        area0 = float((box0[2] - box0[0]) * (box0[3] - box0[1]))
+        warp = _rotation_warp(np.deg2rad(0.5))
+        for _ in range(120):
+            tracker._apply_gmc(warp)
+        box = tracker._tracks[1].bbox
+        area = float((box[2] - box[0]) * (box[3] - box[1]))
+        assert area == pytest.approx(area0, rel=1e-4)
+
+
+class TestGmcRecovery:
+    """A camera pan that breaks IoU is recovered once the predicted box is warped."""
+
+    @staticmethod
+    def _run(*, gmc_enabled: bool) -> list[int]:
+        cfg = StrongSortConfig(
+            lifecycle=LifecycleConfig(min_hits=1, tentative_max_age=1, max_age=5), gmc_enabled=gmc_enabled
+        )
+        tracker = StrongSortTracker(cfg)
+        tracker.update(_dets([[50, 50, 90, 90]], [0.9], frame_id=0))
+        # Camera pans right by 40px: the same object is detected 40px to the right,
+        # so its predicted box no longer overlaps the detection on IoU alone.
+        tracker.set_frame_warp(np.array([[1.0, 0.0, 40.0], [0.0, 1.0, 0.0]], dtype=np.float32))
+        out = tracker.update(_dets([[90, 50, 130, 90]], [0.9], frame_id=1))
+        return out.track_ids.tolist()
+
+    def test_without_gmc_the_pan_breaks_the_track(self):
+        assert self._run(gmc_enabled=False) == [2]
+
+    def test_with_gmc_the_warped_prediction_keeps_the_id(self):
+        assert self._run(gmc_enabled=True) == [1]
+
+    def test_warp_is_consumed_once_per_frame(self):
+        cfg = StrongSortConfig(lifecycle=LifecycleConfig(min_hits=1), gmc_enabled=True)
+        tracker = StrongSortTracker(cfg)
+        tracker.set_frame_warp(np.eye(2, 3, dtype=np.float32))
+        tracker.update(_dets([[50, 50, 90, 90]], [0.9], frame_id=0))
+        assert tracker._pending_warp is None
+
+
+class TestNsaKalman:
+    def test_scale_is_one_when_disabled(self):
+        tracker = StrongSortTracker(StrongSortConfig(nsa_kalman=False))
+        assert tracker._measurement_noise_scale(0.9) == pytest.approx(1.0)
+
+    def test_scale_is_one_minus_score_when_enabled(self):
+        tracker = StrongSortTracker(StrongSortConfig(nsa_kalman=True))
+        assert tracker._measurement_noise_scale(0.7) == pytest.approx(0.3)
+
+    def test_scale_is_floored_for_near_certain_detections(self):
+        tracker = StrongSortTracker(StrongSortConfig(nsa_kalman=True))
+        assert tracker._measurement_noise_scale(1.0) == pytest.approx(StrongSortTracker._NSA_NOISE_FLOOR)
+
+    def test_smaller_noise_scale_trusts_the_measurement_more(self):
+        # NSA-Kalman relies on this filter property: a smaller measurement-noise
+        # scale pulls the posterior mean closer to the observation.
+        kf = KalmanFilter()
+        mean, cov = kf.initiate(np.array([10.0, 10.0, 1.0, 40.0]))
+        mean, cov = kf.predict(mean, cov)
+        measurement = np.array([20.0, 20.0, 1.0, 40.0])
+        loose, _ = kf.update(mean, cov, measurement, measurement_noise_scale=1.0)
+        tight, _ = kf.update(mean, cov, measurement, measurement_noise_scale=0.1)
+        assert abs(tight[0] - measurement[0]) < abs(loose[0] - measurement[0])
+
+    @staticmethod
+    def _posterior_mean(*, nsa_kalman: bool) -> np.ndarray:
+        cfg = StrongSortConfig(lifecycle=LifecycleConfig(min_hits=1), gmc_enabled=False, nsa_kalman=nsa_kalman)
+        tracker = StrongSortTracker(cfg)
+        tracker.update(_dets([[50, 50, 90, 90]], [0.95], frame_id=0))
+        # A moderate-confidence, displaced detection that still overlaps enough to
+        # match track 1 (center 78); NSA scales its R by 1 - 0.5.
+        tracker.update(_dets([[58, 58, 98, 98]], [0.5], frame_id=1))
+        return tracker._kalman_states[1][0].copy()
+
+    def test_nsa_changes_the_update_outcome_end_to_end(self):
+        baseline = self._posterior_mean(nsa_kalman=False)
+        nsa = self._posterior_mean(nsa_kalman=True)
+        # NSA (score 0.5 -> R * 0.5) trusts the observation more, so the posterior
+        # center lands nearer the measured center (78) than the default filter.
+        assert not np.allclose(baseline, nsa)
+        assert abs(nsa[0] - 78.0) < abs(baseline[0] - 78.0)


### PR DESCRIPTION
Adds StrongSORT, extending SORT with appearance, camera-motion compensation, and NSA-Kalman.

- Appearance: a per-track gallery, cosine cost fused with IoU. Recovers identities across occlusions that IoU alone drops.
- GMC: an externally supplied ECC warp is applied to the predicted boxes before association.
- NSA-Kalman: measurement noise scaled by detection confidence.
- Config `StrongSortConfig`; registered as `strongsort`. Reduces to plain SORT with appearance, GMC, and NSA off.

Unit tests cover reduces-to-SORT, appearance recovery and discrimination, the GMC warp, and NSA. A performance comparison on real sequences will follow.
