### PR TITLE
Fix TIMM input size

### DIFF
--- a/application/backend/app/supported_models/timm/manifest_provider.py
+++ b/application/backend/app/supported_models/timm/manifest_provider.py
@@ -66,7 +66,8 @@ class TimmManifestProvider:
                     weight_decay=e["default_weight_decay"],
                     input_size_width=w,
                     input_size_height=h,
-                    allowed_values_input_size=[w, h],
+                    # Deduplicated: square models would otherwise expose the same size twice.
+                    allowed_values_input_size=sorted({w, h}),
                     # everything else (epochs, batch, scheduler, early stopping,
                     # augmentation) inherits classification/base.yaml defaults.
                 ),

--- a/application/backend/tests/unit/supported_models/timm/test_manifest_provider.py
+++ b/application/backend/tests/unit/supported_models/timm/test_manifest_provider.py
@@ -77,8 +77,16 @@ class TestTimmManifestProvider:
         assert manifest.stats.benchmark_metrics.imagenet_top1_accuracy == 70.0
         assert manifest.hyperparameters.training.input_size_width == 224
         assert manifest.hyperparameters.training.input_size_height == 224
+        assert manifest.hyperparameters.training.allowed_values_input_size == [224]
         assert manifest.hyperparameters.training.learning_rate == 0.01
         assert manifest.hyperparameters.training.weight_decay == 0.001
+
+    def test_build_manifest_allowed_input_sizes_for_non_square_model(self) -> None:
+        entry = {**_FAKE_ENTRY, "input_size": [3, 256, 224]}
+        with patch.object(manifest_provider, "_snapshot", return_value={entry["model_name"]: entry}):
+            manifest = TimmManifestProvider.build_manifest("resnet18.a1_in1k")
+
+        assert manifest.hyperparameters.training.allowed_values_input_size == [224, 256]
 
     def test_build_manifest_missing_model_raises_key_error(self) -> None:
         with pytest.raises(KeyError):

--- a/application/ui/src/features/models/train-model/advanced-settings/training/learning-parameters/input-size-parameters.component.tsx
+++ b/application/ui/src/features/models/train-model/advanced-settings/training/learning-parameters/input-size-parameters.component.tsx
@@ -14,7 +14,7 @@ type InputSizeParameterProps = {
 };
 
 const InputSizeParameter = ({ inputSizeParameter, onChange, isReadOnly }: InputSizeParameterProps) => {
-    if (isReadOnly) {
+    if (isReadOnly || inputSizeParameter.allowed_values.length <= 1) {
         return <span aria-label={inputSizeParameter.name}>{inputSizeParameter.value}</span>;
     }
 


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* If we get the same input size, we should not show a picker to the user
* Closes https://github.com/open-edge-platform/geti/issues/7505

<img width="780" height="743" alt="Screenshot 2026-09-08 at 10 39 59" src="https://github.com/user-attachments/assets/17455ba9-e32b-4b14-91b7-60f384a83105" />
<img width="774" height="825" alt="Screenshot 2026-09-08 at 10 39 53" src="https://github.com/user-attachments/assets/e9fcd0c9-b3ac-4d20-baa8-0d94eaa41ad5" />


### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
