### PR TITLE
Training job fixes

### DIFF
--- a/application/backend/app/core/jobs/control_plane/controller.py
+++ b/application/backend/app/core/jobs/control_plane/controller.py
@@ -124,7 +124,17 @@ class JobController:
                     await cancel_task
                 self._jobs_q.cleanup_cancellation_event(job.id)
 
-            logger.success("Job completed, job_id: {}", job.id)
+            # Log when the job has reached its final status
+            final_status: JobStatus = job.status
+            match final_status:
+                case JobStatus.DONE:
+                    logger.success("Job completed successfully, job_id: {}", job.id)
+                case JobStatus.FAILED:
+                    logger.error("Job failed, job_id: {}, error: {}", job.id, job.error)
+                case JobStatus.CANCELLED:
+                    logger.info("Job cancelled, job_id: {}", job.id)
+                case _:
+                    logger.warning("Job ended in unexpected status {}, job_id: {}", final_status.name, job.id)
 
     def _setup_job_execution(self, job: Job, job_run: Runner, event_q: asyncio.Queue) -> asyncio.Task:
         """Set up event pumping thread and cancellation monitoring task."""

--- a/application/backend/app/core/jobs/control_plane/controller.py
+++ b/application/backend/app/core/jobs/control_plane/controller.py
@@ -130,7 +130,7 @@ class JobController:
                 case JobStatus.DONE:
                     logger.success("Job completed successfully, job_id: {}", job.id)
                 case JobStatus.FAILED:
-                    logger.error("Job failed, job_id: {}, error: {}", job.id, job.error)
+                    logger.warning("Job failed, job_id: {}", job.id)
                 case JobStatus.CANCELLED:
                     logger.info("Job cancelled, job_id: {}", job.id)
                 case _:

--- a/application/backend/app/execution/training/getitune_trainer.py
+++ b/application/backend/app/execution/training/getitune_trainer.py
@@ -546,6 +546,10 @@ class GetiTuneTrainer(Execution[TrainingJobParams]):
         - PyTorch (.ckpt) variants are evaluated with the LightningEngine used for training.
         - OpenVINO (.xml) and ONNX (.onnx) variants are evaluated with OVEngine, which
           natively supports both checkpoint types.
