### PR TITLE
Dedupe media item ids

### DIFF
--- a/application/ui/src/hooks/use-get-dataset-media-items.hook.ts
+++ b/application/ui/src/hooks/use-get-dataset-media-items.hook.ts
@@ -126,7 +126,11 @@ export const useGetDatasetMediaItems = (options?: UseGetDatasetMediaItemsOptions
     const items = useMemo(() => {
         const mediaItems = data?.pages?.flatMap((page) => page.items) ?? [];
 
-        return getMediaEntities(mediaItems);
+        // Offset based pagination: uploads and deletions shift items across page boundaries
+        // between refetches, so the same item can end up in two of the loaded pages.
+        const uniqueMediaItems = Array.from(new Map(mediaItems.map((item) => [item.id, item])).values());
+
+        return getMediaEntities(uniqueMediaItems);
     }, [data?.pages]);
 
     const totalCount = data?.pages[0]?.pagination?.total ?? 0;


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* When uploading hundreds of files, and since we invalidate the fetch query quite often, some items can end up in multiple pages, which duplicates the ids resulting in the key-duplication React error
* Closes https://github.com/open-edge-platform/geti/issues/7452

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
