### PR TITLE
Extend API to support export of dataset views

### DIFF
--- a/application/backend/app/api/routers/jobs.py
+++ b/application/backend/app/api/routers/jobs.py
@@ -12,7 +12,14 @@ from fastapi import APIRouter, Body, Depends, HTTPException, status
 from loguru import logger
 from sse_starlette.sse import EventSourceResponse, ServerSentEvent
 
-from app.api.dependencies import get_data_dir, get_job_dir, get_job_queue, get_project_service, get_system_service
+from app.api.dependencies import (
+    get_data_dir,
+    get_dataset_view_service,
+    get_job_dir,
+    get_job_queue,
+    get_project_service,
+    get_system_service,
+)
 from app.api.schemas.jobs import JobRequest, JobType, JobView
 from app.api.validators import JobID
 from app.core.jobs.control_plane import CancellationResult, JobQueue
@@ -34,7 +41,7 @@ from app.models.jobs import (
     PrepareDatasetForImportJob,
     PrepareDatasetForImportJobParams,
 )
-from app.services import ProjectService, SystemService
+from app.services import DatasetViewService, ProjectService, SystemService
 from app.services.model_manifest_service import ModelManifestService
 
 router = APIRouter(prefix="/api/jobs", tags=["Jobs"])
@@ -47,7 +54,7 @@ router = APIRouter(prefix="/api/jobs", tags=["Jobs"])
     responses={
         status.HTTP_202_ACCEPTED: {"description": "Job successfully created"},
         status.HTTP_400_BAD_REQUEST: {"description": "Unknown job type or invalid parameters"},
-        status.HTTP_404_NOT_FOUND: {"description": "Project not found or dataset doesn't exist"},
+        status.HTTP_404_NOT_FOUND: {"description": "Project, dataset or dataset view not found"},
         status.HTTP_409_CONFLICT: {"description": "Dataset is locked by another job"},
         status.HTTP_422_UNPROCESSABLE_CONTENT: {
             "description": "Dataset already in datumaro format and ready for import"
@@ -61,6 +68,7 @@ async def submit_job(
     data_dir: Annotated[Path, Depends(get_data_dir)],
     project_service: Annotated[ProjectService, Depends(get_project_service)],
     system_service: Annotated[SystemService, Depends(get_system_service)],
+    dataset_view_service: Annotated[DatasetViewService, Depends(get_dataset_view_service)],
 ) -> JobView:
     """Create a new job and submit it to the scheduler."""
     try:
@@ -142,11 +150,15 @@ async def submit_job(
                 )
             case JobType.EXPORT_DATASET:
                 project = project_service.get_project_by_id(job_request.project_id)
+                if job_request.dataset_view_id is not None:
+                    # Raises ResourceNotFoundError (-> 404) if the view doesn't exist in the project
+                    dataset_view_service.get_dataset_view_by_id(project.id, job_request.dataset_view_id)
                 job = ExportDatasetJob(
                     id=job_id,
                     project_id=project.id,
                     params=ExportDatasetJobParams(
                         dataset_id=job_request.dataset_id,
+                        dataset_view_id=job_request.dataset_view_id,
                         project_id=project.id,
                         task=project.task,
                         export_format=DatasetFormat(job_request.parameters.export_format),

--- a/application/backend/app/api/schemas/jobs/dataset_export.py
+++ b/application/backend/app/api/schemas/jobs/dataset_export.py
@@ -21,10 +21,20 @@ class ExportDatasetParams(BaseModel):
 class ExportDatasetRequest(BaseJobRequest):
     job_type: Literal[JobType.EXPORT_DATASET]
     dataset_id: UUID | None = Field(
-        None, description="The ID of the dataset used for export. If None, the project's main dataset is used."
+        None, description="The ID of the dataset revision used for export. If None, the project's main dataset is used."
+    )
+    dataset_view_id: UUID | None = Field(
+        None, description="The ID of the dataset view to export. Mutually exclusive with dataset_id."
     )
 
     parameters: ExportDatasetParams = Field(..., description="The configuration for exporting dataset")
+
+    @model_validator(mode="after")
+    def validate_dataset_id_and_view_mutually_exclusive(self) -> "ExportDatasetRequest":
+        """Validate that dataset_id and dataset_view_id are not both set."""
+        if self.dataset_id is not None and self.dataset_view_id is not None:
+            raise ValueError("dataset_id and dataset_view_id are mutually exclusive")
+        return self
 
 
 class StageDatasetParams(BaseModel):
@@ -44,6 +54,7 @@ class StageDatasetRequest(BaseJobRequest):
 
 class ExportDatasetMetadata(BaseModel):
     dataset_id: UUID | None = Field(None, description="Dataset ID")
+    dataset_view_id: UUID | None = Field(None, description="Dataset view ID")
     project_id: UUID = Field(..., description="Project ID")
     filters: DatasetFilters = Field(..., description="Filters to apply to the dataset during export/staging")
     export_format: str | None = Field(None, description="The format of the dataset to export (e.g. coco)")
@@ -54,6 +65,7 @@ class ExportDatasetMetadata(BaseModel):
         if isinstance(data, ExportDatasetJob):
             return {
                 "dataset_id": data.params.dataset_id,
+                "dataset_view_id": data.params.dataset_view_id,
                 "project_id": data.project_id,
                 "filters": DatasetFilters(
                     labels=data.params.labels,

--- a/application/backend/app/execution/dataset_export/export.py
+++ b/application/backend/app/execution/dataset_export/export.py
@@ -67,6 +67,7 @@ class ExportDataset(Execution[ExportDatasetJobParams]):
                     task=export_params.task,
                     annotation_status=annotation_status,
                     sample_mode=SampleMode.IMPORT_EXPORT,
+                    dataset_view_id=export_params.dataset_view_id,
                 )
             else:
                 self._dataset_revision_service.set_db_session(session)

--- a/application/backend/app/models/jobs/export_dataset_job.py
+++ b/application/backend/app/models/jobs/export_dataset_job.py
@@ -18,6 +18,7 @@ VALID_FORMATS_PER_TASK = {
 
 class ExportDatasetJobParams(JobParams):
     dataset_id: UUID | None = None
+    dataset_view_id: UUID | None = None
     project_id: UUID
     task: Task
     export_format: DatasetFormat
@@ -37,6 +38,13 @@ class ExportDatasetJobParams(JobParams):
                 f"Export format '{self.export_format}' is not supported for {self.task.task_type} task. "
                 f"Allowed formats are: {allowed}"
             )
+        return self
+
+    @model_validator(mode="after")
+    def validate_dataset_id_and_view_mutually_exclusive(self) -> "ExportDatasetJobParams":
+        """Validate that dataset_id and dataset_view_id are not both set."""
+        if self.dataset_id is not None and self.dataset_view_id is not None:
+            raise ValueError("dataset_id and dataset_view_id are mutually exclusive")
         return self
 
 

--- a/application/backend/app/repositories/dataset_view_repo.py
+++ b/application/backend/app/repositories/dataset_view_repo.py
@@ -221,6 +221,34 @@ class DatasetViewRepository(BaseRepository[DatasetViewDB]):
         stmt = stmt.order_by(order_by_column).offset(offset).limit(limit)
         return list(self.db.scalars(stmt).all())
 
+    def list_items_with_media(  # noqa: PLR0913
+        self,
+        dataset_view_id: str,
+        limit: int,
+        offset: int,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+        annotation_status: str | None = None,
+        label_ids: list[str] | None = None,
+        subsets: list[str] | None = None,
+    ) -> list[tuple[DatasetItemDB, MediaDB]]:
+        """List (filter) the dataset items assigned to a dataset view, together with their media."""
+        stmt = (
+            select(DatasetItemDB, MediaDB)
+            .join(MediaDB, MediaDB.id == DatasetItemDB.id)
+            .where(
+                DatasetItemDB.project_id == self.project_id,
+                self._media_in_view_condition(dataset_view_id),
+            )
+        )
+        stmt = _apply_date_range_filter(stmt, DatasetItemDB.created_at, start_date, end_date)
+        stmt = _apply_annotation_status_filter(stmt, annotation_status)
+        stmt = _apply_subset_filter(stmt, subsets)
+        if label_ids:
+            stmt = stmt.join(DatasetItemLabelDB).where(DatasetItemLabelDB.label_id.in_(label_ids)).distinct()
+        stmt = stmt.order_by(DatasetItemDB.created_at.desc()).offset(offset).limit(limit)
+        return [(dataset_item, media) for (dataset_item, media) in self.db.execute(stmt).all()]
+
     def get_statistics(self, dataset_view_id: str) -> dict[str, Any]:
         """Get statistics (media & annotation counts) about the media assigned to a dataset view."""
         # Media Counts (images, videos, video frames) among media directly assigned to the view:

--- a/application/backend/app/services/dataset_service.py
+++ b/application/backend/app/services/dataset_service.py
@@ -28,7 +28,7 @@ from app.models import (
 from app.models.dataset import DatasetStatistics
 from app.models.dataset_item import DatasetItemSortBy
 from app.models.media import MediaAdapter, SortDirection, VideoFrame
-from app.repositories import DatasetItemRepository
+from app.repositories import DatasetItemRepository, DatasetViewRepository
 from app.services.media_service import MediaService
 
 from .base import BaseSessionManagedService, ResourceNotFoundError, ResourceType
@@ -356,10 +356,25 @@ class DatasetService(BaseSessionManagedService):
         task: Task,
         annotation_status: DatasetItemAnnotationStatus | None,
         sample_mode: SampleMode,
+        dataset_view_id: UUID | None = None,
     ) -> Dataset:
         from app.datumaro_converter import SampleMode, convert_dataset
 
+        view_repo = DatasetViewRepository(project_id=str(project_id), db=self.db_session)
+        if dataset_view_id is not None and view_repo.get_by_id(str(dataset_view_id)) is None:
+            raise ResourceNotFoundError(ResourceType.DATASET_VIEW, str(dataset_view_id))
+
         def get_dataset_items_and_media(offset: int, limit: int) -> list[tuple[DatasetItem, Media]]:
+            if dataset_view_id is not None:
+                return [
+                    (DatasetItem.model_validate(db_dataset_item), MediaAdapter.validate_python(db_media))
+                    for db_dataset_item, db_media in view_repo.list_items_with_media(
+                        dataset_view_id=str(dataset_view_id),
+                        limit=limit,
+                        offset=offset,
+                        annotation_status=annotation_status,
+                    )
+                ]
             return self.list_dataset_items_with_media(
                 project_id=project_id,
                 filters=DatasetItemFilters(limit=limit, offset=offset, annotation_status=annotation_status),

--- a/application/backend/tests/unit/api/routers/conftest.py
+++ b/application/backend/tests/unit/api/routers/conftest.py
@@ -9,8 +9,8 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 
-from app.api.dependencies import get_project_service
-from app.services import ProjectService
+from app.api.dependencies import get_dataset_view_service, get_project_service
+from app.services import DatasetViewService, ProjectService
 
 
 @pytest.fixture
@@ -23,6 +23,13 @@ def fxt_project_service(fxt_app: FastAPI) -> Mock:
     project_service = Mock(spec=ProjectService)
     fxt_app.dependency_overrides[get_project_service] = lambda: project_service
     return project_service
+
+
+@pytest.fixture
+def fxt_dataset_view_service(fxt_app: FastAPI) -> Mock:
+    dataset_view_service = Mock(spec=DatasetViewService)
+    fxt_app.dependency_overrides[get_dataset_view_service] = lambda: dataset_view_service
+    return dataset_view_service
 
 
 @pytest_asyncio.fixture

--- a/application/backend/tests/unit/api/routers/test_jobs.py
+++ b/application/backend/tests/unit/api/routers/test_jobs.py
@@ -21,6 +21,7 @@ from app.core.jobs.control_plane import CancellationResult
 from app.core.jobs.models import Job, JobStatus, JobType
 from app.models import Project, Task, TaskType, TrainingJob, TrainingJobParams
 from app.models.system import DeviceInfo, DeviceType
+from app.services.base import ResourceNotFoundError, ResourceType
 
 
 async def stream_test(client: AsyncClient, job_id: UUID, path: str = "logs") -> list[str]:
@@ -189,6 +190,89 @@ class TestJobEndpoints:
         assert submitted_job.params.max_calibration_subset_size == 100
         assert submitted_job.params.max_drop is None
         assert submitted_job.params.max_num_iterations == 10
+
+    def test_submit_export_dataset_job_with_dataset_view(
+        self, fxt_app, tmp_path, fxt_client, fxt_jobs_queue, fxt_project_service, fxt_dataset_view_service
+    ):
+        fxt_app.dependency_overrides[get_job_dir] = lambda: tmp_path / "logs" / "jobs"
+        fxt_app.dependency_overrides[get_data_dir] = lambda: tmp_path / "data"
+        project = Mock(spec=Project)
+        project.id = uuid4()
+        project.task = Mock(spec=Task)
+        project.task.task_type = TaskType.DETECTION
+        project.task.exclusive_labels = True
+        fxt_project_service.get_project_by_id.return_value = project
+        dataset_view_id = uuid4()
+        fxt_dataset_view_service.get_dataset_view_by_id.return_value = Mock()
+
+        response = fxt_client.post(
+            "/api/jobs",
+            json={
+                "project_id": str(project.id),
+                "job_type": "export_dataset",
+                "dataset_view_id": str(dataset_view_id),
+                "parameters": {"export_format": "coco", "filters": {}},
+            },
+        )
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        fxt_dataset_view_service.get_dataset_view_by_id.assert_called_once_with(project.id, dataset_view_id)
+        submitted_job = fxt_jobs_queue.submit.call_args[0][0]
+        assert submitted_job.params.dataset_view_id == dataset_view_id
+        assert submitted_job.params.dataset_id is None
+
+    def test_submit_export_dataset_job_with_unknown_dataset_view(
+        self, fxt_app, tmp_path, fxt_client, fxt_jobs_queue, fxt_project_service, fxt_dataset_view_service
+    ):
+        fxt_app.dependency_overrides[get_job_dir] = lambda: tmp_path / "logs" / "jobs"
+        fxt_app.dependency_overrides[get_data_dir] = lambda: tmp_path / "data"
+        project = Mock(spec=Project)
+        project.id = uuid4()
+        project.task = Mock(spec=Task)
+        project.task.task_type = TaskType.DETECTION
+        project.task.exclusive_labels = True
+        fxt_project_service.get_project_by_id.return_value = project
+        dataset_view_id = uuid4()
+        fxt_dataset_view_service.get_dataset_view_by_id.side_effect = ResourceNotFoundError(
+            ResourceType.DATASET_VIEW, str(dataset_view_id)
+        )
+
+        response = fxt_client.post(
+            "/api/jobs",
+            json={
+                "project_id": str(project.id),
+                "job_type": "export_dataset",
+                "dataset_view_id": str(dataset_view_id),
+                "parameters": {"export_format": "coco", "filters": {}},
+            },
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        fxt_jobs_queue.submit.assert_not_called()
+
+    def test_submit_export_dataset_job_with_dataset_id_and_dataset_view_id(
+        self, fxt_app, tmp_path, fxt_client, fxt_jobs_queue, fxt_project_service, fxt_dataset_view_service
+    ):
+        """dataset_id and dataset_view_id are mutually exclusive."""
+        fxt_app.dependency_overrides[get_job_dir] = lambda: tmp_path / "logs" / "jobs"
+        fxt_app.dependency_overrides[get_data_dir] = lambda: tmp_path / "data"
+        project = Mock(spec=Project)
+        project.id = uuid4()
+        fxt_project_service.get_project_by_id.return_value = project
+
+        response = fxt_client.post(
+            "/api/jobs",
+            json={
+                "project_id": str(project.id),
+                "job_type": "export_dataset",
+                "dataset_id": str(uuid4()),
+                "dataset_view_id": str(uuid4()),
+                "parameters": {"export_format": "coco", "filters": {}},
+            },
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        fxt_jobs_queue.submit.assert_not_called()
 
     def test_list_jobs(self, fxt_client, fxt_jobs_queue, fxt_job):
         fxt_jobs_queue.list_all.return_value = [fxt_job(), fxt_job()]

--- a/application/backend/tests/unit/execution/dataset_export/test_export.py
+++ b/application/backend/tests/unit/execution/dataset_export/test_export.py
@@ -84,6 +84,7 @@ class TestDatasetExporter:
             task=fxt_export_params.task,
             annotation_status=None if include_unannotated else DatasetItemAnnotationStatus.WITH_ANNOTATIONS,
             sample_mode=SampleMode.IMPORT_EXPORT,
+            dataset_view_id=None,
         )
         if subsets:
             dataset.filter_by_subset.assert_called_once_with(subset=[Subset[subset.name] for subset in subsets])
@@ -91,6 +92,29 @@ class TestDatasetExporter:
             dataset.filter_by_labels.assert_called_once_with(
                 labels=labels, keep_empty_samples=fxt_export_params.include_unannotated
             )
+
+    def test_prepare_project_dataset_with_dataset_view(
+        self,
+        fxt_export: ExportDataset,
+        fxt_dataset_service: Mock,
+        fxt_export_params: ExportDatasetJobParams,
+    ):
+        """The dataset view id is forwarded to the dataset service when the export is view-scoped."""
+        dataset = MagicMock(spec=Dataset)
+        dataset.__len__.return_value = 10
+        fxt_dataset_service.get_dm_dataset.return_value = dataset
+        dataset_view_id = uuid4()
+        fxt_export_params.dataset_view_id = dataset_view_id
+
+        fxt_export.prepare_dataset(fxt_export_params)
+
+        fxt_dataset_service.get_dm_dataset.assert_called_once_with(
+            project_id=fxt_export_params.project_id,
+            task=fxt_export_params.task,
+            annotation_status=DatasetItemAnnotationStatus.WITH_ANNOTATIONS,
+            sample_mode=SampleMode.IMPORT_EXPORT,
+            dataset_view_id=dataset_view_id,
+        )
 
     @pytest.mark.parametrize(
         "subsets, labels",

--- a/application/backend/tests/unit/models/jobs/test_export_dataset_job.py
+++ b/application/backend/tests/unit/models/jobs/test_export_dataset_job.py
@@ -53,3 +53,25 @@ class TestExportDatasetJobParams:
                 task=Task(task_type=task_type),
                 export_format=export_format,
             )
+
+    def test_dataset_id_and_dataset_view_id_mutually_exclusive(self):
+        """Test that setting both dataset_id and dataset_view_id raises a ValueError."""
+        with pytest.raises(ValidationError, match="dataset_id and dataset_view_id are mutually exclusive"):
+            ExportDatasetJobParams(
+                project_id=uuid4(),
+                task=Task(task_type=TaskType.DETECTION),
+                export_format=DatasetFormat.COCO,
+                dataset_id=uuid4(),
+                dataset_view_id=uuid4(),
+            )
+
+    def test_dataset_view_id_alone_is_valid(self):
+        """Test that dataset_view_id can be set without dataset_id."""
+        params = ExportDatasetJobParams(
+            project_id=uuid4(),
+            task=Task(task_type=TaskType.DETECTION),
+            export_format=DatasetFormat.COCO,
+            dataset_view_id=uuid4(),
+        )
+        assert params.dataset_id is None
+        assert params.dataset_view_id is not None


### PR DESCRIPTION
### Summary

This PR allows the `export_dataset` job to be scoped to a single dataset view instead of the entire project dataset, via a new optional `dataset_view_id` field. UI changes will be added in a later PR.

Resolves #7554 

### How to test

1. Create a dataset view, note its ID and assign some media to it
2. Manually call the endpoint to export the view, with the new parameter `dataset_view_id`. Example:
```console
curl -sk -X POST -H "Content-Type: application/json" "https://localhost:7860/api/jobs" --data '{"project_id":"98257c90-89d4-4c6b-a3ee-3b57a82d3d55","dataset_id":null,"dataset_view_id":"28cd2faa-6cb7-41ce-a136-6d6baeac6bc2","job_type":"export_dataset","parameters":{"export_format":"geti","filters":{"labels":["Dolphin","Eagle","Elephant","Fox","Lion","Owl","Penguin","Sea turtle"],"include_unannotated":true}}}'
```
3. Wait for the job to finish, get the staged dataset ID through the `/staged_datasets` endpoint.
4. Download the archive, e.g. `https://localhost:7860/api/staged_datasets/c819701c-bf08-45fe-a991-355526e78fb4/zip`
5. Re-import the archive as a new project and verify that it only contains the media and annotations of the original view.

### Checklist

- [x] The PR title and description are clear and descriptive
- [x] I have manually tested the changes
- [x] All changes are covered by automated tests
- [x]  All related issues are linked to this PR (if applicable)
- [ ] Documentation has been updated (if applicable)