+
+        If evaluation of the OpenVINO or ONNX variant fails (e.g. an export/runtime quirk),
+        the job is not failed: the PyTorch variant's results are reused instead, so training
+        can still complete successfully with a valid (if not fully independent) evaluation record.
         """
         from getitune.backend.openvino.engine import OVEngine
 
@@ -553,6 +557,7 @@ class GetiTuneTrainer(Execution[TrainingJobParams]):
         ov_work_dir_base = Path(getitune_engine.work_dir)
         datamodule = getitune_engine.datamodule
 
+        pytorch_metrics: dict | None = None
         for variant in model_variants:
             logger.info("Evaluating the {} model...", variant.format.value)
             match variant.format:
@@ -573,7 +578,23 @@ class GetiTuneTrainer(Execution[TrainingJobParams]):
                 case _:
                     raise ExecutionErr(f"Unsupported model variant format for evaluation: {variant.format}")
 
-            metrics = engine.test(metric=metric_callable)
+            try:
+                metrics = engine.test(metric=metric_callable)
+            except Exception as eval_exc:
+                # PyTorch is the source of truth for fallback metrics; if it's the one failing, or no
+                # fallback is available yet, there is nothing to reuse, so let the job fail as usual.
+                if variant.format == ModelFormat.PYTORCH or pytorch_metrics is None:
+                    raise
+                logger.warning(
+                    "Evaluation of the {} model failed ({}); reusing the PyTorch evaluation results instead",
+                    variant.format.value,
+                    eval_exc,
+                )
+                metrics = pytorch_metrics
+            else:
+                if variant.format == ModelFormat.PYTORCH:
+                    pytorch_metrics = metrics
+
             self._save_evaluation_result(
                 metrics=metrics,
                 model_revision_id=model_revision_id,

--- a/application/backend/app/models/jobs/training_job.py
+++ b/application/backend/app/models/jobs/training_job.py
@@ -43,6 +43,11 @@ class TrainingJob(ProjectJob[TrainingJobParams]):
     data_dir: Path
     params: TrainingJobParams
 
+    # TODO (see github.com/open-edge-platform/geti/pull/7494#discussion_r3935273273)
+    # Consider refactoring to avoid placing this logic in the model layer: one possible
+    # approach is to rely on domain events (the model publishes events, a decoupled
+    # listener handles them); another approach is to let the controller handle the
+    # completion logic based on the job type.
     def on_complete(self) -> None:
         """Copy the training log and clean up the getitune workspace upon job completion."""
         log_path = self.log_dir / self.log_file

--- a/application/backend/app/models/jobs/training_job.py
+++ b/application/backend/app/models/jobs/training_job.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 import shutil
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 from uuid import UUID, uuid4
@@ -70,3 +71,37 @@ class TrainingJob(ProjectJob[TrainingJobParams]):
             pass
         except Exception as cleanup_exc:
             logger.error(f"Failed to clean up getitune workspace directory at {workspace_dir}: {cleanup_exc}")
+
+        try:
+            self._reconcile_stuck_training_status()
+        except Exception as reconcile_exc:
+            logger.error(f"Failed to verify the training status for model {self.params.model_id}: {reconcile_exc}")
+
+    def _reconcile_stuck_training_status(self) -> None:
+        """Force training_status to FAILED if the trainer process died without updating it (e.g. a crash/kill)."""
+        # Imported locally: the "models" layer normally must not depend on the "services" layer;
+        # this is a deliberate, narrow exception to provide a safety net at job completion time.
+        from app.db.engine import get_db_session
+        from app.models import TrainingStatus
+        from app.services import ModelService, ResourceNotFoundError
+
+        with get_db_session() as db:
+            model_service = ModelService(data_dir=self.data_dir, db_session=db)
+            try:
+                model = model_service.get_model(project_id=self.project_id, model_id=self.params.model_id)
+            except ResourceNotFoundError:
+                return  # revision was never created (or was already deleted), nothing to reconcile
+
+            if model.training_info is not None:
+                found_status = model.training_info.status
+                if found_status not in (TrainingStatus.SUCCESSFUL, TrainingStatus.FAILED):
+                    model_service.update_revision_status(
+                        project_id=self.project_id,
+                        model_id=self.params.model_id,
+                        training_status=TrainingStatus.FAILED,
+                        training_finished_at=datetime.now(UTC),
+                    )
+                    logger.warning(
+                        f"Model {self.params.model_id} was left at {found_status} after job completion; "
+                        "forced to FAILED"
+                    )

--- a/application/backend/pyproject.toml
+++ b/application/backend/pyproject.toml
@@ -160,6 +160,11 @@ layers = [
     "app.repositories",
     "app.db",
 ]
+ignore_imports = [
+    # Deliberate exception: on_complete() reconciles a training status stuck at IN_PROGRESS
+    # after a job crash, as a safety net independent of the trainer process itself.
+    "app.models.jobs.training_job -> app.services",
+]
 
 [[tool.importlinter.contracts]]
 name = "Internal API"
@@ -200,6 +205,11 @@ layers = [
     "app.services",
     "app.models",
     "app.utils",
+]
+ignore_imports = [
+    # Deliberate exception: on_complete() reconciles a training status stuck at IN_PROGRESS
+    # after a job crash, as a safety net independent of the trainer process itself.
+    "app.models.jobs.training_job -> app.services",
 ]
 
 [tool.pytest.ini_options]

--- a/application/backend/tests/unit/core/jobs/control_plane/test_controller.py
+++ b/application/backend/tests/unit/core/jobs/control_plane/test_controller.py
@@ -122,6 +122,58 @@ class TestJobController:
         fxt_runner_factory.for_job.assert_called_with(job)
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "events,expected_status,expected_log_method,expected_log_args",
+        [
+            (
+                [Started(), Progress("progress", 100.0), Done()],
+                JobStatus.DONE,
+                "success",
+                ("Job completed successfully, job_id: {}", "job_id"),
+            ),
+            (
+                [Started(), Progress("progress", 50.0), Failed("boom")],
+                JobStatus.FAILED,
+                "error",
+                ("Job failed, job_id: {}, error: {}", "job_id", "error"),
+            ),
+            (
+                [Started(), Progress("progress", 50.0), Cancelled()],
+                JobStatus.CANCELLED,
+                "info",
+                ("Job cancelled, job_id: {}", "job_id"),
+            ),
+        ],
+    )
+    async def test_run_job_logs_actual_terminal_status(
+        self,
+        events,
+        expected_status,
+        expected_log_method,
+        expected_log_args,
+        fxt_job_controller,
+        fxt_job_queue,
+        fxt_runner_factory,
+        fxt_job,
+    ):
+        """Test that _run_job logs a message matching the job's real terminal status, not a generic success."""
+        job = fxt_job()
+        fxt_job_queue.next_runnable.side_effect = [job, asyncio.CancelledError()]
+        fxt_job_queue.get_cancellation_event = Mock(return_value=asyncio.Event())
+        fxt_runner_factory.for_job.return_value = MockRunner(events)
+
+        with patch("app.core.jobs.control_plane.controller.logger") as mock_logger:
+            await fxt_job_controller.start()
+            await asyncio.sleep(0.1)
+            await fxt_job_controller.stop()
+
+        assert job.status == expected_status
+        expected_call_args = tuple(
+            job.id if arg == "job_id" else job.error if arg == "error" else arg for arg in expected_log_args
+        )
+        getattr(mock_logger, expected_log_method).assert_any_call(*expected_call_args)
+
+    @pytest.mark.asyncio
     async def test_supervise_loop_handles_exceptions(self, fxt_job_controller, fxt_job_queue):
         """Test supervisor loop handles exceptions gracefully."""
         fxt_job_queue.next_runnable.side_effect = [Exception("Test error"), asyncio.CancelledError()]

