### PR TITLE
Fix OV evaluation step

### DIFF
--- a/application/backend/app/core/jobs/control_plane/controller.py
+++ b/application/backend/app/core/jobs/control_plane/controller.py
@@ -41,14 +41,24 @@ class JobController:
         max_parallel_jobs: Maximum number of capacity-managed jobs that can execute simultaneously
     """
 
-    def __init__(self, jobs_queue: JobQueue, runner_factory: RunnerFactory, max_parallel_jobs: int) -> None:
+    def __init__(
+        self,
+        jobs_queue: JobQueue,
+        runner_factory: RunnerFactory,
+        max_parallel_jobs: int,
+        stale_threshold_seconds: int = 3600,
+        stale_check_interval_seconds: int = 60,
+    ) -> None:
         self._jobs_q = jobs_queue
         self._runner_factory = runner_factory
         self._capacity = Capacity(max_parallel_jobs)
         self._running = False
+        self._stale_threshold = stale_threshold_seconds
+        self._stale_check_interval = stale_check_interval_seconds
         self._supervisor_task: asyncio.Task | None = None
         self._stale_monitor_task: asyncio.Task | None = None
         self._tasks: set[asyncio.Task] = set()
+        self._stale_job_ids: set = set()
 
     async def start(self) -> None:
         self._running = True
@@ -75,20 +85,25 @@ class JobController:
                 logger.exception("Exception during supervise loop")
 
     async def _monitor_stale_loop(self) -> None:
-        """Monitor running jobs and terminate those that haven't updated in 1 hour."""
-        stale_threshold = 3600  # 1 hour inactivity threshold
-        check_interval = 60  # Check every minute
+        """Terminate running jobs that have not reported any progress for too long.
 
+        A job is only considered stale when its ``updated_at`` stops moving. Steps that
+        do long, non-incremental work must therefore emit a heartbeat, otherwise a
+        healthy-but-slow job is killed here by signal, which leaves no trace in the
+        job's own log (see ProcessRun._log_abnormal_exit).
+        """
         while self._running:
             try:
-                await asyncio.sleep(check_interval)
-                stale_jobs = self._jobs_q.list_stale_jobs(stale_threshold)
+                await asyncio.sleep(self._stale_check_interval)
+                stale_jobs = self._jobs_q.list_stale_jobs(self._stale_threshold)
 
                 for job in stale_jobs:
+                    self._stale_job_ids.add(job.id)
                     logger.warning(
-                        "Job {} has not updated in {} seconds, marking as stale and scheduling termination",
+                        "Job {} has not reported progress in {} seconds, marking as stale and scheduling termination. "
+                        "If the job was still making progress, the running step is missing a heartbeat.",
                         job.id,
-                        stale_threshold,
+                        self._stale_threshold,
                     )
                     _, result = self._jobs_q.cancel(job.id)
                     logger.info("Cancelling job with ID {} and result {}", job.id, result)
@@ -123,6 +138,7 @@ class JobController:
                 with contextlib.suppress(asyncio.CancelledError):
                     await cancel_task
                 self._jobs_q.cleanup_cancellation_event(job.id)
+                self._stale_job_ids.discard(job.id)
 
             logger.success("Job completed, job_id: {}", job.id)
 
@@ -139,7 +155,13 @@ class JobController:
             """Watch for job cancellation requests and trigger graceful shutdown."""
             event = self._jobs_q.get_cancellation_event(job.id)
             await event.wait()
-            await job_run.stop()
+            reason = None
+            if job.id in self._stale_job_ids:
+                reason = (
+                    f"the stale-job monitor, because the job reported no progress for more than "
+                    f"{self._stale_threshold}s"
+                )
+            await job_run.stop(reason=reason)
 
         threading.Thread(target=_pump, daemon=True).start()
         cancel_task = asyncio.create_task(_cancel())

--- a/application/backend/app/core/jobs/exec/process_run.py
+++ b/application/backend/app/core/jobs/exec/process_run.py
@@ -18,6 +18,7 @@ Functions:
 import asyncio
 import contextlib
 import multiprocessing as mp
+import signal
 from collections.abc import Iterator
 from multiprocessing.connection import Connection
 from multiprocessing.context import SpawnProcess
@@ -27,11 +28,53 @@ from typing import Any
 from loguru import logger
 
 from app.core.jobs.models import Done, ExecutionEvent, Failed, Job, JobType, Started
-from app.core.logging import LogConfig, logging_ctx
+from app.core.logging import LogConfig, job_log_sink, logging_ctx
 from app.core.run import ExecutionContext, RunnableFactory, Runner
 from app.settings import get_settings
 
 from .exceptions import CancelledExc
+
+
+def _describe_exit_code(code: int | None) -> str:
+    """Build a human readable explanation for a child process exit code.
+
+    A negative exit code means the child was terminated by a signal rather than
+    returning normally. In that case no Python-level exception handler ever ran,
+    so nothing was written to the job log: the job simply stops mid-way. The most
+    common cause is the Linux OOM killer (SIGKILL) reaping a job whose memory
+    usage spiked, e.g. during model evaluation on high-resolution inputs.
+
+    Args:
+        code: The child process exit code (``Process.exitcode``).
+
+    Returns:
+        str: Description of how the process ended.
+    """
+    if code is None:
+        return "process ended without an exit code (it may still be running or was never started)"
+    if code >= 0:
+        return f"process exit {code}"
+
+    signum = -code
+    try:
+        signame = signal.Signals(signum).name
+    except ValueError:
+        signame = f"signal {signum}"
+
+    detail = f"process was terminated by {signame} (exit code {code})"
+    # Compare by name: SIGKILL/SIGBUS are not defined on every platform.
+    if signame == "SIGKILL":
+        detail += (
+            ". This is almost always the OS out-of-memory (OOM) killer: the job exceeded the available "
+            "memory and was killed before it could report an error. Check dmesg/`journalctl -k` for an "
+            "'Out of memory: Killed process' entry, and consider lowering the evaluation batch size"
+        )
+    elif signame in ("SIGSEGV", "SIGABRT", "SIGBUS"):
+        detail += (
+            ". This indicates a crash inside a native extension (OpenVINO, PyTorch, OpenCV, ...) rather "
+            "than a Python error, so no traceback could be captured"
+        )
+    return detail
 
 
 class ProcessRun:
