### PR TITLE
feat(ui, dataset views): Add toast notification when dataset view is deleted

### DIFF
--- a/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/dataset-view-selector.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/dataset-view-selector.component.tsx
@@ -3,6 +3,7 @@
 
 import { useEffect, useState } from 'react';
 
+import { toast } from '@/components/toast/toast.component';
 import { Content, Dialog, DialogContainer, DialogTrigger, Flex, PressableElement, Text, View } from '@geti-ui/ui';
 import { ChevronDownSmall } from '@geti-ui/ui/icons';
 import { clsx } from 'clsx';
@@ -79,6 +80,10 @@ export const DatasetViewSelector = ({ datasetViews, resetSelectedMediaIds }: Dat
         if (datasetViewToBeDeleted?.id === datasetViewId) {
             setDatasetViewId(ENTIRE_DATASET_VIEW_ID);
         }
+        toast({
+            message: `Dataset view "${datasetViewToBeDeleted?.name}" has been deleted successfully.`,
+            type: 'success',
+        });
         setDatasetViewToBeDeleted(null);
     };
 

--- a/application/ui/tests/datasets/dataset-views-page.ts
+++ b/application/ui/tests/datasets/dataset-views-page.ts
@@ -90,4 +90,8 @@ export class DatasetViewsPage {
     getOpenViewToastLink(name: string) {
         return this.page.getByLabel('toast').getByRole('link', { name: `Open ${name} view` });
     }
+
+    getDeletedSuccessToast(name: string) {
+        return this.page.getByText(`Dataset view "${name}" has been deleted successfully.`);
+    }
 }

--- a/application/ui/tests/datasets/dataset-views.spec.ts
+++ b/application/ui/tests/datasets/dataset-views.spec.ts
@@ -216,6 +216,7 @@ test.describe('Dataset views', () => {
             await datasetPage.goto('id-1', '?datasetViewId=collection-one');
 
             await datasetPage.views.deleteView('Collection One');
+            await expect(datasetPage.views.getDeletedSuccessToast('Collection One')).toBeVisible();
 
             await expect(datasetPage.views.getViewSelectorTrigger()).toHaveText('Entire dataset');
             await expect(page).not.toHaveURL(/datasetViewId/);


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->
I was not able to reproduce the issue described in #7483 but this PR adds notification when dataset view is deleted successfully.

Closes #7483 

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [X] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
