### PR TITLE
Add entrypoint for translation engine

### DIFF
--- a/application/ui/eslint.config.js
+++ b/application/ui/eslint.config.js
@@ -79,6 +79,14 @@ const apiBarrelRestrictedImportPattern = {
     message: 'Do not import the `@/api` barrel from within `src/api/`. Use a direct relative import instead.',
 };
 
+// Containment rule for the translation engine. Only src/i18n/** may name
+// `i18next` / `react-i18next`; everywhere else goes through the `@/i18n`
+// barrel, so swapping or removing the engine stays a single-folder change.
+const i18nEngineRestrictedImportPattern = {
+    group: ['i18next', 'react-i18next', 'i18next-*'],
+    message: 'Do not import the i18n engine directly. Use `useTranslation`, `Trans` and `TranslateFn` from `@/i18n`.',
+};
+
 // Containment rule for the `@/api` barrel. Files inside src/api/ are the ones
 // building that barrel, so importing it back via the alias creates a
 // self-import / circular-reference risk. Use direct relative imports
@@ -130,7 +138,7 @@ export default [
                 'error',
                 {
                     paths: restrictedImportPaths,
-                    patterns: restrictedImportPatterns,
+                    patterns: [...restrictedImportPatterns, i18nEngineRestrictedImportPattern],
                 },
             ],
             'header/header': [
@@ -164,7 +172,11 @@ export default [
                 'error',
                 {
                     paths: restrictedImportPaths,
-                    patterns: [...restrictedImportPatterns, tauriRestrictedImportPattern],
+                    patterns: [
+                        ...restrictedImportPatterns,
+                        tauriRestrictedImportPattern,
+                        i18nEngineRestrictedImportPattern,
+                    ],
                 },
             ],
         },
@@ -172,6 +184,27 @@ export default [
     {
         files: ['src/**/*.{ts,tsx}'],
         ignores: ['src/**/*.tauri.{ts,tsx}', 'src/api/**', 'src/query-client/**'],
+        rules: {
+            'no-restricted-imports': [
+                'error',
+                {
+                    paths: restrictedImportPaths,
+                    patterns: [
+                        ...restrictedImportPatterns,
+                        tauriRestrictedImportPattern,
+                        openapiSpecRestrictedImportPattern,
+                        apiBarrelRestrictedImportPattern,
+                        sharedTypesRestrictedImportPattern,
+                        i18nEngineRestrictedImportPattern,
+                    ],
+                },
+            ],
+        },
+    },
+    {
+        // The i18n folder owns the engine, so it is the one place allowed to
+        // name `i18next` / `react-i18next` and to reach its own siblings.
+        files: ['src/i18n/**/*.{ts,tsx}'],
         rules: {
             'no-restricted-imports': [
                 'error',
@@ -201,6 +234,7 @@ export default [
                         openapiSpecRestrictedImportPattern,
                         apiBarrelRestrictedImportPattern,
                         sharedTypesRestrictedImportPattern,
+                        i18nEngineRestrictedImportPattern,
                     ],
                 },
             ],
@@ -216,7 +250,11 @@ export default [
                 'error',
                 {
                     paths: [...restrictedImportPaths, apiBarrelRestrictedImportPath],
-                    patterns: [...restrictedImportPatterns, tauriRestrictedImportPattern],
+                    patterns: [
+                        ...restrictedImportPatterns,
+                        tauriRestrictedImportPattern,
+                        i18nEngineRestrictedImportPattern,
+                    ],
                 },
             ],
         },

--- a/application/ui/src/components/project-dialogs/delete-project-dialog.component.tsx
+++ b/application/ui/src/components/project-dialogs/delete-project-dialog.component.tsx
@@ -1,9 +1,9 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { useTranslation } from '@/i18n';
 import { AlertDialog, DialogContainer } from '@geti-ui/ui';
 import { useDeleteProject } from 'hooks/api/project.hook';
-import { useTranslation } from 'react-i18next';
 
 import { toast } from '../toast/toast.component';
 

--- a/application/ui/src/components/project-dialogs/edit-project-name-dialog.component.tsx
+++ b/application/ui/src/components/project-dialogs/edit-project-name-dialog.component.tsx
@@ -3,10 +3,10 @@
 
 import { FormEvent, useState } from 'react';
 
+import { useTranslation } from '@/i18n';
 import { Button, ButtonGroup, Content, Dialog, DialogContainer, Divider, Form, Heading, TextField } from '@geti-ui/ui';
 import { usePatchProject } from 'hooks/api/project.hook';
 import { isEmpty } from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 
 import { PROJECT_NAME_MAX_LENGTH, validateProjectName } from '../../features/project/validator';
 import { toast } from '../toast/toast.component';

--- a/application/ui/src/components/project-panel/project-list-item/project-list-item.component.tsx
+++ b/application/ui/src/components/project-panel/project-list-item/project-list-item.component.tsx
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Project } from '@/api/types';
+import { useTranslation } from '@/i18n';
 import { Badge, Flex, Text } from '@geti-ui/ui';