@@ -78,9 +121,39 @@ class ProcessRun:
         except EOFError:
             # Child exited; infer outcome
             code = self._proc.exitcode if self._proc else 1
-            yield Done() if code == 0 else Failed(f"process exit {code}")
+            if code == 0:
+                yield Done()
+            else:
+                # The child died without sending a Failed event, meaning no Python
+                # exception handler ran (killed by a signal, hard native crash, ...).
+                # Nothing was written to the job log by the child, so record the
+                # cause here - both in the application log and, best effort, in the
+                # job's own log file so the user can actually see why it failed.
+                details = _describe_exit_code(code)
+                self._log_abnormal_exit(details)
+                yield Failed(details)
         finally:
             self._parent.close()
+
+    def _log_abnormal_exit(self, details: str) -> None:
+        """Record an abnormal child-process termination.
+
+        The child process owns the job log file sink, so when it is killed nothing
+        explains the failure to the user. This re-attaches the job log sink from the
+        parent process just long enough to append the diagnosis.
+
+        Args:
+            details: Human readable description of how the process ended.
+        """
+        job_name = self._proc.name if self._proc else f"job-{self._job.job_type}-{self._job.id}"
+        message = f"Job {self._job.id} ({self._job.job_type}) terminated abnormally: {details}"
+        logger.error("{} [{}]", message, job_name)
+
+        try:
+            with job_log_sink(LogConfig(log_folder=str(get_settings().job_dir), log_file=self._job.log_file)):
+                logger.error(message)
+        except Exception:
+            logger.exception("Failed to append the abnormal termination reason to the job log file")
 
     async def stop(self, graceful_timeout: float = 30.0, term_timeout: float = 15.0, kill_timeout: float = 1.0) -> None:
         """

--- a/application/backend/app/core/jobs/exec/process_run.py
+++ b/application/backend/app/core/jobs/exec/process_run.py
@@ -94,6 +94,7 @@ class ProcessRun:
         self._parent, self._child = ctx.Pipe(duplex=False)
         self._cancel = ctx.Event()
         self._proc: SpawnProcess | None = None
+        self._stop_reason: str | None = None
 
     def start(self) -> "ProcessRun":
         self._proc = self._ctx.Process(
@@ -130,6 +131,8 @@ class ProcessRun:
                 # cause here - both in the application log and, best effort, in the
                 # job's own log file so the user can actually see why it failed.
                 details = _describe_exit_code(code)
+                if self._stop_reason:
+                    details = f"{details}. Termination was requested by: {self._stop_reason}"
                 self._log_abnormal_exit(details)
                 yield Failed(details)
         finally:
@@ -155,7 +158,13 @@ class ProcessRun:
         except Exception:
             logger.exception("Failed to append the abnormal termination reason to the job log file")
 
-    async def stop(self, graceful_timeout: float = 30.0, term_timeout: float = 15.0, kill_timeout: float = 1.0) -> None:
+    async def stop(
+        self,
+        graceful_timeout: float = 30.0,
+        term_timeout: float = 15.0,
+        kill_timeout: float = 1.0,
+        reason: str | None = None,
+    ) -> None:
         """
         Stop the process with graceful degradation.
 
@@ -163,7 +172,12 @@ class ProcessRun:
             graceful_timeout: How long to wait for graceful shutdown (seconds)
             term_timeout: How long to wait after SIGTERM (seconds)
             kill_timeout: How long to wait after SIGKILL (seconds)
+            reason: Why the process is being stopped. Recorded so that a process which
+                does not shut down gracefully - and therefore dies by signal, without
+                writing anything to its own log - can still be explained to the user.
         """
+        if reason:
+            self._stop_reason = reason
         if self._proc is None:
             return
 

--- a/application/backend/app/core/jobs/exec/thread_run.py
+++ b/application/backend/app/core/jobs/exec/thread_run.py
@@ -64,8 +64,24 @@ class ThreadRun(Runner[Job, ExecutionEvent]):
                 # Continue polling if no events available
                 continue
 
-    async def stop(self, graceful_timeout: float = 6.0, term_timeout: float = 3.0, kill_timeout: float = 1.0) -> None:
-        """Stop the runner by setting the cancellation event."""
+    async def stop(
+        self,
+        graceful_timeout: float = 6.0,
+        term_timeout: float = 3.0,
+        kill_timeout: float = 1.0,
+        reason: str | None = None,
+    ) -> None:
+        """Stop the runner by setting the cancellation event.
+
+        Args:
+            graceful_timeout: How long to wait for the execution thread to finish.
+            term_timeout: Unused - the thread runner cannot escalate beyond cooperative
+                cancellation; included for Runner protocol compatibility.
+            kill_timeout: Unused - included for Runner protocol compatibility.
+            reason: Why the runner is being stopped. Unused here because a thread is
+                always cancelled cooperatively and therefore reports its own outcome;
+                included for Runner protocol compatibility.
+        """
         self._cancel_event.set()
 
         if self._execution_thread and self._execution_thread.is_alive():

--- a/application/backend/app/core/logging/__init__.py
+++ b/application/backend/app/core/logging/__init__.py
@@ -4,11 +4,12 @@
 from .config import LogConfig
 from .handlers import InterceptHandler
 from .setup import setup_hypercorn_logging, setup_logging
-from .utils import logging_ctx
+from .utils import job_log_sink, logging_ctx
 
 __all__ = [
     "InterceptHandler",
     "LogConfig",
+    "job_log_sink",
     "logging_ctx",
     "setup_hypercorn_logging",
     "setup_logging",

--- a/application/backend/app/core/logging/utils.py
+++ b/application/backend/app/core/logging/utils.py
@@ -13,6 +13,36 @@ from .handlers import InterceptHandler
 
 
 @contextmanager
+def job_log_sink(config: LogConfig) -> Generator[str]:
+    """Temporarily attach *only* a file sink for a job log file.
+
+    Unlike :func:`logging_ctx` this does not touch the stdlib ``logging`` root
+    handlers and does not import heavy third-party modules, which makes it safe
+    to use from the parent process (e.g. the job control plane) to append a few
+    records to a job log file that is otherwise written by the child process.
+
+    Args:
+        config: LogConfig instance specifying the log file path and sink parameters.
+
+    Yields:
+        str: Full path to the log file.
+    """
+    log_path = os.path.join(config.log_folder, config.log_file)
+    sink_id = logger.add(
+        log_path,
+        rotation=config.rotation,
+        retention=config.retention,
+        level=config.level,
+        serialize=config.serialize,
+        enqueue=True,
+    )
+    try:
+        yield log_path
+    finally:
+        logger.remove(sink_id)
+
+
+@contextmanager
 def logging_ctx(config: LogConfig) -> Generator[str]:
     """Create a temporary logging context with an additional file sink.
 