--- a/application/backend/tests/unit/core/jobs/control_plane/test_controller.py
+++ b/application/backend/tests/unit/core/jobs/control_plane/test_controller.py
@@ -134,8 +134,8 @@ class TestJobController:
             (
                 [Started(), Progress("progress", 50.0), Failed("boom")],
                 JobStatus.FAILED,
-                "error",
-                ("Job failed, job_id: {}, error: {}", "job_id", "error"),
+                "warning",
+                ("Job failed, job_id: {}", "job_id"),
             ),
             (
                 [Started(), Progress("progress", 50.0), Cancelled()],
@@ -168,9 +168,7 @@ class TestJobController:
             await fxt_job_controller.stop()
 
         assert job.status == expected_status
-        expected_call_args = tuple(
-            job.id if arg == "job_id" else job.error if arg == "error" else arg for arg in expected_log_args
-        )
+        expected_call_args = tuple(job.id if arg == "job_id" else arg for arg in expected_log_args)
         getattr(mock_logger, expected_log_method).assert_any_call(*expected_call_args)
 
     @pytest.mark.asyncio

--- a/application/backend/tests/unit/execution/training/test_getitune_trainer.py
+++ b/application/backend/tests/unit/execution/training/test_getitune_trainer.py
@@ -1275,6 +1275,110 @@ class TestGetiTuneTrainerEvaluateModel:
         mock_getitune_engine.test.assert_called_once_with(metric=MeanAPCallable)
         fxt_model_service.save_evaluation_result.assert_called_once()
 
+    def test_evaluate_model_reuses_pytorch_results_when_openvino_fails(
+        self,
+        fxt_getitune_trainer: Callable[[], GetiTuneTrainer],
+        tmp_path: Path,
+        fxt_model_service: Mock,
+    ):
+        """OpenVINO/ONNX evaluation failures must not fail the job; PyTorch results are reused instead."""
+        # Arrange
+        getitune_trainer = fxt_getitune_trainer()
+        model_id = uuid4()
+        pytorch_variant_id = uuid4()
+        openvino_variant_id = uuid4()
+        onnx_variant_id = uuid4()
+        dataset_revision_id = uuid4()
+
+        pytorch_metrics = {"test/accuracy": torch.tensor(0.85)}
+
+        mock_getitune_engine = Mock()
+        mock_getitune_engine.test.return_value = pytorch_metrics
+        mock_getitune_engine.work_dir = tmp_path / "getitune-workspace"
+        mock_getitune_engine.datamodule = Mock()
+
+        model_checkpoint_path = tmp_path / "best_checkpoint.pt"
+        model_checkpoint_path.touch()
+        ov_xml_path = tmp_path / "exported_model.xml"
+        onnx_path = tmp_path / "exported_model.onnx"
+
+        model_variants = [
+            ModelVariantDescriptor(id=pytorch_variant_id, path=model_checkpoint_path, format=ModelFormat.PYTORCH),
+            ModelVariantDescriptor(id=openvino_variant_id, path=ov_xml_path, format=ModelFormat.OPENVINO),
+            ModelVariantDescriptor(id=onnx_variant_id, path=onnx_path, format=ModelFormat.ONNX),
+        ]
+
+        mock_ov_engine = Mock()
+        mock_ov_engine.test.side_effect = RuntimeError("OpenVINO evaluation blew up")
+        mock_onnx_engine = Mock()
+        mock_onnx_engine.test.return_value = {"test/accuracy": torch.tensor(0.83)}
+
+        # Act
+        with (
+            patch(
+                "getitune.backend.openvino.engine.OVEngine",
+                side_effect=[mock_ov_engine, mock_onnx_engine],
+            ),
+            patch("app.execution.training.getitune_trainer.logger") as mock_logger,
+        ):
+            getitune_trainer.evaluate_model(
+                getitune_engine=mock_getitune_engine,
+                task=Task(task_type=TaskType.CLASSIFICATION, exclusive_labels=True),
+                model_revision_id=model_id,
+                model_variants=model_variants,
+                dataset_revision_id=dataset_revision_id,
+            )
+
+        # Assert: a warning was logged for the failed OpenVINO evaluation
+        mock_logger.warning.assert_called_once()
+        assert "openvino" in mock_logger.warning.call_args.args[1].lower()
+
+        # Assert: all three variants still got a saved evaluation result
+        save_calls = fxt_model_service.save_evaluation_result.call_args_list
+        assert len(save_calls) == 3
+        results_by_variant = {c.args[0].model_variant_id: c.args[0] for c in save_calls}
+
+        # The OpenVINO variant reused the PyTorch metrics instead of failing
+        assert results_by_variant[openvino_variant_id].metrics == results_by_variant[pytorch_variant_id].metrics
+        # The ONNX variant still evaluated normally and kept its own metrics
+        assert results_by_variant[onnx_variant_id].metrics == pytest.approx({"accuracy": 0.83}, rel=1e-6)
+
+    def test_evaluate_model_raises_when_pytorch_evaluation_fails(
+        self,
+        fxt_getitune_trainer: Callable[[], GetiTuneTrainer],
+        tmp_path: Path,
+        fxt_model_service: Mock,
+    ):
+        """A failure evaluating the PyTorch variant itself must still fail the job (no fallback available)."""
+        # Arrange
+        getitune_trainer = fxt_getitune_trainer()
+        model_id = uuid4()
+        pytorch_variant_id = uuid4()
+        dataset_revision_id = uuid4()
+
+        mock_getitune_engine = Mock()
+        mock_getitune_engine.test.side_effect = RuntimeError("PyTorch evaluation blew up")
+        mock_getitune_engine.work_dir = tmp_path / "getitune-workspace"
+        mock_getitune_engine.datamodule = Mock()
+
+        model_checkpoint_path = tmp_path / "best_checkpoint.pt"
+        model_checkpoint_path.touch()
+
+        model_variants = [
+            ModelVariantDescriptor(id=pytorch_variant_id, path=model_checkpoint_path, format=ModelFormat.PYTORCH),
+        ]
+
+        # Act / Assert
+        with pytest.raises(RuntimeError, match="PyTorch evaluation blew up"):
+            getitune_trainer.evaluate_model(
+                getitune_engine=mock_getitune_engine,
+                task=Task(task_type=TaskType.CLASSIFICATION, exclusive_labels=True),
+                model_revision_id=model_id,
+                model_variants=model_variants,
+                dataset_revision_id=dataset_revision_id,
+            )
+        fxt_model_service.save_evaluation_result.assert_not_called()
+
 
 class TestGetiTuneTrainerExportModel:
     """Tests for the GetiTuneTrainer.export_model method."""

--- a/application/backend/tests/unit/models/jobs/test_training_job.py
+++ b/application/backend/tests/unit/models/jobs/test_training_job.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Callable
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from uuid import UUID, uuid4
 
 import pytest
 
-from app.models import Task, TaskType, TrainingJob, TrainingJobParams
+from app.models import Task, TaskType, TrainingJob, TrainingJobParams, TrainingStatus
 from app.models.system import DeviceInfo, DeviceType
+from app.services import ResourceNotFoundError, ResourceType
 
 
 @pytest.fixture
@@ -45,6 +46,12 @@ def fxt_training_job(tmp_path, fxt_training_params):
 
 
 class TestTrainingJob:
+    @pytest.fixture(autouse=True)
+    def fxt_skip_status_reconciliation(self):
+        """These tests only cover log/workspace cleanup; the reconciliation step has its own test class."""
+        with patch.object(TrainingJob, "_reconcile_stuck_training_status"):
+            yield
+
     def test_on_complete_copies_log_file(self, fxt_training_job):
         """Test that log file is copied to the correct destination."""
         # Create the log file
@@ -106,3 +113,50 @@ class TestTrainingJob:
 
         # Should not raise
         fxt_training_job.on_complete()
+
+
+class TestTrainingJobReconcileTrainingStatus:
+    @patch("app.services.ModelService")
+    @patch("app.db.engine.get_db_session")
+    def test_forces_failed_when_status_stuck_in_progress(
+        self, mock_get_db_session, mock_model_service_cls, fxt_training_job
+    ):
+        """A model left at IN_PROGRESS after job completion (e.g. a trainer crash) must be forced to FAILED."""
+        mock_get_db_session.return_value.__enter__.return_value = Mock()
+        mock_model_service = mock_model_service_cls.return_value
+        mock_model_service.get_model.return_value = Mock(training_info=Mock(status=TrainingStatus.IN_PROGRESS))
+
+        fxt_training_job._reconcile_stuck_training_status()
+
+        mock_model_service.update_revision_status.assert_called_once()
+        call_kwargs = mock_model_service.update_revision_status.call_args.kwargs
+        assert call_kwargs["project_id"] == fxt_training_job.project_id
+        assert call_kwargs["model_id"] == fxt_training_job.params.model_id
+        assert call_kwargs["training_status"] == TrainingStatus.FAILED
+
+    @pytest.mark.parametrize("terminal_status", [TrainingStatus.SUCCESSFUL, TrainingStatus.FAILED])
+    @patch("app.services.ModelService")
+    @patch("app.db.engine.get_db_session")
+    def test_no_op_when_status_already_terminal(
+        self, mock_get_db_session, mock_model_service_cls, terminal_status, fxt_training_job
+    ):
+        """A model that already reached a terminal status must not be touched."""
+        mock_get_db_session.return_value.__enter__.return_value = Mock()
+        mock_model_service = mock_model_service_cls.return_value
+        mock_model_service.get_model.return_value = Mock(training_info=Mock(status=terminal_status))
+
+        fxt_training_job._reconcile_stuck_training_status()
+
+        mock_model_service.update_revision_status.assert_not_called()
+
+    @patch("app.services.ModelService")
+    @patch("app.db.engine.get_db_session")
+    def test_no_op_when_model_revision_missing(self, mock_get_db_session, mock_model_service_cls, fxt_training_job):
+        """A job that failed before the model revision was ever created has nothing to reconcile."""
+        mock_get_db_session.return_value.__enter__.return_value = Mock()
+        mock_model_service = mock_model_service_cls.return_value
+        mock_model_service.get_model.side_effect = ResourceNotFoundError(ResourceType.MODEL, "missing")
+
+        fxt_training_job._reconcile_stuck_training_status()
+
+        mock_model_service.update_revision_status.assert_not_called()


### PR DESCRIPTION
### Summary

This PR addresses three different issues of the training job, found while investigating #7487.

1. 18ba15f22d9f5f49dd5b49decf21adab452b54c5 fixes an issue where the job controller logged a successful job completion even when the job actually failed. Now the log reflects the real termination state.
2. cc0d71bb52a8a8379317631e6126dd74f22bd807 reconciles the `model_status` attribute to FAILED if the training job subprocess crashes abruptly before having a chance to update the status to a terminal state.
  - Note: the `on_complete` function is in the "models" layer, which normally shouldn't call services and repos. Here we make an exception because other implementation alternatives that I explored (e.g. passing a callback) also look dirty.
3. a351b6a96f42924cf33d6911e751e49d05a1a1ab makes the job tolerate errors that occur during the OpenVINO / ONNX model evaluation phase. Instead of letting the job crash (the worst thing UX-wise), it now logs a warning and fallbacks to the evaluation results of the Pytorch variant, assuming that OV/ONNX performance doesn't deviate significantly. Note that this fix protects against regular exceptions, but not OOM which bypass the `try...except` block.

Fixes https://github.com/open-edge-platform/geti/issues/7487

### How to test

- [x] Replicate the scenario in the ticket -> the model is now visible and marked as failed (due to OOM), logs can be retrieved via the UI.

<img width="1342" height="292" alt="image" src="https://github.com/user-attachments/assets/e3f3691b-7f0d-4e0e-bc5a-9f3f3b0c5f29" />

### Checklist

- [x] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
