### PR TITLE
Deduplicate values in the 'allowed_input_size' field for timm models

### DIFF
--- a/application/backend/app/supported_models/timm/manifest_provider.py
+++ b/application/backend/app/supported_models/timm/manifest_provider.py
@@ -66,7 +66,7 @@ class TimmManifestProvider:
                     weight_decay=e["default_weight_decay"],
                     input_size_width=w,
                     input_size_height=h,
-                    allowed_values_input_size=[w, h],
+                    allowed_values_input_size=sorted({w, h}),
                     # everything else (epochs, batch, scheduler, early stopping,
                     # augmentation) inherits classification/base.yaml defaults.
                 ),

--- a/application/backend/tests/unit/supported_models/timm/test_manifest_provider.py
+++ b/application/backend/tests/unit/supported_models/timm/test_manifest_provider.py
@@ -77,6 +77,7 @@ class TestTimmManifestProvider:
         assert manifest.stats.benchmark_metrics.imagenet_top1_accuracy == 70.0
         assert manifest.hyperparameters.training.input_size_width == 224
         assert manifest.hyperparameters.training.input_size_height == 224
+        assert manifest.hyperparameters.training.allowed_values_input_size == [224]
         assert manifest.hyperparameters.training.learning_rate == 0.01
         assert manifest.hyperparameters.training.weight_decay == 0.001
 


### PR DESCRIPTION
### Summary

Fixes #7505 

### How to test

Open any TIMM model, click Advanced Parameters > Training

<img width="530" height="313" alt="image" src="https://github.com/user-attachments/assets/9af98ed4-f3ea-4783-a6c2-8bc40e513d8b" />

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