--- a/application/backend/app/core/run/runner.py
+++ b/application/backend/app/core/run/runner.py
@@ -31,7 +31,11 @@ class Runner(Protocol[T, E]):
     def start(self) -> "Runner[T, E]": ...
     def events(self) -> Iterator[E]: ...
     async def stop(
-        self, graceful_timeout: float = 6.0, term_timeout: float = 3.0, kill_timeout: float = 1.0
+        self,
+        graceful_timeout: float = 6.0,
+        term_timeout: float = 3.0,
+        kill_timeout: float = 1.0,
+        reason: str | None = None,
     ) -> None: ...
 
 

--- a/application/backend/app/execution/base.py
+++ b/application/backend/app/execution/base.py
@@ -115,6 +115,22 @@ class Execution(Runnable, ABC, Generic[JobParamsT]):
         """Update the current progress metadata without changing the message or percentage."""
         self._report_progress(metadata=metadata)
 
+    def heartbeat(self) -> None:
+        """Signal that the job is still alive, without changing the message or percentage.
+
+        A step only reports progress when it starts and when it finishes. Any step that
+        runs longer than the control plane's stale-job threshold without reporting is
+        therefore misclassified as hung and gets terminated with SIGTERM/SIGKILL -- which
+        kills the process without running any Python exception handler, so the job log
+        simply stops mid-way with no error.
+
+        Long-running, non-incremental work (model evaluation in particular, which runs on
+        CPU for the OpenVINO and ONNX variants and can take hours) must call this
+        periodically. It also makes such work cooperatively cancellable, because the
+        reporting hook raises when a cancellation has been requested.
+        """
+        self._report_progress()
+
     def _report_progress(
         self, msg: str = "", percent: float = 0.0, metadata: dict[str, Any] | None = None, level: str = "INFO"
     ) -> None:

--- a/application/backend/app/execution/training/getitune_trainer.py
+++ b/application/backend/app/execution/training/getitune_trainer.py
@@ -546,40 +546,77 @@ class GetiTuneTrainer(Execution[TrainingJobParams]):
         - PyTorch (.ckpt) variants are evaluated with the LightningEngine used for training.
         - OpenVINO (.xml) and ONNX (.onnx) variants are evaluated with OVEngine, which
           natively supports both checkpoint types.
