### PR TITLE
fix: Don't invalidate query cache when assigning media to dataset view

### DIFF
--- a/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/assign-to-existing-view/assign-to-existing-view.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/assign-to-existing-view/assign-to-existing-view.component.tsx
@@ -58,7 +58,7 @@ const useAssignMediaToExistingView = () => {
                 },
             },
             {
-                onSuccess: async () => {
+                onSuccess: () => {
                     onClose(selectedDatasetViewId);
                 },
             }

--- a/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/assign-to-existing-view/assign-to-existing-view.component.tsx
+++ b/application/ui/src/features/dataset/gallery/toolbar/dataset-view-selector/assign-to-existing-view/assign-to-existing-view.component.tsx
@@ -19,13 +19,11 @@ import {
     Text,
 } from '@geti-ui/ui';
 import { Info } from '@geti-ui/ui/icons';
-import { useQueryClient } from '@tanstack/react-query';
 import { DATASET_VIEW_ID_PARAM, ENTIRE_DATASET_VIEW_ID, useDatasetViewId } from 'hooks/use-dataset-view-id.hook';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { isEmpty } from 'lodash-es';
 import { createSearchParams, Link, useLocation } from 'react-router-dom';
 
-import { getQueryKey } from '../../../../../../query-client/query-client';
 import { pluralizeItems } from '../../../../../../shared/util';
 import { useAssignMediaToExistingDatasetView } from '../api/use-assign-media-to-existing-dataset-view';
 import { SelectedMediaCount } from '../selected-media-count/selected-media-count.component';
@@ -35,7 +33,6 @@ import classes from './assign-to-existing-view.module.scss';
 
 const useAssignMediaToExistingView = () => {
     const projectId = useProjectIdentifier();
-    const queryClient = useQueryClient();
 
     const assignToExistingViewMutation = useAssignMediaToExistingDatasetView();
 
@@ -62,35 +59,6 @@ const useAssignMediaToExistingView = () => {
             },
             {
                 onSuccess: async () => {
-                    await Promise.all([
-                        queryClient.invalidateQueries({
-                            queryKey: getQueryKey([
-                                'get',
-                                '/api/projects/{project_id}/dataset/media',
-                                {
-                                    params: {
-                                        path: {
-                                            project_id: projectId,
-                                        },
-                                    },
-                                },
-                            ]),
-                        }),
-                        queryClient.invalidateQueries({
-                            queryKey: getQueryKey([
-                                'get',
-                                '/api/projects/{project_id}/dataset/items',
-                                {
-                                    params: {
-                                        path: {
-                                            project_id: projectId,
-                                        },
-                                    },
-                                },
-                            ]),
-                        }),
-                    ]);
-
                     onClose(selectedDatasetViewId);
                 },
             }


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider
including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

When we assign media to dataset view, we don't need to invalidate the cache because when we open new view, we fetch media that belongs to the dataset view (because we have `staleTime: 0`).

Closes #7479

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [X] The PR title and description are clear and descriptive
- [X] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [X] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