-import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 import { paths } from '../../../constants/paths';

--- a/application/ui/src/components/project-panel/projects-list-panel.component.tsx
+++ b/application/ui/src/components/project-panel/projects-list-panel.component.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Project } from '@/api/types';
+import { useTranslation } from '@/i18n';
 import {
     ActionButton,
     Badge,
@@ -21,7 +22,6 @@ import { Edit } from '@geti-ui/ui/icons';
 import { useProjects } from 'hooks/api/project.hook';
 import { useProjectIdentifier } from 'hooks/use-project-identifier.hook';
 import { partition } from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 import { EnablePipelineBlockedDialog } from '../../components/enable-pipeline-blocked-dialog/enable-pipeline-blocked-dialog.component';

--- a/application/ui/src/features/project/create/classification-label-selection/classification-task-type-selection.component.tsx
+++ b/application/ui/src/features/project/create/classification-label-selection/classification-task-type-selection.component.tsx
@@ -1,9 +1,9 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { useTranslation } from '@/i18n';
 import { Flex, Radio, RadioGroup, Text } from '@geti-ui/ui';
 import { InfoOutline } from '@geti-ui/ui/icons';
-import { useTranslation } from 'react-i18next';
 
 import classes from './classification-task-type-selection.module.scss';
 

--- a/application/ui/src/features/project/create/create-project-form.tsx
+++ b/application/ui/src/features/project/create/create-project-form.tsx
@@ -4,9 +4,9 @@
 import { FormEvent, useState } from 'react';
 
 import type { Label, Project, TaskType } from '@/api/types';
+import { useTranslation } from '@/i18n';
 import { Button, ButtonGroup, Divider, Flex, Form, Text, TextField } from '@geti-ui/ui';
 import { useCreateProject } from 'hooks/api/project.hook';
-import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { v4 as uuid } from 'uuid';
 

--- a/application/ui/src/features/project/label-selection/create-label/create-label.component.tsx
+++ b/application/ui/src/features/project/label-selection/create-label/create-label.component.tsx
@@ -7,10 +7,10 @@ import type { Label, TaskType } from '@/api/types';
 import { HotkeyField } from '@/components/label-fields/hotkey-field.component';
 import { LabelColorPicker } from '@/components/label-fields/label-color-picker.component';
 import { validateLabelHotkey, validateLabelName } from '@/components/label-fields/label-validation';
+import { useTranslation } from '@/i18n';
 import { ActionButton, DOMRefValue, Grid, TextField, TextFieldRef, useUnwrapDOMRef, View } from '@geti-ui/ui';
 import { Add } from '@geti-ui/ui/icons';
 import { useEventListener } from 'hooks/event-listener.hook';
-import { useTranslation } from 'react-i18next';
 import { v4 as uuid } from 'uuid';
 
 import { TASK_HOTKEYS } from '../../../../shared/hotkeys-definition';

--- a/application/ui/src/features/project/label-selection/label-selection.component.tsx
+++ b/application/ui/src/features/project/label-selection/label-selection.component.tsx
@@ -5,8 +5,8 @@ import { Dispatch, SetStateAction } from 'react';
 
 import type { Label, TaskType } from '@/api/types';
 import { toast } from '@/components/toast/toast.component';
+import { useTranslation } from '@/i18n';
 import { Flex } from '@geti-ui/ui';
-import { useTranslation } from 'react-i18next';
 
 import { CreateLabel } from './create-label/create-label.component';
 import { LabelTag } from './label-tag/label-tag.component';

--- a/application/ui/src/features/project/label-selection/label-tag/label-tag.component.tsx
+++ b/application/ui/src/features/project/label-selection/label-tag/label-tag.component.tsx
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Label } from '@/api/types';
+import { useTranslation } from '@/i18n';
 import { ActionButton, Flex, PressableElement, Text, Tooltip, TooltipTrigger } from '@geti-ui/ui';
 import { Cross } from '@geti-ui/ui/icons';