+
+        Every variant reports a heartbeat while it runs. Evaluation is the longest
+        non-incremental part of a training job (the OpenVINO and ONNX variants run on
+        CPU and can take hours for large, high-resolution models such as MaskRCNN
+        SwinT), and the surrounding ``@step`` decorator only reports progress when the
+        step starts and ends. Without the heartbeat the control plane sees a job whose
+        ``updated_at`` never moves, declares it stale and terminates the process with
+        SIGTERM/SIGKILL -- which runs no Python exception handler, so the job log ends
+        mid-evaluation with no error at all.
         """
         from getitune.backend.openvino.engine import OVEngine
+
+        from .progress import EvaluationHeartbeatCallback
 
         metric_callable = get_metric_by_task(task)
         ov_work_dir_base = Path(getitune_engine.work_dir)
         datamodule = getitune_engine.datamodule
 
         for variant in model_variants:
-            logger.info("Evaluating the {} model...", variant.format.value)
+            self.update_message(f"Evaluating the {variant.format.value} model...")
+            test_kwargs: dict[str, Any] = {"metric": metric_callable}
             match variant.format:
                 case ModelFormat.PYTORCH:
                     engine = getitune_engine
+                    test_kwargs["callbacks"] = [EvaluationHeartbeatCallback(self.heartbeat)]
                 case ModelFormat.OPENVINO:
                     engine = OVEngine(
                         model=variant.path,
                         data=datamodule,
                         work_dir=ov_work_dir_base / "ov_eval",
                     )
+                    test_kwargs["progress_callback"] = self._evaluation_progress_callback(variant.format.value)
                 case ModelFormat.ONNX:
                     engine = OVEngine(
                         model=variant.path,
                         data=datamodule,
                         work_dir=ov_work_dir_base / "onnx_eval",
                     )
+                    test_kwargs["progress_callback"] = self._evaluation_progress_callback(variant.format.value)
                 case _:
                     raise ExecutionErr(f"Unsupported model variant format for evaluation: {variant.format}")
 
-            metrics = engine.test(metric=metric_callable)
+            metrics = engine.test(**test_kwargs)
             self._save_evaluation_result(
                 metrics=metrics,
                 model_revision_id=model_revision_id,
                 model_variant_id=variant.id,
                 dataset_revision_id=dataset_revision_id,
             )
+
+    def _evaluation_progress_callback(self, variant_name: str) -> Callable[[int, int], None]:
+        """Build the per-batch callback used to keep a long OpenVINO evaluation observable.
+
+        Besides emitting the heartbeat that prevents the job from being declared stale,
+        it logs the batch counter at a coarse interval so a slow evaluation is visible in
+        the job log instead of looking like a hang.
+
+        Args:
+            variant_name: Model variant being evaluated, used in the log message.
+
+        Returns:
+            Callable accepting ``(completed_batches, total_batches)``.
+        """
+        log_every = 10
+
+        def _on_batch(completed: int, total: int) -> None:
+            self.heartbeat()
+            if completed == total or completed % log_every == 0:
+                logger.info("Evaluating the {} model: batch {}/{}", variant_name, completed, total)
+
+        return _on_batch
 
     def _save_evaluation_result(
         self,

--- a/application/backend/app/execution/training/progress.py
+++ b/application/backend/app/execution/training/progress.py
@@ -42,3 +42,36 @@ class TrainingProgressCallback(Callback):
         self._update_total_steps(trainer)
         self._current_step += 1
         self._emit_progress()
+
+
+class EvaluationHeartbeatCallback(Callback):
+    """Emit a liveness heartbeat while a Lightning test loop is running.
+
+    The "Evaluate Model" step reports progress only when it starts and when it ends.
+    A test loop that runs longer than the control plane's stale-job threshold would
+    otherwise be mistaken for a hung job and terminated by a signal, killing the
+    process without any Python-level error and leaving the job log truncated.
+
+    Args:
+        on_heartbeat: Called periodically to signal liveness.
+        every_n_batches: Emit at most one heartbeat every N test batches, to avoid
+            flooding the IPC channel on fast (e.g. GPU) evaluations.
+    """
+
+    def __init__(self, on_heartbeat: Callable[[], None], every_n_batches: int = 10) -> None:
+        self._on_heartbeat = on_heartbeat
+        self._every_n_batches = max(1, every_n_batches)
+        self._seen = 0
+
+    def on_test_batch_end(
+        self,
+        trainer: LightningTrainer,
+        pl_module: LightningModule,
+        outputs: STEP_OUTPUT,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        self._seen += 1
+        if self._seen % self._every_n_batches == 0:
+            self._on_heartbeat()

--- a/application/backend/tests/unit/core/jobs/control_plane/test_controller.py
+++ b/application/backend/tests/unit/core/jobs/control_plane/test_controller.py
@@ -162,6 +162,37 @@ class TestJobController:
         # Verify cancellation was requested for both stale jobs
         fxt_job_queue.cancel.assert_has_calls(calls=[call(stale_job1.id), call(stale_job2.id)], any_order=True)
 
+        # The jobs are remembered so the eventual signal-based termination can be explained
+        # in the job log instead of the job simply dying silently.
+        assert {stale_job1.id, stale_job2.id} <= fxt_job_controller._stale_job_ids
+
+    @pytest.mark.asyncio
+    async def test_stale_termination_reason_is_propagated_to_runner(self, fxt_job_controller, fxt_job_queue, fxt_job):
+        """A stale-triggered stop must tell the runner why, so it can be logged.
+
+        Regression test: a long evaluation step reports no progress, so the stale monitor
+        SIGTERMs the process. That kills it without running any Python handler, leaving the
+        job log truncated with no error at all.
+        """
+        job = fxt_job()
+        fxt_job_controller._stale_job_ids.add(job.id)
+
+        job_run = Mock()
+        job_run.events = Mock(return_value=iter([]))
+        job_run.stop = AsyncMock()
+        cancel_event = asyncio.Event()
+        cancel_event.set()
+        fxt_job_queue.get_cancellation_event = Mock(return_value=cancel_event)
+
+        cancel_task = fxt_job_controller._setup_job_execution(job, job_run, asyncio.Queue())
+        await asyncio.sleep(0)
+        await cancel_task
+
+        job_run.stop.assert_awaited_once()
+        reason = job_run.stop.await_args_list[0].kwargs["reason"]
+        assert "stale-job monitor" in reason
+        assert str(fxt_job_controller._stale_threshold) in reason
+
     @pytest.mark.asyncio
     async def test_monitor_stale_jobs_handles_exceptions(self, fxt_job_controller, fxt_job_queue):
         """Test stale monitor handles exceptions gracefully and continues running."""

--- a/application/backend/tests/unit/core/jobs/control_plane/test_process_run.py
+++ b/application/backend/tests/unit/core/jobs/control_plane/test_process_run.py
@@ -110,6 +110,63 @@ class TestProcessRun:
 
         fxt_process_run._parent.close.assert_called_once()
 
+    def test_events_reports_sigkill_as_oom(self, fxt_process_run):
+        """A child killed by SIGKILL (OOM killer) must produce an explicit Failed reason."""
+        fxt_process_run._parent.recv.side_effect = EOFError()
+        fxt_process_run._proc = Mock(exitcode=-9)
+
+        with patch.object(ProcessRun, "_log_abnormal_exit") as mock_log:
+            events = list(fxt_process_run.events())
+
+        assert len(events) == 1
+        assert isinstance(events[0], Failed)
+        assert "SIGKILL" in events[0].details
+        assert "out-of-memory" in events[0].details
+        mock_log.assert_called_once()
+
+    def test_events_reports_native_crash(self, fxt_process_run):
+        """A child killed by SIGSEGV must be reported as a native crash."""
+        fxt_process_run._parent.recv.side_effect = EOFError()
+        fxt_process_run._proc = Mock(exitcode=-11)
+
+        with patch.object(ProcessRun, "_log_abnormal_exit"):
+            events = list(fxt_process_run.events())
+
+        assert "SIGSEGV" in events[0].details
+        assert "native extension" in events[0].details
+
+    def test_events_logs_abnormal_exit_to_job_log(self, fxt_process_run):
+        """The abnormal termination reason is appended to the job's own log file."""
+        fxt_process_run._parent.recv.side_effect = EOFError()
+        fxt_process_run._proc = Mock(exitcode=-9)
+
+        with patch("app.core.jobs.exec.process_run.job_log_sink") as mock_sink:
+            list(fxt_process_run.events())
+
+        mock_sink.assert_called_once()
+        assert mock_sink.call_args.args[0].log_file == fxt_process_run._job.log_file
+
+    def test_log_abnormal_exit_survives_sink_failure(self, fxt_process_run):
+        """Failing to write to the job log must not break event handling."""
+        fxt_process_run._parent.recv.side_effect = EOFError()
+        fxt_process_run._proc = Mock(exitcode=-9)
+
+        with patch("app.core.jobs.exec.process_run.job_log_sink", side_effect=OSError("read-only fs")):
+            events = list(fxt_process_run.events())
+
+        assert len(events) == 1
+        assert isinstance(events[0], Failed)
+
+    def test_events_handles_missing_exit_code(self, fxt_process_run):
+        """A None exit code is reported instead of being silently swallowed."""
+        fxt_process_run._parent.recv.side_effect = EOFError()
+        fxt_process_run._proc = Mock(exitcode=None)
+
+        with patch.object(ProcessRun, "_log_abnormal_exit"):
+            events = list(fxt_process_run.events())
+
+        assert "without an exit code" in events[0].details
+
     @pytest.mark.asyncio
     async def test_stop_with_no_process(self, fxt_process_run):
         """Test stop method when no process exists."""

--- a/application/backend/tests/unit/execution/training/test_getitune_trainer.py
+++ b/application/backend/tests/unit/execution/training/test_getitune_trainer.py
@@ -39,6 +39,7 @@ from app.execution.training.getitune_trainer import (
     ModelVariantDescriptor,
     TrainingDependencies,
 )
