### PR TITLE
Rename the TIMM card and pin it to the bottom

### DIFF
--- a/application/backend/app/api/routers/model_architectures.py
+++ b/application/backend/app/api/routers/model_architectures.py
@@ -110,7 +110,7 @@ def _build_timm_card_entry() -> ModelArchitectureView:
     return ModelArchitectureView(
         id=TIMM_CARD_ID,
         task=TaskType.CLASSIFICATION,
-        name="PyTorch Image Models (timm)",
+        name="Other models (TIMM)",
         timm_metadata=None,
         description=description,
         capabilities=Capabilities(xai=False, tiling=False),

--- a/application/backend/tests/unit/api/routers/test_model_architectures.py
+++ b/application/backend/tests/unit/api/routers/test_model_architectures.py
@@ -143,7 +143,7 @@ class TestModelArchitecturesEndpoint:
         timm_card = next(arch for arch in data["model_architectures"] if arch["id"] == "image-classification-timm")
 
         assert timm_card["task"] == "classification"
-        assert timm_card["name"] == "PyTorch Image Models (timm)"
+        assert timm_card["name"] == "Other models (TIMM)"
         assert timm_card["timm_metadata"] is None
         assert timm_card["license"] == "varies by model"
         assert f"Geti offers {TimmCatalog.count_backbones()} of these models" in timm_card["description"]

--- a/application/ui/src/features/models/train-model/model-architectures-list/all-model-architectures.component.tsx
+++ b/application/ui/src/features/models/train-model/model-architectures-list/all-model-architectures.component.tsx
@@ -5,9 +5,11 @@ import { useState } from 'react';
 
 import type { ModelArchitecture as ModelArchitectureType } from '@/api/types';
 import { Flex } from '@geti-ui/ui';
+import { partition } from 'lodash-es';
 
 import { SortModelArchitectures } from '../sort-model-architectures/sort-model-architectures.component';
 import { SORT_OPTIONS, SORTING_HANDLERS, SortingOptions } from '../sort-model-architectures/utils';
+import { TIMM_MODEL_ARCHITECTURE_ID } from '../timm-model-configuration/utils';
 import { DetailedModelArchitecture } from './model-architecture.component';
 import { ModelArchitecturesListLayout } from './model-architectures-list-layout/model-architectures-list-layout.component';
 
@@ -23,7 +25,14 @@ export const AllModelArchitectures = ({
     selectedModelArchitectureId,
 }: AllModelArchitecturesProps) => {
     const [sortBy, setSortBy] = useState<SortingOptions>(SortingOptions.NAME_ASC);
-    const sortedModelArchitectures = SORTING_HANDLERS[sortBy](modelArchitectures);
+    const [[timmCard], sortableModelArchitectures] = partition(
+        modelArchitectures,
+        (modelArchitecture) => modelArchitecture.id === TIMM_MODEL_ARCHITECTURE_ID
+    );
+    const sortedModelArchitectures = SORTING_HANDLERS[sortBy](sortableModelArchitectures);
+    // The TIMM card always stays last, regardless of the active sort.
+    const modelArchitecturesToRender =
+        timmCard === undefined ? sortedModelArchitectures : [...sortedModelArchitectures, timmCard];
 
     return (
         <Flex direction={'column'} gap={'size-200'}>
@@ -33,7 +42,7 @@ export const AllModelArchitectures = ({
                 onSelectedModelArchitectureIdChange={onSelectedModelArchitectureIdChange}
                 ariaLabel={'ALL model architectures'}
             >
-                {sortedModelArchitectures.map((modelArchitecture) => (
+                {modelArchitecturesToRender.map((modelArchitecture) => (
                     <DetailedModelArchitecture
                         key={modelArchitecture.id}
                         modelArchitecture={modelArchitecture}

--- a/application/ui/src/features/models/train-model/sort-model-architectures/utils.ts
+++ b/application/ui/src/features/models/train-model/sort-model-architectures/utils.ts
@@ -4,6 +4,8 @@
 import type { ModelArchitectureWithPerformanceCategory } from '@/api/types';
 import { orderBy } from 'lodash-es';
 
+import { TIMM_MODEL_ARCHITECTURE_ID } from '../timm-model-configuration/utils';
+
 export const SortingOptions = {
     NAME_ASC: 'name-asc',
     NAME_DESC: 'name-desc',
@@ -27,19 +29,33 @@ const getAccuracyMetricBasedOnTask = ({ stats }: ModelArchitectureWithPerformanc
     );
 };
 
+// Pins the synthetic TIMM card to the last position regardless of the chosen sort.
+const pinTimmCardLast = (handler: SortingHandler): SortingHandler => (modelArchitectures) => {
+    const timmCard = modelArchitectures.filter(({ id }) => id === TIMM_MODEL_ARCHITECTURE_ID);
+    const rest = modelArchitectures.filter(({ id }) => id !== TIMM_MODEL_ARCHITECTURE_ID);
+
+    return [...handler(rest), ...timmCard];
+};
+
 export const SORTING_HANDLERS: Record<SortingOptions, SortingHandler> = {
-    [SortingOptions.ACCURACY_ASC]: (modelArchitectures) =>
-        orderBy(modelArchitectures, getAccuracyMetricBasedOnTask, 'asc'),
-    [SortingOptions.ACCURACY_DESC]: (modelArchitectures) =>
-        orderBy(modelArchitectures, getAccuracyMetricBasedOnTask, 'desc'),
-    [SortingOptions.NAME_ASC]: (modelArchitectures) =>
-        orderBy(modelArchitectures, (modelArchitecture) => modelArchitecture.name, 'asc'),
-    [SortingOptions.NAME_DESC]: (modelArchitectures) =>
-        orderBy(modelArchitectures, (modelArchitecture) => modelArchitecture.name, 'desc'),
-    [SortingOptions.SPEED_ASC]: (modelArchitectures) =>
-        orderBy(modelArchitectures, (modelArchitecture) => modelArchitecture.stats?.gigaflops, 'asc'),
-    [SortingOptions.SPEED_DESC]: (modelArchitectures) =>
-        orderBy(modelArchitectures, (modelArchitecture) => modelArchitecture.stats?.gigaflops, 'desc'),
+    [SortingOptions.ACCURACY_ASC]: pinTimmCardLast((modelArchitectures) =>
+        orderBy(modelArchitectures, getAccuracyMetricBasedOnTask, 'asc')
+    ),
+    [SortingOptions.ACCURACY_DESC]: pinTimmCardLast((modelArchitectures) =>
+        orderBy(modelArchitectures, getAccuracyMetricBasedOnTask, 'desc')
+    ),
+    [SortingOptions.NAME_ASC]: pinTimmCardLast((modelArchitectures) =>
+        orderBy(modelArchitectures, (modelArchitecture) => modelArchitecture.name, 'asc')
+    ),
+    [SortingOptions.NAME_DESC]: pinTimmCardLast((modelArchitectures) =>
+        orderBy(modelArchitectures, (modelArchitecture) => modelArchitecture.name, 'desc')
+    ),
+    [SortingOptions.SPEED_ASC]: pinTimmCardLast((modelArchitectures) =>
+        orderBy(modelArchitectures, (modelArchitecture) => modelArchitecture.stats?.gigaflops, 'asc')
+    ),
+    [SortingOptions.SPEED_DESC]: pinTimmCardLast((modelArchitectures) =>
+        orderBy(modelArchitectures, (modelArchitecture) => modelArchitecture.stats?.gigaflops, 'desc')
+    ),
 };
 
 export const SORT_OPTIONS = [

--- a/application/ui/src/features/models/train-model/sort-model-architectures/utils.ts
+++ b/application/ui/src/features/models/train-model/sort-model-architectures/utils.ts
@@ -4,8 +4,6 @@
 import type { ModelArchitectureWithPerformanceCategory } from '@/api/types';
 import { orderBy } from 'lodash-es';
 
-import { TIMM_MODEL_ARCHITECTURE_ID } from '../timm-model-configuration/utils';
-
 export const SortingOptions = {
     NAME_ASC: 'name-asc',
     NAME_DESC: 'name-desc',
@@ -29,33 +27,19 @@ const getAccuracyMetricBasedOnTask = ({ stats }: ModelArchitectureWithPerformanc
     );
 };
 
-// Pins the synthetic TIMM card to the last position regardless of the chosen sort.
-const pinTimmCardLast = (handler: SortingHandler): SortingHandler => (modelArchitectures) => {
-    const timmCard = modelArchitectures.filter(({ id }) => id === TIMM_MODEL_ARCHITECTURE_ID);
-    const rest = modelArchitectures.filter(({ id }) => id !== TIMM_MODEL_ARCHITECTURE_ID);
-
-    return [...handler(rest), ...timmCard];
-};
-
 export const SORTING_HANDLERS: Record<SortingOptions, SortingHandler> = {
-    [SortingOptions.ACCURACY_ASC]: pinTimmCardLast((modelArchitectures) =>
-        orderBy(modelArchitectures, getAccuracyMetricBasedOnTask, 'asc')
-    ),
-    [SortingOptions.ACCURACY_DESC]: pinTimmCardLast((modelArchitectures) =>
-        orderBy(modelArchitectures, getAccuracyMetricBasedOnTask, 'desc')
-    ),
-    [SortingOptions.NAME_ASC]: pinTimmCardLast((modelArchitectures) =>
-        orderBy(modelArchitectures, (modelArchitecture) => modelArchitecture.name, 'asc')
-    ),
-    [SortingOptions.NAME_DESC]: pinTimmCardLast((modelArchitectures) =>
-        orderBy(modelArchitectures, (modelArchitecture) => modelArchitecture.name, 'desc')
-    ),
-    [SortingOptions.SPEED_ASC]: pinTimmCardLast((modelArchitectures) =>
-        orderBy(modelArchitectures, (modelArchitecture) => modelArchitecture.stats?.gigaflops, 'asc')
-    ),
-    [SortingOptions.SPEED_DESC]: pinTimmCardLast((modelArchitectures) =>
-        orderBy(modelArchitectures, (modelArchitecture) => modelArchitecture.stats?.gigaflops, 'desc')
-    ),
+    [SortingOptions.ACCURACY_ASC]: (modelArchitectures) =>
+        orderBy(modelArchitectures, getAccuracyMetricBasedOnTask, 'asc'),
+    [SortingOptions.ACCURACY_DESC]: (modelArchitectures) =>
+        orderBy(modelArchitectures, getAccuracyMetricBasedOnTask, 'desc'),
+    [SortingOptions.NAME_ASC]: (modelArchitectures) =>
+        orderBy(modelArchitectures, (modelArchitecture) => modelArchitecture.name, 'asc'),
+    [SortingOptions.NAME_DESC]: (modelArchitectures) =>
+        orderBy(modelArchitectures, (modelArchitecture) => modelArchitecture.name, 'desc'),
+    [SortingOptions.SPEED_ASC]: (modelArchitectures) =>
+        orderBy(modelArchitectures, (modelArchitecture) => modelArchitecture.stats?.gigaflops, 'asc'),
+    [SortingOptions.SPEED_DESC]: (modelArchitectures) =>
+        orderBy(modelArchitectures, (modelArchitecture) => modelArchitecture.stats?.gigaflops, 'desc'),
 };
 
 export const SORT_OPTIONS = [

--- a/application/ui/tests/models/timm-model-training.spec.ts
+++ b/application/ui/tests/models/timm-model-training.spec.ts
@@ -25,7 +25,7 @@ const mockedModelArchitectures = [
     getMockedModelArchitecture({ id: 'Object_Detection_SSD', name: 'Object_Detection_SSD' }),
     getMockedModelArchitecture({
         id: TIMM_MODEL_ARCHITECTURE_ID,
-        name: 'PyTorch Image Models (timm)',
+        name: 'Other models (TIMM)',
         description: 'PyTorch Image Models (TIMM) is a large collection of SOTA image classification models.',
         license: 'varies by model',
         stats: null,
@@ -127,7 +127,7 @@ test.describe('TIMM model training flow', () => {
         });
 
         await test.step('shows the timm configuration once the timm architecture is selected', async () => {
-            await modelsPage.selectModelArchitecture('PyTorch Image Models (timm)');
+            await modelsPage.selectModelArchitecture('Other models (TIMM)');
 
             await expect(timmConfiguration).toBeVisible();
         });


### PR DESCRIPTION
### Summary

A few UX improvements for the display of TIMM models in the UI, as per Radwan's suggestions.
I renamed the card to "Other models (TIMM)" and moved it at the end of the list, where it's more natural to find an "other" option.
The rationale is that "TIMM" is an implementation detail of how we expose hundreds of models, users don't really need to understand it, they only care about finding the best model architecture for their task. By calling the card "Other models", I remove some emphasis from the underlying technology and make it less "odd" that several models are grouped under a special card.

### How to test

<img width="980" height="833" alt="image" src="https://github.com/user-attachments/assets/9b16d716-cdba-44b9-b8ee-26be927dc857" />

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
