### PR TITLE
Log traceback when a job fails

### DIFF
--- a/application/ui/src/features/models/training-logs/log-entry.component.test.tsx
+++ b/application/ui/src/features/models/training-logs/log-entry.component.test.tsx
@@ -89,4 +89,30 @@ describe('LogEntry', () => {
             expect(mockCopy).toHaveBeenCalledWith('/tmp/output/result.json');
         });
     });
+
+    describe('exception traceback rendering', () => {
+        it('renders the traceback appended in `text` when the record has an exception', () => {
+            const entry = getMockedLogEntry({
+                message: 'Unhandled exception in worker',
+                exception: { type: 'ValueError', value: 'bad value', traceback: true },
+            });
+            entry.text =
+                '2026-09-10 10:00:00 | ERROR | mod:fn:1 - Unhandled exception in worker\n' +
+                'Traceback (most recent call last):\n  raise ValueError("bad value")\nValueError: bad value';
+
+            render(<LogEntry entry={entry} />);
+
+            expect(screen.getByText(/Traceback \(most recent call last\)/)).toBeInTheDocument();
+            expect(screen.getByText(/ValueError: bad value/)).toBeInTheDocument();
+        });
+
+        it('falls back to record.message when there is no exception', () => {
+            const entry = getMockedLogEntry({ message: 'Plain message' });
+            entry.text = 'unrelated formatted text';
+
+            render(<LogEntry entry={entry} />);
+
+            expect(screen.getByText('Plain message')).toBeInTheDocument();
+        });
+    });
 });