+from app.execution.training.progress import EvaluationHeartbeatCallback
 from app.models import (
     DatasetItemAnnotationStatus,
     DatasetItemSubset,
@@ -1192,7 +1193,14 @@ class TestGetiTuneTrainerEvaluateModel:
             )
 
         # Assert: PyTorch evaluation via the LightningEngine
-        mock_getitune_engine.test.assert_called_once_with(metric=metric_callable)
+        pytorch_call = mock_getitune_engine.test.call_args
+        assert mock_getitune_engine.test.call_count == 1
+        assert pytorch_call.kwargs["metric"] is metric_callable
+        # A heartbeat callback keeps the job's updated_at moving during a long test loop,
+        # otherwise the stale-job monitor terminates the process by signal (no traceback).
+        assert any(isinstance(cb, EvaluationHeartbeatCallback) for cb in pytorch_call.kwargs.get("callbacks", [])), (
+            "PyTorch evaluation must report liveness"
+        )
 
         # Assert: OVEngine instantiated twice (OV + ONNX) and tested with the right checkpoints
         assert mock_ov_engine_cls.call_count == 2
@@ -1210,8 +1218,13 @@ class TestGetiTuneTrainerEvaluateModel:
                 ),
             ]
         )
-        mock_ov_engine.test.assert_called_once_with(metric=metric_callable)
-        mock_onnx_engine.test.assert_called_once_with(metric=metric_callable)
+        for engine_mock in (mock_ov_engine, mock_onnx_engine):
+            assert engine_mock.test.call_count == 1
+            kwargs = engine_mock.test.call_args.kwargs
+            assert kwargs["metric"] is metric_callable
+            # OpenVINO/ONNX evaluation runs on CPU and is the slowest part of a training
+            # job, so it must report per-batch liveness to the control plane.
+            assert callable(kwargs["progress_callback"])
 
         # Assert: each variant's metrics are persisted with the matching variant id
         save_calls = fxt_model_service.save_evaluation_result.call_args_list
@@ -1272,7 +1285,8 @@ class TestGetiTuneTrainerEvaluateModel:
         )
 
         # Assert — metric is always passed uniformly; Ultralytics engines ignore it.
-        mock_getitune_engine.test.assert_called_once_with(metric=MeanAPCallable)
+        assert mock_getitune_engine.test.call_count == 1
+        assert mock_getitune_engine.test.call_args.kwargs["metric"] is MeanAPCallable
         fxt_model_service.save_evaluation_result.assert_called_once()
 
 

--- a/library/src/getitune/backend/openvino/engine.py
+++ b/library/src/getitune/backend/openvino/engine.py
@@ -28,6 +28,8 @@ from getitune.tools.auto_configurator import AutoConfigurator
 from getitune.types import PathLike, TaskType
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from getitune.metrics import MetricCallable
     from getitune.types.types import ANNOTATIONS, DATA, METRICS, MODEL
 
@@ -228,6 +230,7 @@ class OVEngine(Engine):
         data: DataModule | PathLike | None = None,
         checkpoint: PathLike | None = None,
         metric: MetricCallable | None = None,
+        progress_callback: Callable[[int, int], None] | None = None,
         **kwargs,
     ) -> METRICS:
         """Run the testing phase of the engine.
@@ -240,6 +243,12 @@ class OVEngine(Engine):
                 Defaults to None.
             metric (MetricCallable | None, optional): If provided, overrides
                 `LightningModel.metric_callable` with the given metric callable for evaluation.
+            progress_callback (Callable[[int, int], None] | None, optional): Called after every
+                test batch with ``(completed_batches, total_batches)``. OpenVINO evaluation runs
+                on CPU and can take hours for large, high-resolution models; without a way to
+                observe that it is progressing, an embedding application cannot distinguish a
+                slow-but-healthy evaluation from a hung one. Exceptions raised by the callback
+                propagate, so it can also be used to implement cooperative cancellation.
 
         Returns:
             METRICS: The computed metrics after testing the model on the provided data.
@@ -294,10 +303,13 @@ class OVEngine(Engine):
         metric_callable = metric(datamodule.label_info)
         with Progress() as progress:
             dataloader = datamodule.test_dataloader()
-            task = progress.add_task("Testing", total=len(dataloader))
-            for data_batch in dataloader:
+            total_batches = len(dataloader)
+            task = progress.add_task("Testing", total=total_batches)
+            for completed, data_batch in enumerate(dataloader, start=1):
                 model.test_step(data_batch, metric_callable)
                 progress.update(task, advance=1)
+                if progress_callback is not None:
+                    progress_callback(completed, total_batches)
 
         metrics_result = model.compute_metrics(metric_callable)
 

--- a/library/src/getitune/backend/openvino/models/utils.py
+++ b/library/src/getitune/backend/openvino/models/utils.py
@@ -84,6 +84,7 @@ def rescale_masks_to_original(
     img_shape: tuple[int, int],
     ori_shape: tuple[int, int],
     padding: tuple[int, int, int, int],
+    chunk_size: int = 8,
 ) -> torch.Tensor:
     """Rescale predicted binary masks from model input coordinates to original image coordinates.
 