-import { useTranslation } from 'react-i18next';
 
 import { formatHotkeyForDisplay } from '../../../../shared/hotkeys-definition';
 

--- a/application/ui/src/features/project/list/active-project-badge/active-project-badge.component.tsx
+++ b/application/ui/src/features/project/list/active-project-badge/active-project-badge.component.tsx
@@ -1,9 +1,9 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { useTranslation } from '@/i18n';
 import { Badge, Text } from '@geti-ui/ui';
 import { clsx } from 'clsx';
-import { useTranslation } from 'react-i18next';
 
 import classes from './active-project-badge.module.scss';
 

--- a/application/ui/src/features/project/list/empty-project-list/empty-project-list.component.tsx
+++ b/application/ui/src/features/project/list/empty-project-list/empty-project-list.component.tsx
@@ -1,8 +1,8 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { Trans, useTranslation } from '@/i18n';
 import { Button, Flex, Text } from '@geti-ui/ui';
-import { Trans, useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 import { ReactComponent as EmptyFolderImage } from '../../../../assets/empty-folder.svg';

--- a/application/ui/src/features/project/list/empty-project-list/workflow-steps.component.tsx
+++ b/application/ui/src/features/project/list/empty-project-list/workflow-steps.component.tsx
@@ -1,9 +1,9 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { useTranslation } from '@/i18n';
 import { Text, View } from '@geti-ui/ui';
 import { Adjustments, AICPUIcon, AutoTraining, Edit, FolderLight } from '@geti-ui/ui/icons';
-import { useTranslation } from 'react-i18next';
 
 import classes from './workflow-steps.module.scss';
 

--- a/application/ui/src/features/project/list/filter-projects/no-matching-projects.component.tsx
+++ b/application/ui/src/features/project/list/filter-projects/no-matching-projects.component.tsx
@@ -1,8 +1,8 @@
 // Copyright (C) 2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { useTranslation } from '@/i18n';
 import { Flex, Heading, Text } from '@geti-ui/ui';
-import { useTranslation } from 'react-i18next';
 
 import { ReactComponent as EmptyFolderImage } from '../../../../assets/empty-folder.svg';
 

--- a/application/ui/src/features/project/list/filter-projects/project-filters.component.tsx
+++ b/application/ui/src/features/project/list/filter-projects/project-filters.component.tsx
@@ -3,9 +3,9 @@
 
 import type { TaskType } from '@/api/types';
 import { FilterPopoverButton } from '@/components/filter-popover-button/filter-popover-button.component';
+import { useTranslation } from '@/i18n';
 import { Checkbox, CheckboxGroup, Flex, SearchField, View } from '@geti-ui/ui';
 import { isEmpty } from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 
 import { MAP_PROJECT_TYPE_TO_TITLE_KEY } from '../util';
 import { TASK_TYPE_OPTIONS } from './utils';

--- a/application/ui/src/features/project/list/import-dataset-as-new-project/import-task-selection/import-task-selection.component.tsx
+++ b/application/ui/src/features/project/list/import-dataset-as-new-project/import-task-selection/import-task-selection.component.tsx
@@ -4,12 +4,12 @@
 import { useActionState, useState } from 'react';
 
 import type { TaskType } from '@/api/types';
+import { useTranslation } from '@/i18n';
 import { Flex, Form, Item, Picker, Text, TextField, View } from '@geti-ui/ui';
 import { InfoOutline } from '@geti-ui/ui/icons';
 import { useProjects } from 'hooks/api/project.hook';
 import { useStagedDatasetSuspense } from 'hooks/api/staged-dataset.hook';
 import { useImportDatasetAsNewProject } from 'hooks/storage/use-import-dataset-as-new-project.hook';
-import { useTranslation } from 'react-i18next';
 
 import { generateUniqueProjectName } from '../../../create/utils';
 import { useImportDatasetDialog } from '../../../providers/import-dataset-dialog-provider.component';

--- a/application/ui/src/features/project/list/menu-actions/menu-actions.component.tsx
+++ b/application/ui/src/features/project/list/menu-actions/menu-actions.component.tsx
@@ -6,10 +6,10 @@ import { useState, type CSSProperties } from 'react';
 import { EnablePipelineBlockedDialog } from '@/components/enable-pipeline-blocked-dialog/enable-pipeline-blocked-dialog.component';
 import { DeleteProjectDialog } from '@/components/project-dialogs/delete-project-dialog.component';
 import { EditProjectNameDialog } from '@/components/project-dialogs/edit-project-name-dialog.component';
+import { useTranslation } from '@/i18n';
 import { ActionButton, Item, Menu, MenuTrigger } from '@geti-ui/ui';
 import { MoreMenu } from '@geti-ui/ui/icons';
 import { useOverlayTriggerState } from '@react-stately/overlays';
-import { useTranslation } from 'react-i18next';
 
 import { useProjectMenuActions } from './use-project-menu-actions';
 

--- a/application/ui/src/features/project/list/menu-actions/use-project-menu-actions.ts
+++ b/application/ui/src/features/project/list/menu-actions/use-project-menu-actions.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { toast } from '@/components/toast/toast.component';
+import { useTranslation } from '@/i18n';
 import { Key } from '@geti-ui/ui';
 import { useIsPipelineConfigured } from 'hooks/use-is-pipeline-configured.hook';
-import { useTranslation } from 'react-i18next';
 
 import { useDisablePipeline, useEnablePipeline, useProjectPipeline } from '../../../../hooks/api/pipeline.hook';
 

--- a/application/ui/src/features/project/list/new-project-card/new-project-card.component.tsx
+++ b/application/ui/src/features/project/list/new-project-card/new-project-card.component.tsx
@@ -1,9 +1,9 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { useTranslation } from '@/i18n';
 import { ActionButton, Flex, Text } from '@geti-ui/ui';
 import { AddCircle } from '@geti-ui/ui/icons';
-import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 import { paths } from '../../../../constants/paths';

--- a/application/ui/src/features/project/list/project-card.component.test.tsx
+++ b/application/ui/src/features/project/list/project-card.component.test.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { API_BASE_URL } from '@/api';
+import { i18n } from '@/i18n';
 import { screen } from '@testing-library/react';
 import { getMockedPipeline } from 'mocks/mock-pipeline';
 import { getMockedProject } from 'mocks/mock-project';
@@ -9,7 +10,6 @@ import { HttpResponse } from 'msw';
 import { render } from 'test-utils/render';
 
 import { http } from '../../../api/utils';
-import { i18n } from '../../../i18n';
 import { server } from '../../../msw-node-setup';
 import { ProjectCard } from './project-card.component';
 import { formatCreationDate, getProjectTypeTitle } from './util';

--- a/application/ui/src/features/project/list/project-card.component.tsx
+++ b/application/ui/src/features/project/list/project-card.component.tsx
@@ -4,11 +4,11 @@
 import { useState } from 'react';
 
 import type { Project } from '@/api/types';
+import { useTranslation } from '@/i18n';
 import { Badge, dimensionValue, Flex, Heading, Text, View } from '@geti-ui/ui';
 import { useQueryClient } from '@tanstack/react-query';
 import { clsx } from 'clsx';
 import { getProjectQueryOptions } from 'hooks/api/project.hook';
-import { useTranslation } from 'react-i18next';
 import { NavLink } from 'react-router-dom';
 
 import placeholderThumbnailIconUrl from '../../../assets/icons/image-icon.svg?url';

--- a/application/ui/src/features/project/list/project-list.component.tsx
+++ b/application/ui/src/features/project/list/project-list.component.tsx
@@ -3,10 +3,10 @@
 
 import { Suspense, useMemo, useState } from 'react';
 
+import { useTranslation } from '@/i18n';
 import { Content, Divider, Flex, Grid, Heading, Loading, Text, View } from '@geti-ui/ui';
 import { useProjects } from 'hooks/api/project.hook';
 import { partition } from 'lodash-es';
-import { useTranslation } from 'react-i18next';
 
 import { version } from '../../../../package.json';
 import { isNonEmptyArray } from '../../../shared/util';

--- a/application/ui/src/features/project/list/sort-projects/sort-projects.component.tsx
+++ b/application/ui/src/features/project/list/sort-projects/sort-projects.component.tsx
@@ -1,8 +1,8 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import { useTranslation } from '@/i18n';
 import { Item, Picker, Section } from '@geti-ui/ui';
-import { useTranslation } from 'react-i18next';
 
 import { SORT_BY_OPTIONS, SortBy } from './utils';
 

--- a/application/ui/src/features/project/list/util.ts
+++ b/application/ui/src/features/project/list/util.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { Task, TaskType } from '@/api/types';
+import type { TranslateFn } from '@/i18n';
 import dayjs from 'dayjs';
-import type { TFunction } from 'i18next';
 
 import { isMultiLabelClassificationTask } from '../task-type-guards';
 
@@ -17,7 +17,7 @@ export const MAP_PROJECT_TYPE_TO_TITLE_KEY = {
     instance_segmentation: 'project.taskTypes.instanceSegmentation',
 } as const satisfies Record<TaskType, string>;
 
-export const getProjectTypeTitle = (task: Task | undefined, t: TFunction): string | undefined => {
+export const getProjectTypeTitle = (task: Task | undefined, t: TranslateFn): string | undefined => {
     if (task === undefined) {
         return undefined;
     }

--- a/application/ui/src/features/project/task-selection/task-selection.component.tsx
+++ b/application/ui/src/features/project/task-selection/task-selection.component.tsx
@@ -4,9 +4,8 @@
 import type { Dispatch, SetStateAction } from 'react';
 
 import type { TaskType } from '@/api/types';
+import { useTranslation, type TranslateFn } from '@/i18n';
 import { Divider, Flex, Grid, Heading, Image, Radio, RadioGroup, Text, View } from '@geti-ui/ui';
-import type { TFunction } from 'i18next';
-import { useTranslation } from 'react-i18next';
 
 import classificationImageUrl from '../../../assets/classification.webp';
 import detectionImageUrl from '../../../assets/detection.webp';
@@ -21,7 +20,7 @@ export const MAP_TASK_TYPE_TO_VERB_KEY = {
     classification: 'project.create.tasks.classification.verb',
 } as const satisfies Record<TaskType, string>;
 
-const getTaskOptions = (t: TFunction): TaskOption[] => [
+const getTaskOptions = (t: TranslateFn): TaskOption[] => [
     {
         id: 'detection_task',
         imageSrc: detectionImageUrl,

--- a/application/ui/src/features/project/validator.ts
+++ b/application/ui/src/features/project/validator.ts
@@ -1,9 +1,9 @@
 // Copyright (C) 2025 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
-import type { TFunction } from 'i18next';
+import type { TranslateFn } from '@/i18n';
 
-export const validateProjectName = (name: string, projectNames: string[], t: TFunction): string | undefined => {
+export const validateProjectName = (name: string, projectNames: string[], t: TranslateFn): string | undefined => {
     if (name.trim().length === 0) {
         return t('project.validation.nameEmpty');
     }

--- a/application/ui/src/i18n/index.ts
+++ b/application/ui/src/i18n/index.ts
@@ -9,8 +9,8 @@ import { createI18nInstance } from './config';
 export const i18n = createI18nInstance();
 
 /**
- * Single entry point for the translation engine. Everything outside `src/i18n/` imports from here
- * (enforced by `no-restricted-imports`) so swapping the engine stays contained to this folder.
+ * Single entry point for the i18n public API (`useTranslation`, `Trans`, `TranslateFn`).
+ * Direct imports from the underlying engine packages are restricted outside `src/i18n/` via ESLint.
  */
 export { Trans, useTranslation } from 'react-i18next';
 

--- a/application/ui/src/i18n/index.ts
+++ b/application/ui/src/i18n/index.ts
@@ -1,10 +1,21 @@
 // Copyright (C) 2025-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+import type { TFunction } from 'i18next';
+
 import { createI18nInstance } from './config';
 
 /** Shared instance used by the app and by non-React code that needs to translate at call time. */
 export const i18n = createI18nInstance();
+
+/**
+ * Single entry point for the translation engine. Everything outside `src/i18n/` imports from here
+ * (enforced by `no-restricted-imports`) so swapping the engine stays contained to this folder.
+ */
+export { Trans, useTranslation } from 'react-i18next';
+
+/** Engine-agnostic alias for the translate function, for modules that take `t` as an argument. */
+export type TranslateFn = TFunction;
 
 export { createI18nInstance, LANGUAGE_STORAGE_KEY } from './config';
 export { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from './locales';

--- a/application/ui/src/index.tsx
+++ b/application/ui/src/index.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import ReactDOM from 'react-dom/client';
 
-import './i18n';
+import '@/i18n';
 
 import { setupStorageCleanup } from './platform/storage-cleanup';
 import { Providers } from './providers';

--- a/application/ui/src/layout.tsx
+++ b/application/ui/src/layout.tsx
@@ -5,11 +5,11 @@ import { Suspense } from 'react';
 
 import { $api } from '@/api';
 import { ProjectsListPanel } from '@/components/project-panel/projects-list-panel.component';
+import { useTranslation } from '@/i18n';
 import { Flex, Grid, Item, Loading, TabList, Tabs, Text, View } from '@geti-ui/ui';
 import { usePrefetchQuery } from '@tanstack/react-query';
 import { usePrefetchPipeline } from 'hooks/api/pipeline.hook';
 import { useProject } from 'hooks/api/project.hook';
-import { useTranslation } from 'react-i18next';
 import { Link, Outlet, useLocation } from 'react-router-dom';
 
 import getiLogo from './assets/icons/geti-logo.webp';

--- a/application/ui/tsconfig.json
+++ b/application/ui/tsconfig.json
@@ -23,7 +23,8 @@
             "mocks/*": ["./mocks/*"],
             "@/api": ["./src/api/index.ts"],
             "@/api/types": ["./src/api/shared-types.ts"],
-            "@/components/*": ["./src/components/*"]
+            "@/components/*": ["./src/components/*"],
+            "@/i18n": ["./src/i18n/index.ts"]
         }
     }
 }


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/training_extensions/blob/develop/CONTRIBUTING.md -->

### Summary

* Reasoning: If in the future we want to switch the translation engine, it's trivial, instead of changing each file
* Add exports to index.ts, update consumers, and extend eslint rule

### How to test

<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [ ] The PR title and description are clear and descriptive
- [ ] I have manually tested the changes
- [ ] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