--- a/application/ui/src/features/models/training-logs/log-entry.component.test.tsx
+++ b/application/ui/src/features/models/training-logs/log-entry.component.test.tsx
@@ -91,7 +91,7 @@ describe('LogEntry', () => {
     });
 
     describe('exception traceback rendering', () => {
-        it('renders the traceback appended in `text` when the record has an exception', () => {
+        const buildExceptionEntry = () => {
             const entry = getMockedLogEntry({
                 message: 'Unhandled exception in worker',
                 exception: { type: 'ValueError', value: 'bad value', traceback: true },
@@ -100,19 +100,35 @@ describe('LogEntry', () => {
                 '2026-09-10 10:00:00 | ERROR | mod:fn:1 - Unhandled exception in worker\n' +
                 'Traceback (most recent call last):\n  raise ValueError("bad value")\nValueError: bad value';
 
-            render(<LogEntry entry={entry} />);
+            return entry;
+        };
 
-            expect(screen.getByText(/Traceback \(most recent call last\)/)).toBeInTheDocument();
-            expect(screen.getByText(/ValueError: bad value/)).toBeInTheDocument();
+        it('shows a "Show traceback" toggle and keeps the traceback collapsed by default', () => {
+            render(<LogEntry entry={buildExceptionEntry()} />);
+
+            expect(screen.getByText('Unhandled exception in worker')).toBeInTheDocument();
+            expect(screen.getByText('Show traceback')).toBeInTheDocument();
+            expect(screen.queryByText(/Traceback \(most recent call last\)/)).not.toBeVisible();
         });
 
-        it('falls back to record.message when there is no exception', () => {
-            const entry = getMockedLogEntry({ message: 'Plain message' });
-            entry.text = 'unrelated formatted text';
+        it('reveals the traceback appended in `text` when the toggle is opened', () => {
+            const { container } = render(<LogEntry entry={buildExceptionEntry()} />);
 
-            render(<LogEntry entry={entry} />);
+            const details = container.querySelector('details');
+            expect(details).not.toBeNull();
+
+            fireEvent.click(screen.getByText('Show traceback'));
+
+            expect(details).toHaveAttribute('open');
+            expect(screen.getByText(/Traceback \(most recent call last\)/)).toBeVisible();
+            expect(screen.getByText(/ValueError: bad value/)).toBeVisible();
+        });
+
+        it('does not render a toggle when there is no exception', () => {
+            renderLogEntry({ message: 'Plain message' });
 
             expect(screen.getByText('Plain message')).toBeInTheDocument();
+            expect(screen.queryByText('Show traceback')).not.toBeInTheDocument();
         });
     });
 });

--- a/application/ui/src/features/models/training-logs/log-entry.component.tsx
+++ b/application/ui/src/features/models/training-logs/log-entry.component.tsx
@@ -39,6 +39,17 @@ const formatSource = (name: string, func: string, line: number): string => {
     return parts.filter(Boolean).join(':');
 };
 
+// `record.message` never includes a traceback (loguru keeps it separate); `text` has it appended after the message.
+const getDisplayMessage = ({ text, record }: LogEntryType): string => {
+    if (!record.exception) {
+        return record.message.trim();
+    }
+
+    const messageStart = text.indexOf(record.message);
+
+    return messageStart === -1 ? record.message.trim() : text.slice(messageStart).trim();
+};
+
 const MessageWithPaths = ({ message }: { message: string }) => {
     const { copy } = useClipboard();
 
@@ -86,7 +97,7 @@ export const LogEntry = ({ entry }: LogEntryProps) => {
             </span>
             {source ? <span className={classes.source}>{source}</span> : null}
             <span className={classes.message}>
-                <MessageWithPaths message={record.message.trim()} />
+                <MessageWithPaths message={getDisplayMessage(entry)} />
             </span>
         </div>
     );

--- a/application/ui/src/features/models/training-logs/log-entry.component.tsx
+++ b/application/ui/src/features/models/training-logs/log-entry.component.tsx
@@ -40,14 +40,19 @@ const formatSource = (name: string, func: string, line: number): string => {
 };
 
 // `record.message` never includes a traceback (loguru keeps it separate); `text` has it appended after the message.
-const getDisplayMessage = ({ text, record }: LogEntryType): string => {
+const getTraceback = ({ text, record }: LogEntryType): string | null => {
     if (!record.exception) {
-        return record.message.trim();
+        return null;
     }
 
     const messageStart = text.indexOf(record.message);
+    if (messageStart === -1) {
+        return null;
+    }
 
-    return messageStart === -1 ? record.message.trim() : text.slice(messageStart).trim();
+    const traceback = text.slice(messageStart + record.message.length).trim();
+
+    return traceback.length > 0 ? traceback : null;
 };
 
 const MessageWithPaths = ({ message }: { message: string }) => {
@@ -88,17 +93,28 @@ export const LogEntry = ({ entry }: LogEntryProps) => {
     const levelColor = LOG_LEVEL_COLORS[record.level.name] ?? LOG_LEVEL_COLORS.INFO;
     const timestamp = formatTimestamp(record.time.timestamp);
     const source = formatSource(record.name, record.function, record.line);
+    const traceback = getTraceback(entry);
 
     return (
         <div className={classes.logEntry} role={'listitem'}>
-            {timestamp ? <span className={classes.timestamp}>{timestamp}</span> : null}
-            <span className={classes.level} style={{ color: levelColor }}>
-                {record.level.name}
-            </span>
-            {source ? <span className={classes.source}>{source}</span> : null}
-            <span className={classes.message}>
-                <MessageWithPaths message={getDisplayMessage(entry)} />
-            </span>
+            <div className={classes.logEntryRow}>
+                {timestamp ? <span className={classes.timestamp}>{timestamp}</span> : null}
+                <span className={classes.level} style={{ color: levelColor }}>
+                    {record.level.name}
+                </span>
+                {source ? <span className={classes.source}>{source}</span> : null}
+                <span className={classes.message}>
+                    <MessageWithPaths message={record.message.trim()} />
+                </span>
+            </div>
+            {traceback ? (
+                <details className={classes.traceback}>
+                    <summary className={classes.tracebackSummary}>Show traceback</summary>
+                    <div className={classes.tracebackBody}>
+                        <MessageWithPaths message={traceback} />
+                    </div>
+                </details>
+            ) : null}
         </div>
     );
 };

--- a/application/ui/src/features/models/training-logs/log-entry.module.scss
+++ b/application/ui/src/features/models/training-logs/log-entry.module.scss
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 .logEntry {
-    display: flex;
-    align-items: flex-start;
-    gap: var(--spectrum-global-dimension-size-100);
     padding: var(--spectrum-global-dimension-size-50) var(--spectrum-global-dimension-size-200);
     font-family: var(--spectrum-global-font-family-code);
     font-size: var(--spectrum-global-dimension-font-size-75);
@@ -14,6 +11,12 @@
     &:hover {
         background-color: var(--spectrum-global-color-gray-100);
     }
+}
+
+.logEntryRow {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--spectrum-global-dimension-size-100);
 }
 
 .timestamp {
@@ -45,6 +48,24 @@
     white-space: pre-wrap;
     word-break: break-word;
     min-width: 0;
+}
+
+.traceback {
+    margin-top: var(--spectrum-global-dimension-size-50);
+}
+
+.tracebackSummary {
+    width: fit-content;
+    color: var(--spectrum-global-color-static-white);
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.tracebackBody {
+    margin-top: var(--spectrum-global-dimension-size-50);
+    white-space: pre-wrap;
+    word-break: break-word;
+    color: var(--spectrum-global-color-gray-700);
 }
 
 .path {


### PR DESCRIPTION
### Summary

A small but very helpful enhancement for training jobs: include the traceback in the logs.

Previously you would just see "Failed: Export Model" with no additional info, now you get the following:

<img width="1524" height="843" alt="training-log-traceback" src="https://github.com/user-attachments/assets/1435457f-37d1-4b30-9cb6-5efb6d75b135" />

### Technical details

Why the traceback was missing before: job logs are written by loguru with `serialize=True` so each line in the log file is a JSON object like:
```json
{"text": "<full formatted line, including the multi-line traceback if the log call was logger.exception(...)>",
 "record": {"message": "<just the message string passed to the log call>", "exception": {"type": ..., "value": ..., "traceback": true}, ...}}
```
`record.message` is only the raw message string passed to the log call, it doesn't contain the traceback.
When you cat the log file and pipe it through `jq -r '.text'`, you get the text field, so you see the traceback. The UI, however, parsed each line as JSON and rendered only `record.message`.

### How to test

Patch the server code to raise an exception during training, then train a model and:

- [x] Verify that the traceback is shown and readable in the logs
- [x] Verify that the traceback is also in the downloaded log

### Checklist

<!-- Put an 'x' in all the boxes that apply -->

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [ ] All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