@@ -96,6 +97,14 @@ def rescale_masks_to_original(
         img_shape: (H, W) of the preprocessed model input image.
         ori_shape: (H, W) of the original image.
         padding: (left, top, right, bottom) padding applied during preprocessing.
+        chunk_size: Number of masks interpolated at once. ``F.interpolate`` requires
+            float32 inputs, so processing all masks in one call materialises a float32
+            copy of the whole stack *and* of the (N, ori_H, ori_W) result — 8 bytes per
+            output pixel per instance. For a high-resolution instance segmentation model
+            (e.g. MaskRCNN SwinT at 1344x1344 with up to 100 instances per image) that is
+            several GiB of transient allocation for a single image, which is enough to get
+            the evaluation process killed by the OS OOM killer. Interpolating in chunks
+            bounds that transient peak without changing the result.
 
     Returns:
         Tensor of shape (N, ori_H, ori_W) with masks mapped to ori_shape space.
@@ -117,9 +126,15 @@ def rescale_masks_to_original(
         content_w = img_w - pad_left - pad_right
         masks = masks[:, pad_top : pad_top + content_h, pad_left : pad_left + content_w]
 
-    # Resize masks to ori_shape using bilinear interpolation
-    # f.interpolate expects (N, C, H, W) input
-    masks_4d = masks.unsqueeze(1).float()  # (N, 1, H, W)
-    return (f.interpolate(masks_4d, size=(ori_h, ori_w), mode="bilinear", align_corners=False).squeeze(1) > 0.5).to(
-        torch.uint8
-    )
+    # Resize masks to ori_shape using bilinear interpolation.
+    # f.interpolate expects (N, C, H, W) float input, so work in chunks to keep the
+    # transient float32 buffers bounded regardless of the number of instances.
+    num_masks = masks.shape[0]
+    step = max(1, chunk_size)
+    rescaled = torch.empty((num_masks, ori_h, ori_w), dtype=torch.uint8)
+    for start in range(0, num_masks, step):
+        chunk = masks[start : start + step].unsqueeze(1).float()  # (n, 1, H, W)
+        resized = f.interpolate(chunk, size=(ori_h, ori_w), mode="bilinear", align_corners=False).squeeze(1)
+        rescaled[start : start + step] = (resized > 0.5).to(torch.uint8)
+        del chunk, resized
+    return rescaled

--- a/library/src/getitune/tools/auto_configurator.py
+++ b/library/src/getitune/tools/auto_configurator.py
@@ -31,6 +31,22 @@ if TYPE_CHECKING:
 logger = logging.getLogger()
 RECIPE_PATH = get_getitune_root_path() / "recipe"
 
+# Memory budget (in MiB) for the decoded image tensors of a *single* OpenVINO
+# evaluation batch.  The ``openvino_model.yaml`` recipes hard-code a batch size
+# (e.g. 64 for instance segmentation) that was tuned for low-resolution models.
+# That same batch size becomes a memory bomb for high-resolution architectures
+# such as MaskRCNN SwinT (1344x1344): 64 * 3 * 1344 * 1344 * 4 B ~= 1.4 GiB of
+# float32 pixels *per batch*, multiplied again by the dataloader prefetch queue
+# (num_workers * prefetch_factor) and once more by the per-instance full-image
+# masks that ModelAPI allocates during post-processing.  The resulting RSS spike
+# gets the worker process killed by the OS OOM killer, which surfaces as a
+# training job that dies during evaluation without any Python traceback.
+#
+# Capping the batch size by a memory budget keeps evaluation results identical
+# (batching only affects throughput, not metrics) while making the peak memory
+# roughly independent of the model input resolution.
+OV_EVAL_BATCH_BUDGET_MB = int(os.environ.get("GETITUNE_OV_EVAL_BATCH_BUDGET_MB", "256"))
+
 DEFAULT_CONFIG_PER_TASK = {
     TaskType.MULTI_CLASS_CLS: RECIPE_PATH / "classification" / "multi_class_cls" / "mobilenet_v3_large.yaml",
     TaskType.MULTI_LABEL_CLS: RECIPE_PATH / "classification" / "multi_label_cls" / "mobilenet_v3_large.yaml",
@@ -429,6 +445,16 @@ class AutoConfigurator:
             )
             raise ValueError(msg)
 
+        if not tiling_enabled:
+            # The recipe batch size is resolution-agnostic; clamp it so that a
+            # high-resolution model does not blow up host memory (see
+            # OV_EVAL_BATCH_BUDGET_MB).  Tiled pipelines already force batch_size=1.
+            subset_config.batch_size = self._cap_eval_batch_size(
+                batch_size=subset_config.batch_size,
+                input_size=actual_input_size,
+                subset=subset,
+            )
+
         msg = (
             f"For OpenVINO IR models, Update the following {subset} \n"
             f"\t augmentations_cpu: {subset_config.augmentations_cpu} \n"
@@ -475,6 +501,58 @@ class AutoConfigurator:
             auto_num_workers=datamodule.auto_num_workers,
             device=datamodule.device,
         )
+
+    @staticmethod
+    def _cap_eval_batch_size(batch_size: int, input_size: tuple[int, int], subset: str = "test") -> int:
+        """Clamp an OpenVINO evaluation batch size to a host-memory budget.
+
+        The ``openvino_model.yaml`` recipes declare a single, resolution-agnostic
+        batch size (64 for most tasks).  Combined with a high-resolution model such
+        as MaskRCNN SwinT (1344x1344) this makes one dataloader batch hold ~1.4 GiB
+        of float32 pixels, which is then multiplied by the dataloader prefetch queue
+        and by the per-instance, full-image masks produced during post-processing.
+        The resulting allocation spike is typically resolved by the OS OOM killer,
+        i.e. the evaluation process dies by SIGKILL without a Python traceback.
+
+        Batch size only affects evaluation throughput, never the computed metrics,
+        so clamping it is always safe.
+
+        Args:
+            batch_size: Batch size requested by the OpenVINO recipe.
+            input_size: ``(H, W)`` the images are resized to before inference.
+            subset: Name of the subset being configured, used for logging only.
+
+        Returns:
+            int: ``batch_size``, or a smaller value that fits the memory budget
+            (never less than 1).
+        """
+        height, width = int(input_size[0]), int(input_size[1])
+        if height <= 0 or width <= 0:
+            return batch_size
+
+        # 3 channels, float32 (the OV CPU pipeline scales pixels to float).
+        bytes_per_image = 3 * height * width * 4
+        budget_bytes = max(OV_EVAL_BATCH_BUDGET_MB, 1) * 1024 * 1024
+        max_batch_size = max(1, budget_bytes // bytes_per_image)
+
+        if batch_size <= max_batch_size:
+            return batch_size
+
+        logger.warning(
+            "update_ov_subset_pipeline: OpenVINO recipe %s_subset.batch_size=%d would allocate "
+            "~%.1f MiB of float32 pixels per batch at input_size=%dx%d (plus dataloader prefetch "
+            "and per-instance full-image masks), which risks the evaluation process being killed "
+            "by the OS OOM killer. Reducing batch_size to %d to stay within the %d MiB budget "
+            "(override via GETITUNE_OV_EVAL_BATCH_BUDGET_MB). Metrics are unaffected.",
+            subset,
+            batch_size,
+            batch_size * bytes_per_image / 1024 / 1024,
+            height,
+            width,
+            max_batch_size,
+            OV_EVAL_BATCH_BUDGET_MB,
+        )
+        return int(max_batch_size)
 
     @staticmethod
     def _strip_resize_transforms(augmentations: list[dict]) -> None:

--- a/library/tests/unit/backend/openvino/models/test_utils.py
+++ b/library/tests/unit/backend/openvino/models/test_utils.py
@@ -69,3 +69,24 @@ class TestRescaleMasksToOriginal:
         assert result.shape == (1, 480, 640)
         # Content was 480x640, resized to 480x640 — should be all 1s
         assert result[0].sum() == 480 * 640
+
+    def test_chunking_does_not_change_result(self) -> None:
+        """Chunked interpolation must be numerically identical to a single-shot resize.
+        The masks are rescaled in chunks to bound the transient float32 buffers that
+        ``F.interpolate`` allocates. For a high-resolution instance segmentation model
+        (MaskRCNN SwinT at 1344x1344, up to 100 instances per image) a single-shot
+        resize allocated several GiB at once, which got the evaluation process killed
+        by the OS OOM killer with no Python traceback.
+        """
+        torch.manual_seed(0)
+        masks = (torch.rand(17, 64, 64) > 0.5).to(torch.uint8)
+        one_shot = rescale_masks_to_original(
+            masks, img_shape=(64, 64), ori_shape=(128, 96), padding=(0, 0, 0, 0), chunk_size=1000
+        )
+        chunked = rescale_masks_to_original(
+            masks, img_shape=(64, 64), ori_shape=(128, 96), padding=(0, 0, 0, 0), chunk_size=4
+        )
+        assert one_shot.shape == (17, 128, 96)
+        assert one_shot.dtype == torch.uint8
+        assert chunked.dtype == torch.uint8
+        assert torch.equal(one_shot, chunked)

--- a/library/tests/unit/backend/openvino/test_engine.py
+++ b/library/tests/unit/backend/openvino/test_engine.py
@@ -144,6 +144,64 @@ class TestEngine:
         ):
             fxt_engine.test()
 
+    def test_test_reports_batch_progress(self, fxt_engine, mocker: MockerFixture) -> None:
+        """``test`` invokes ``progress_callback`` once per batch.
+
+        OpenVINO evaluation is a single long-running, silent loop. Embedding
+        applications rely on this callback to prove the evaluation is alive; without
+        it a slow-but-healthy evaluation is indistinguishable from a hung one.
+        """
+        mocker.patch(
+            "getitune.backend.openvino.engine.AutoConfigurator.update_ov_subset_pipeline",
+            return_value=fxt_engine.datamodule,
+        )
+        mock_get_ov_model = mocker.patch("getitune.backend.openvino.engine.AutoConfigurator.get_ov_model")
+        fxt_engine._derive_task_from_ir = MagicMock(return_value="MULTI_LABEL_CLS")
+        mock_model = MagicMock()
+        mock_get_ov_model.return_value = mock_model
+        fxt_engine._model = fxt_engine._auto_configurator.get_ov_model("model.xml")
+
+        mock_dataloader = MagicMock()
+        mock_dataloader.__iter__ = MagicMock(return_value=iter([MagicMock() for _ in range(3)]))
+        mock_dataloader.__len__ = MagicMock(return_value=3)
+        mocker.patch.object(fxt_engine.datamodule, "test_dataloader", return_value=mock_dataloader)
+
+        mock_model.label_info = fxt_engine.datamodule.label_info
+        mock_model.prepare_metric_inputs = mocker.MagicMock(return_value={"preds": [1], "target": [1]})
+        mock_model.compute_metrics = mocker.MagicMock(return_value={})
+
+        seen: list[tuple[int, int]] = []
+        fxt_engine.test(metric=MagicMock(), progress_callback=lambda done, total: seen.append((done, total)))
+
+        assert seen == [(1, 3), (2, 3), (3, 3)]
+
+    def test_test_propagates_progress_callback_errors(self, fxt_engine, mocker: MockerFixture) -> None:
+        """Errors raised by the callback propagate, enabling cooperative cancellation."""
+        mocker.patch(
+            "getitune.backend.openvino.engine.AutoConfigurator.update_ov_subset_pipeline",
+            return_value=fxt_engine.datamodule,
+        )
+        mock_get_ov_model = mocker.patch("getitune.backend.openvino.engine.AutoConfigurator.get_ov_model")
+        fxt_engine._derive_task_from_ir = MagicMock(return_value="MULTI_LABEL_CLS")
+        mock_model = MagicMock()
+        mock_get_ov_model.return_value = mock_model
+        fxt_engine._model = fxt_engine._auto_configurator.get_ov_model("model.xml")
+
+        mock_dataloader = MagicMock()
+        mock_dataloader.__iter__ = MagicMock(return_value=iter([MagicMock() for _ in range(3)]))
+        mock_dataloader.__len__ = MagicMock(return_value=3)
+        mocker.patch.object(fxt_engine.datamodule, "test_dataloader", return_value=mock_dataloader)
+
+        mock_model.label_info = fxt_engine.datamodule.label_info
+        mock_model.prepare_metric_inputs = mocker.MagicMock(return_value={"preds": [1], "target": [1]})
+        mock_model.compute_metrics = mocker.MagicMock(return_value={})
+
+        def _cancel(done: int, total: int) -> None:
+            raise KeyboardInterrupt
+
+        with pytest.raises(KeyboardInterrupt):
+            fxt_engine.test(metric=MagicMock(), progress_callback=_cancel)
+
     @pytest.mark.parametrize("explain", [True, False])
     def test_predict(self, fxt_engine, tmp_path, explain, mocker: MockerFixture) -> None:
         checkpoint = f"{tmp_path}/model.xml"

--- a/library/tests/unit/tools/test_auto_configurator.py
+++ b/library/tests/unit/tools/test_auto_configurator.py
@@ -158,8 +158,58 @@ class TestAutoConfigurator:
         assert len(updated_datamodule.test_subset.augmentations_cpu) == 1
         assert "Resize" in updated_datamodule.test_subset.augmentations_cpu[0]["class_path"]
         assert not updated_datamodule.tile_config.enable_tiler
-        # Without tiling, the OV recipe's batch_size is used as-is (no override).
-        assert updated_datamodule.test_subset.batch_size == ov_recipe_batch_size
+        # Without tiling, the OV recipe's batch_size is used, clamped to the memory budget.
+        assert updated_datamodule.test_subset.batch_size == AutoConfigurator._cap_eval_batch_size(
+            batch_size=ov_recipe_batch_size,
+            input_size=updated_datamodule.test_subset.input_size,  # pyrefly: ignore[bad-argument-type]
+        )
+        assert updated_datamodule.test_subset.batch_size <= ov_recipe_batch_size
+
+    @pytest.mark.parametrize(
+        ("batch_size", "input_size", "budget_mb", "expected"),
+        [
+            # Low resolution: the recipe batch size fits the budget and is left alone.
+            (64, (224, 224), 256, 64),
+            # MaskRCNN SwinT resolution: 64 * 3 * 1344 * 1344 * 4 B ~= 1.4 GiB -> clamped.
+            (64, (1344, 1344), 256, 12),
+            # Never clamp below 1, even for an absurd resolution.
+            (64, (8192, 8192), 1, 1),
+            # Degenerate/dynamic shapes are passed through untouched.
+            (64, (0, 0), 256, 64),
+        ],
+    )
+    def test_cap_eval_batch_size(self, batch_size, input_size, budget_mb, expected, monkeypatch) -> None:
+        """The OV evaluation batch size is clamped to a host-memory budget.
+
+        Regression test: the instance segmentation OV recipe hard-codes batch_size=64,
+        which at MaskRCNN SwinT's 1344x1344 input resolution makes a single batch hold
+        ~1.4 GiB of float32 pixels (before dataloader prefetch and per-instance
+        full-image masks). The resulting memory spike got the training job's evaluation
+        process killed by the OS OOM killer, i.e. it died with no Python traceback.
+        """
+        monkeypatch.setattr("getitune.tools.auto_configurator.OV_EVAL_BATCH_BUDGET_MB", budget_mb)
+
+        assert AutoConfigurator._cap_eval_batch_size(batch_size=batch_size, input_size=input_size) == expected
+
+    def test_update_ov_subset_pipeline_clamps_high_resolution_batch_size(self) -> None:
+        """A high-resolution model must not inherit the OV recipe's large batch size."""
+        data_root = "tests/assets/detection_coco"
+        auto_configurator = AutoConfigurator(data_root=data_root, task="DETECTION")
+        datamodule = auto_configurator.get_datamodule()
+
+        ov_config_path = DEFAULT_CONFIG_PER_TASK[TaskType.DETECTION].parent / "openvino_model.yaml"
+        ov_recipe_batch_size = auto_configurator._load_default_config(config_path=ov_config_path)["data"][
+            "test_subset"
+        ]["batch_size"]
+
+        updated_datamodule = auto_configurator.update_ov_subset_pipeline(
+            datamodule,
+            subset="test",
+            input_size=(1344, 1344),
+        )
+
+        assert updated_datamodule.test_subset.batch_size < ov_recipe_batch_size
+        assert updated_datamodule.test_subset.batch_size >= 1
 
     def test_update_ov_subset_pipeline_tiling_keeps_tiler_and_strips_resize(self) -> None:
         """With tiling enabled, the OV pipeline keeps the tiler on and removes the tile Resize.


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

Fixes the OV evaluation step that crashes with no error logged

```
2026-09-06 13:57:08.605 | INFO     | app.execution.training.getitune_trainer:evaluate_model:562 - Evaluating the openvino model...
2026-09-06 13:57:08.844 | INFO     | getitune.cli.utils.jsonargparse:get_configuration:451 - /application/backend/.venv/lib/python3.13/site-packages/getitune/recipe/instance_segmentation/rfdetr_seg_small.yaml is loaded.
2026-09-06 13:57:08.853 | INFO     | model_api.adapters.openvino_adapter:create_core:56 - OpenVINO Runtime
2026-09-06 13:57:08.854 | INFO     | model_api.adapters.openvino_adapter:create_core:57 -       build: 2026.3.1-22476-759c5a6ab8c-releases/2026/3
2026-09-06 13:57:08.854 | INFO     | model_api.adapters.openvino_adapter:__init__:180 - Reading model /application/data/getitune-workspace-3a306236-723a-4818-82c6-bd469eb096d5/exported_model.xml
2026-09-06 13:57:10.200 | INFO     | model_api.adapters.openvino_adapter:load_model:247 - The model /application/data/getitune-workspace-3a306236-723a-4818-82c6-bd469eb096d5/exported_model.xml is loaded to CPU
2026-09-06 13:57:10.201 | INFO     | model_api.adapters.openvino_adapter:log_runtime_settings:274 -     Number of model infer requests: 16
2026-09-06 13:57:11.777 | INFO     | model_api.adapters.openvino_adapter:load_model:247 - The model /application/data/getitune-workspace-3a306236-723a-4818-82c6-bd469eb096d5/exported_model.xml is loaded to CPU
2026-09-06 13:57:11.779 | INFO     | model_api.adapters.openvino_adapter:log_runtime_settings:274 -     Number of model infer requests: 16
2026-09-06 13:57:11.865 | INFO     | getitune.cli.utils.jsonargparse:get_configuration:451 - /application/backend/.venv/lib/python3.13/site-packages/getitune/recipe/instance_segmentation/openvino_model.yaml is loaded.
2026-09-06 13:57:11.865 | WARNING  | getitune.data.module:from_vision_datasets:327 - The provided train SubsetConfig contains augmentations_cpu which will be overridden by the transforms of the provided VisionDataset. When building DataModule from pre-constructed datasets, developers should set up the transforms when creating the datasets.
2026-09-06 13:57:11.865 | WARNING  | getitune.data.module:from_vision_datasets:327 - The provided val SubsetConfig contains augmentations_cpu which will be overridden by the transforms of the provided VisionDataset. When building DataModule from pre-constructed datasets, developers should set up the transforms when creating the datasets.
2026-09-06 13:57:11.865 | WARNING  | getitune.data.module:from_vision_datasets:327 - The provided test SubsetConfig contains augmentations_cpu which will be overridden by the transforms of the provided VisionDataset. When building DataModule from pre-constructed datasets, developers should set up the transforms when creating the datasets.
2026-09-06 13:57:11.865 | INFO     | getitune.data.augmentation.intensity:build_intensity_transform:312 - Built intensity transform pipeline: [ScaleToUnit(max_value=255.0)]
```

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
